### PR TITLE
Feature/no removescript variable

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -257,9 +257,6 @@ cd "$HOME"
 echo "_version=\"$version"\" | sudo tee "$LOGDIR"/"$PACKAGE" > /dev/null
 echo "_description=\"$description"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
 echo "_date=\"$(date)"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
-if [[ $removescript == "yes" ]]; then
-  echo "_removescript=\"yes"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
-fi
 echo "_maintainer=\"$maintainer"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
 if [[ -n $depends ]]; then
   echo "_dependencies=\"$depends"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -28,7 +28,7 @@ sudo rm -rf "$PACKAGE"
 # Update PATH database
 hash -r
 
-if [[ $(fn_exists removescript && return 0 || return 1) ]] ; then
+if [[ $(fn_exists removescript && return 0 || return 1) -eq 0 ]] ; then
     fancy_message info "Running post removal script"
     REPO=$(cat "$STGDIR/repo/pacstallrepo.txt")
     # Sources the output of /var/cache/pacstall/pkg/version/pkg.pacscript so we don't have to download scripts from the repo

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+function fn_exists() {
+  declare -F "$1" > /dev/null;
+}
+
 cd "$STOWDIR" || (sudo mkdir -p "$STOWDIR"; cd "$STOWDIR")
 
 # Run preliminary checks
@@ -23,7 +28,7 @@ sudo rm -rf "$PACKAGE"
 # Update PATH database
 hash -r
 
-  if [[ $_removescript == "yes" ]] ; then
+if [[ $(fn_exists removescript && return 0 || return 1) ]] ; then
     fancy_message info "Running post removal script"
     REPO=$(cat "$STGDIR/repo/pacstallrepo.txt")
     # Sources the output of /var/cache/pacstall/pkg/version/pkg.pacscript so we don't have to download scripts from the repo

--- a/pacstall
+++ b/pacstall
@@ -27,7 +27,7 @@ export LC_ALL=C
 export HOMEDIR="/home/$(logname)"
 export LOGDIR="/var/log/pacstall"
 export SRCDIR="/tmp/pacstall"
-export STGDIR="/home/$(logname)/.local/share/pacstall/scripts"
+export STGDIR="/home/$(logname)/.local/share/pacstall"
 export STOWDIR="/usr/src/pacstall"
 
 # Colors


### PR DESCRIPTION
With this, the `removescript` variable is deprecated and pacstall just relies on the `removescript` function