### PR TITLE
[bug] Remove obsolete `rm`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,7 @@ sudo mkdir -p $PACSTALL_DIRECTORY
 sudo mkdir -p $PACSTALL_DIRECTORY/scripts
 sudo mkdir -p $PACSTALL_DIRECTORY/repo
 sudo mkdir -p /var/log/pacstall_orphaned
+sudo rm -f $PACSTALL_DIRECTORY/repo/pacstallrepo.txt > /dev/null
 sudo touch $PACSTALL_DIRECTORY/repo/pacstallrepo.txt
 sudo sh -c "echo 'https://raw.githubusercontent.com/pacstall/pacstall-programs/master' > $PACSTALL_DIRECTORY/repo/pacstallrepo.txt"
 sudo rm -rf /var/log/pacstall_installed

--- a/install.sh
+++ b/install.sh
@@ -97,7 +97,6 @@ sudo mkdir -p $PACSTALL_DIRECTORY
 sudo mkdir -p $PACSTALL_DIRECTORY/scripts
 sudo mkdir -p $PACSTALL_DIRECTORY/repo
 sudo mkdir -p /var/log/pacstall_orphaned
-sudo rm -f $PACSTALL_DIRECTORY/repo/pacstallrepo.txt
 sudo touch $PACSTALL_DIRECTORY/repo/pacstallrepo.txt
 sudo sh -c "echo 'https://raw.githubusercontent.com/pacstall/pacstall-programs/master' > $PACSTALL_DIRECTORY/repo/pacstallrepo.txt"
 sudo rm -rf /var/log/pacstall_installed


### PR DESCRIPTION
Says what it does, no need to `rm` the file, as `touch` already does that.