### PR TITLE
Fix showing blank dependencies when removing packages

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -259,7 +259,7 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
             source <(cat /var/cache/pacstall/"$PACKAGE"/$(pacstall -Qi "$PACKAGE" | sed 's/: /=/g' | sed -n -e 's/version=//p')/"$PACKAGE".pacscript)
 	        removescript
         fi
-        if [ -z "$dependencies" ]; then
+        if [ -n "$dependencies" ]; then
             fancy_message info "You may want to remove ${BLUE}$dependencies${NC}"
         fi
         exit


### PR DESCRIPTION
This PR fixes the issue of pacstall showing this warning when removing a package
```
You may want to remove:
```
Its showing `<blank>` as there are no dependencies to show, this PR fixes this