### PR TITLE
Fix `-R` showing file error

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -240,7 +240,7 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
         fancy_message error "You failed to specify a package"
         exit 1
       fi
-      source /var/log/pacstall_installed/"$PACKAGE"
+      source /var/log/pacstall_installed/"$PACKAGE" >/dev/null 2>&1
       if [ -d "/usr/src/pacstall/$PACKAGE" ]; then
         fancy_message info "Removing symlinks"
         cd /usr/src/pacstall

--- a/pacstall
+++ b/pacstall
@@ -262,7 +262,7 @@ while [[ "$1" =~ ^- && ! "$1" == "--" ]]; do
         sudo rm -f /var/log/pacstall_installed/"$PACKAGE"
         exit
       else
-        fancy_message error "$PACKAGE does not exist or not properly symlinked"
+        fancy_message error "$PACKAGE is not installed or not properly symlinked"
         exit 1
       fi
       ;;


### PR DESCRIPTION
When removing a package that doesn't exist, this shows:
```bash
➜  ~ sudo pacstall -R soundux
/bin/pacstall: line 243: /var/log/pacstall_installed/soundux: No such file or directory
[!] ERROR: soundux does not exist or not properly symlinked
```
This pr fixes the no such file or directory