### PR TITLE
Add basic explicitly installed thingy

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -226,7 +226,7 @@ if [[ -n $build_depends ]]; then
     echo "build_dependencies=\"$build_depends"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
 if [[ -n $pacdeps ]]; then
-    echo "pacdeps=\"$pacdeps"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
+    echo "_pacdeps=\"$pacdeps"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
 if test -f /tmp/pacstall-pacdeps; then
     echo "pacstall_depends=\"true"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -228,7 +228,7 @@ if [[ -n $build_depends ]]; then
     echo "build_dependencies=\"$build_depends"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
 if [[ -n $pacdepslist ]]; then
-    echo "pacdeps=\"${pacdepslist[*]}"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
+    echo "pacdeps=\"$pacdepslist"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
 if [[ -n $PACSTALL_DEPENDS ]]; then
     echo "pacstall_depends=\"true"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -103,9 +103,9 @@ if [[ -n "$pacdeps" ]]; then
     for i in "${pacdeps[@]}"
     do
         fancy_message info "Installing $i"
-        sudo touch /tmp/pacstall-pacdeps
+        sudo touch /tmp/pacstall-pacdeps-$i
         sudo pacstall -P -I "$i"
-        sudo rm -f /tmp/pacstall-pacdeps
+        sudo rm -f /tmp/pacstall-pacdeps-$i
     done
 fi
 
@@ -228,7 +228,7 @@ fi
 if [[ -n $pacdeps ]]; then
     echo "_pacdeps=\"$pacdeps"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
-if test -f /tmp/pacstall-pacdeps; then
+if test -f /tmp/pacstall-pacdeps-$PACKAGE; then
     echo "_pacstall_depends=\"true"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -104,9 +104,11 @@ if [[ -n "$pacdeps" ]]; then
     for i in "${pacdeps[@]}"
     do
         fancy_message info "Installing $i"
+        echo "PACSTALL_DEPENDS=true" | sudo tee /tmp/pacstall-pacdeps
         export PACSTALL_DEPENDS=true
         sudo pacstall -P -I "$i"
         pacdepslist+=($i)
+        sudo rm -f /tmp/pacstall-pacdeps
         unset PACSTALL_DEPENDS
     done
 fi
@@ -230,7 +232,7 @@ fi
 if [[ -n $pacdepslist ]]; then
     echo "pacdeps=\"$pacdepslist"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
-if [[ -n $PACSTALL_DEPENDS ]]; then
+if test -f /tmp/pacstall-pacdeps; then
     echo "pacstall_depends=\"true"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -104,8 +104,10 @@ if [[ -n "$pacdeps" ]]; then
     for i in "${pacdeps[@]}"
     do
         fancy_message info "Installing $i"
+        export PACSTALL_DEPENDS=true
         sudo pacstall -P -I "$i"
         pacdepslist+=($i)
+        unset PACSTALL_DEPENDS
     done
 fi
 
@@ -227,6 +229,9 @@ if [[ -n $build_depends ]]; then
 fi
 if [[ -n $pacdepslist ]]; then
     echo "pacdeps=\"${pacdepslist[*]}"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
+fi
+if [[ -n $PACSTALL_DEPENDS ]]; then
+    echo "pacstall_depends=\"true"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
 
 # If optdepends exists do this

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -103,9 +103,9 @@ if [[ -n "$pacdeps" ]]; then
     for i in "${pacdeps[@]}"
     do
         fancy_message info "Installing $i"
-        sudo touch /tmp/pacstall-pacdeps-$i
+        sudo touch /tmp/pacstall-pacdeps-"$i"
         sudo pacstall -P -I "$i"
-        sudo rm -f /tmp/pacstall-pacdeps-$i
+        sudo rm -f /tmp/pacstall-pacdeps-"$i"
     done
 fi
 
@@ -228,7 +228,7 @@ fi
 if [[ -n $pacdeps ]]; then
     echo "_pacdeps=\"$pacdeps"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
