### PR TITLE
Resort to using `editor` as last resort

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -69,7 +69,7 @@ if ask "Do you want to edit the pacscript" N; then
     elif [[ -n $VISUAL ]]; then
         $VISUAL "$PACKAGE".pacscript
     else
-        nano "$PACKAGE".pacscript
+        editor "$PACKAGE".pacscript
     fi
 fi
 fancy_message info "Sourcing pacscript"


### PR DESCRIPTION
This PR makes pacstall use `editor` (the command to open the default system editor) instead of `nano` to edit pacscripts while installing them.

This may fix  #20 