### PR TITLE
Feat: Add global `*dir` constants

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -94,10 +94,10 @@ if [[ -n "$build_depends" ]]; then
     fancy_message info "${BLUE}$name${NC} requires ${CYAN}$(echo -e "$build_depends")${NC} to install"
     if ask "Do you want to remove them after installing ${BLUE}$name${NC}" N; then
         NOBUILDDEP=0
-	fi
     else
         NOBUILDDEP=1
     fi
+fi
 
 if [[ -n "$pacdeps" ]]; then
     for i in "${pacdeps[@]}"
@@ -170,6 +170,7 @@ cd /tmp/pacstall
 # Detects if url ends in .git (in that case git clone it), or ends in .zip, or just assume that the url can be uncompressed with tar. Then cd into them
 if [[ $url = *.git ]] ; then
   sudo git clone --quiet --depth=1 --jobs=10 "$url"
+  export srcdir="/tmp/pacstall/$(/bin/ls -d -- */|head -n 1)"
   cd $(/bin/ls -d -- */|head -n 1)
   sudo chown -R "$(logname)":"$(logname)" .
   git fsck --full
@@ -178,11 +179,13 @@ else
   if [[ $url = *.zip ]] ; then
     hashcheck "${url##*/}"
     sudo unzip -q "${url##*/}" 1>&1
+    export srcdir="/tmp/pacstall/$(/bin/ls -d -- */|head -n 1)"
     cd $(/bin/ls -d -- */|head -n 1)
     sudo chown -R "$(logname)":"$(logname)" .
   else
     hashcheck "${url##*/}"
     sudo tar -xf "${url##*/}" 1>&1
+    srcdir="/tmp/pacstall/$(/bin/ls -d -- */|head -n 1)"
     cd $(/bin/ls -d -- */|head -n 1)
     sudo chown -R "$(logname)":"$(logname)" .
   fi
@@ -197,6 +200,7 @@ if [[ -n $patch ]] ; then
 export PACPATCH=$(pwd)/PACSTALL_patchesdir
 fi
 
+export pkgdir="/usr/src/pacstall/$name"
 prepare
 # Check if build function exists
 if type -t build >/dev/null 2>&1; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -74,6 +74,7 @@ if ask "Do you want to edit the pacscript" N; then
 fi
 fancy_message info "Sourcing pacscript"
 DIR=$(pwd)
+export homedir="/home/$(logname)"
 source "$PACKAGE".pacscript >/dev/null
 if [[ $? -eq 1 ]]; then
     fancy_message error "Couldn't parse pacscript"


### PR DESCRIPTION
`srcdir` is the package's source directory. For example, pkg foo has a
directory that is extracted to `/tmp/pacstall` called `foo-1.0`. The
`srcdir` would be `/tmp/pacstall/foo-1.0`

`pkgdir` is the path that a package is to be installed to. Package
`foo`'s `pkgdir` would be `/usr/src/pacstall/foo`