-if test -f /tmp/pacstall-pacdeps-$PACKAGE; then
+if test -f /tmp/pacstall-pacdeps-"$PACKAGE"; then
     echo "_pacstall_depends=\"true"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -105,11 +105,9 @@ if [[ -n "$pacdeps" ]]; then
     do
         fancy_message info "Installing $i"
         echo "PACSTALL_DEPENDS=true" | sudo tee /tmp/pacstall-pacdeps
-        export PACSTALL_DEPENDS=true
         sudo pacstall -P -I "$i"
         pacdepslist+=($i)
         sudo rm -f /tmp/pacstall-pacdeps
-        unset PACSTALL_DEPENDS
     done
 fi
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -100,13 +100,11 @@ if [[ -n "$build_depends" ]]; then
     fi
 
 if [[ -n "$pacdeps" ]]; then
-    declare -a pacdepslist
     for i in "${pacdeps[@]}"
     do
         fancy_message info "Installing $i"
         echo "PACSTALL_DEPENDS=true" | sudo tee /tmp/pacstall-pacdeps
         sudo pacstall -P -I "$i"
-        pacdepslist+=($i)
         sudo rm -f /tmp/pacstall-pacdeps
     done
 fi
@@ -227,8 +225,8 @@ fi
 if [[ -n $build_depends ]]; then
     echo "build_dependencies=\"$build_depends"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
-if [[ -n $pacdepslist ]]; then
-    echo "pacdeps=\"$pacdepslist"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
+if [[ -n $pacdeps ]]; then
+    echo "pacdeps=\"$pacdeps"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
 if test -f /tmp/pacstall-pacdeps; then
     echo "pacstall_depends=\"true"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -103,7 +103,7 @@ if [[ -n "$pacdeps" ]]; then
     for i in "${pacdeps[@]}"
     do
         fancy_message info "Installing $i"
