### PR TITLE
Fix: /root is not /home/root

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -24,7 +24,6 @@
 
 # Configuration
 export LC_ALL=C
-export HOMEDIR="/home/$(logname)"
 export LOGDIR="/var/log/pacstall"
 export SRCDIR="/tmp/pacstall"
 export STGDIR="~/.local/share/pacstall"

--- a/pacstall
+++ b/pacstall
@@ -27,7 +27,7 @@ export LC_ALL=C
 export HOMEDIR="/home/$(logname)"
 export LOGDIR="/var/log/pacstall"
 export SRCDIR="/tmp/pacstall"
-export STGDIR="/home/$(logname)/.local/share/pacstall"
+export STGDIR="~/.local/share/pacstall"
 export STOWDIR="/usr/src/pacstall"
 
 # Colors


### PR DESCRIPTION
So a normal user has a `/home` directory, but what about root? Root's home directory is `/root`. This fixes that