### PR TITLE
Fix a typo

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -234,7 +234,7 @@ fi
 # If optdepends exists do this
 if [[ -n $optdepends ]] ; then
     sudo rm -f /tmp/pacstall-optdepends
-    fancy_message info "Package has some optional dependencies that can enhance it's functionalities"
+    fancy_message info "Package has some optional dependencies that can enhance its functionalities"
     echo "Optional dependencies:"
     printf '    %s\n' "${optdepends[@]}"
     if ask "Do you want to install them" Y; then


### PR DESCRIPTION
The optional dependencies dialog used the wrong form of its/it's. This is unprofessional, so I fixed it. It's nothing to do with any code.