-        echo "PACSTALL_DEPENDS=true" | sudo tee /tmp/pacstall-pacdeps
+        sudo touch /tmp/pacstall-pacdeps
         sudo pacstall -P -I "$i"
         sudo rm -f /tmp/pacstall-pacdeps
     done

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -212,24 +212,24 @@ sudo rm -rf /tmp/pacstall/*
 cd "$HOME"
 
 # Metadata writing
-echo "version=\"$version"\" | sudo tee /var/log/pacstall_installed/"$PACKAGE" >/dev/null
-echo "description=\"$description"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
-echo "date=\"$(date)"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
+echo "_version=\"$version"\" | sudo tee /var/log/pacstall_installed/"$PACKAGE" >/dev/null
+echo "_description=\"$description"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
+echo "_date=\"$(date)"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 if [[ $removescript == "yes" ]] ; then
-   echo "removescript=\"yes"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
+   echo "_removescript=\"yes"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
-echo "maintainer=\"$maintainer"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
+echo "_maintainer=\"$maintainer"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 if [[ -n $depends ]]; then
-    echo "dependencies=\"$depends"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
+    echo "_dependencies=\"$depends"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
 if [[ -n $build_depends ]]; then
-    echo "build_dependencies=\"$build_depends"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
+    echo "_build_dependencies=\"$build_depends"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
 if [[ -n $pacdeps ]]; then
     echo "_pacdeps=\"$pacdeps"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
 if test -f /tmp/pacstall-pacdeps; then
-    echo "pacstall_depends=\"true"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
+    echo "_pacstall_depends=\"true"\" | sudo tee -a /var/log/pacstall_installed/"$PACKAGE" >/dev/null
 fi
 
 # If optdepends exists do this

--- a/pacstall
+++ b/pacstall
@@ -391,7 +391,7 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
       echo "size: $(du -sh /usr/src/pacstall/"$PACKAGE" | awk '{print $1}')"
       echo "description: ""$_description"""
       echo "date installed: ""$_date"""
-      if [[ -n $maintainer ]]; then
+      if [[ -n $_maintainer ]]; then
         echo "maintainer: ""$_maintainer"""
       fi
       if [[ -n $_pacdeps ]]; then

--- a/pacstall
+++ b/pacstall
@@ -403,7 +403,7 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
       if [[ -n $_build_dependencies ]]; then
           echo "build dependencies: ""$_build_dependencies"""
       fi
-      if [[ -n $pacstall_depends ]]; then
+      if [[ -n $_pacstall_depends ]]; then
           echo "install type: installed as dependency"
       else
           echo "install type: explicitly installed"

--- a/pacstall
+++ b/pacstall
@@ -400,7 +400,7 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
       if [[ -n $dependencies ]]; then
           echo "dependencies: ""$_dependencies"""
       fi
-      if [[ -n $build_dependencies ]]; then
+      if [[ -n $_build_dependencies ]]; then
           echo "build dependencies: ""$_build_dependencies"""
       fi
       if [[ -n $pacstall_depends ]]; then

--- a/pacstall
+++ b/pacstall
@@ -394,8 +394,8 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
       if [[ -n $maintainer ]]; then
         echo "maintainer: ""$maintainer"""
       fi
-      if [[ -n $pacdepslist ]]; then
-          echo "pacstall dependencies: ""${pacdepslist[*]}"""
+      if [[ -n $pacdeps ]]; then
+          echo "pacstall dependencies: ""$pacdeps"""
       fi
       if [[ -n $dependencies ]]; then
           echo "dependencies: ""$dependencies"""

--- a/pacstall
+++ b/pacstall
@@ -394,8 +394,8 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
       if [[ -n $maintainer ]]; then
         echo "maintainer: ""$maintainer"""
       fi
-      if [[ -n $pacdeps ]]; then
-          echo "pacstall dependencies: ""$pacdeps"""
+      if [[ -n $_pacdeps ]]; then
+          echo "pacstall dependencies: ""$_pacdeps"""
       fi
       if [[ -n $dependencies ]]; then
           echo "dependencies: ""$dependencies"""

--- a/pacstall
+++ b/pacstall
@@ -403,6 +403,11 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
       if [[ -n $build_dependencies ]]; then
           echo "build dependencies: ""$build_dependencies"""
       fi
+      if [[ -n $pacstall_depends ]]; then
+          echo "install type: installed as dependency"
+      else
+          echo "install type: explicitly installed"
+      fi
       exit
       ;;
     -T|--tree)

--- a/pacstall
+++ b/pacstall
@@ -397,7 +397,7 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
       if [[ -n $_pacdeps ]]; then
           echo "pacstall dependencies: ""$_pacdeps"""
       fi
-      if [[ -n $dependencies ]]; then
+      if [[ -n $_dependencies ]]; then
           echo "dependencies: ""$_dependencies"""
       fi
       if [[ -n $_build_dependencies ]]; then

--- a/pacstall
+++ b/pacstall
@@ -387,21 +387,21 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
       fi
       source /var/log/pacstall_installed/"$PACKAGE"
       echo "name: $PACKAGE"
-      echo "version: $version"
+      echo "version: $_version"
       echo "size: $(du -sh /usr/src/pacstall/"$PACKAGE" | awk '{print $1}')"
-      echo "description: ""$description"""
-      echo "date installed: ""$date"""
+      echo "description: ""$_description"""
+      echo "date installed: ""$_date"""
       if [[ -n $maintainer ]]; then
-        echo "maintainer: ""$maintainer"""
+        echo "maintainer: ""$_maintainer"""
       fi
       if [[ -n $_pacdeps ]]; then
           echo "pacstall dependencies: ""$_pacdeps"""
       fi
       if [[ -n $dependencies ]]; then
-          echo "dependencies: ""$dependencies"""
+          echo "dependencies: ""$_dependencies"""
       fi
       if [[ -n $build_dependencies ]]; then
-          echo "build dependencies: ""$build_dependencies"""
+          echo "build dependencies: ""$_build_dependencies"""
       fi
       if [[ -n $pacstall_depends ]]; then
           echo "install type: installed as dependency"


### PR DESCRIPTION
This will export a variable that is only called when something is installing with pacdeps. The metadata logger will see that and log it as `installed as dependency`. If `-Qi` can't find the `$pacstall_depends`, it will print that is was explicitly installed. I'm testing now with `sudo pacstall -I soundux`