### PR TITLE
Fix: suffix issue

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -218,7 +218,7 @@ while [[ ! "$1" == "--" ]]; do
       INPUT="$(echo "$2" | sed 's/\..*$//')" # Removes the .pacscript suffix
 
       # Check if the file exist (both .pacscript and without)
-      if [[ ! -f "$2" && ! -f "$INPUT" ]]; then
+      if [[ ! -f "$2".pacscript && ! -f "$INPUT" ]]; then
         fancy_message error "$2 does not exist"
         exit 1
       fi


### PR DESCRIPTION
When commit 84e9c7e417de5ca467be6531085f5d19bb6ccbc3 was introduced, it
created a problem with tab completing scripts and issues with how
pacstall works when installing. How it works is if you have package
`foo`, the file will be `foo.pacscript` and you run `pacstall -Il foo`
to install it, but this commit changed it so that you would have to
include the `.pacscript`, so I fixed it