### PR TITLE
bash doesn't do tilde expansion in quotes

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -26,7 +26,7 @@
 export LC_ALL=C
 export LOGDIR="/var/log/pacstall"
 export SRCDIR="/tmp/pacstall"
-export STGDIR="~/.local/share/pacstall"
+export STGDIR="${HOME}/.local/share/pacstall"
 export STOWDIR="/usr/src/pacstall"
 
 # Colors


### PR DESCRIPTION
```
$ pacstall -Il bat
cat: '~/.local/share/pacstall/repo/pacstallrepo.txt': No such file or directory
/bin/pacstall: line 238: ~/.local/share/pacstall/scripts/install-local.sh: No such file or directory
```