### PR TITLE
Fix: Upgrading echo's packages at wrong time

### DIFF
--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -37,7 +37,7 @@ for i in "${list[@]}"; do
     localver=$(sed -n -e 's/_version=//p' /var/log/pacstall_installed/"$i" | tr -d \")
     remotever=$(source <(curl -s "$REPO"/packages/"$i"/"$i".pacscript) && type pkgver &>/dev/null && pkgver || echo "$version") >/dev/null
     if [[ $remotever != $localver ]]; then
-      echo "$i" | sudo tee -a /tmp/pacstall-up-list
+      echo "$i" | sudo tee -a /tmp/pacstall-up-list >/dev/null
     fi
 done &
 


### PR DESCRIPTION
When running `sudo pacstall -Up`, pacstall will output something like
this:

```bash
➜  ~ sudo pacstall -Up
[+] INFO: Checking for updates
*exa
.neofetch
@
[+] INFO: Packages can be upgraded
Upgradable: 2
exa neofetch

Do you want to continue? [Y/n] n
```
This commit removes the text below `Checking for updates`