### PR TITLE
[bug] Remove `fzf` dependency

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -88,7 +88,7 @@ fancy_message info "Updating"
 sudo apt-get -q update
 fancy_message info "Installing packages"
 
-sudo apt-get install -qq -y {curl,wget,stow,build-essential,unzip,fzf}
+sudo apt-get install -qq -y {curl,wget,stow,build-essential,unzip}
 
 unset PACSTALL_DIRECTORY
 export PACSTALL_DIRECTORY="/usr/share/pacstall"


### PR DESCRIPTION
It is a redundant dependency, as it is no longer used. This PR removes that dependency from `install.sh`