### PR TITLE
Hotfixes for v1.5.1

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -96,7 +96,7 @@ sudo apt-get -qq update
 fancy_message info "Installing packages"
 sudo apt-get install -qq -y {curl,wget,stow,build-essential,unzip,tree,dialog}
 
-export STGDIR="${HOME}/.local/share/pacstall"
+export STGDIR="${LOGNAME}/.local/share/pacstall"
 fancy_message info "making directories"
 mkdir -p $STGDIR
 mkdir -p $STGDIR/scripts

--- a/install.sh
+++ b/install.sh
@@ -96,13 +96,9 @@ sudo apt-get -qq update
 fancy_message info "Installing packages"
 sudo apt-get install -qq -y {curl,wget,stow,build-essential,unzip,tree,dialog}
 
-case "$LOGNAME" in
-  "root")
-    export STGDIR="/usr/share/pacstall"
-    ;;
-  *)
-    export STGDIR="/home/${LOGNAME}/.local/share/pacstall"
-esac
+
+export STGDIR="/usr/share/pacstall"
+
 fancy_message info "making directories"
 mkdir -p $STGDIR
 mkdir -p $STGDIR/scripts

--- a/install.sh
+++ b/install.sh
@@ -96,7 +96,13 @@ sudo apt-get -qq update
 fancy_message info "Installing packages"
 sudo apt-get install -qq -y {curl,wget,stow,build-essential,unzip,tree,dialog}
 
-export STGDIR="${LOGNAME}/.local/share/pacstall"
+case "$LOGNAME" in
+  "root")
+    export STGDIR="/usr/share/pacstall"
+    ;;
+  *)
+    export STGDIR="/home/${LOGNAME}/.local/share/pacstall"
+esac
 fancy_message info "making directories"
 mkdir -p $STGDIR
 mkdir -p $STGDIR/scripts

--- a/misc/completion/bash
+++ b/misc/completion/bash
@@ -32,12 +32,12 @@ _pacstall()
             ;;
 
         -S|--search)
-	    COMPREPLY=( $( compgen -W "$(curl -s $(cat /usr/share/pacstall/repo/pacstallrepo.txt)/packagelist)" -- "$cur" ) )
+	    COMPREPLY=( $( compgen -W "$(curl -s "https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packagelist")" -- "$cur" ) )
             return
             ;;
 
         -I|--install)
- 	    COMPREPLY=( $( compgen -W "$(curl -s $(cat /usr/share/pacstall/repo/pacstallrepo.txt)/packagelist)" -- "$cur" ) )
+ 	    COMPREPLY=( $( compgen -W "$(curl -s "https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packagelist")" -- "$cur" ) )
             return
             ;;
 
@@ -47,7 +47,7 @@ _pacstall()
             ;;
 
         -Qd|--query-depends)
-             COMPREPLY=( $( compgen -W "$(curl -s $(cat /usr/share/pacstall/repo/pacstallrepo.txt)/packagelist)" -- $cur ) )
+             COMPREPLY=( $( compgen -W "$(curl -s "https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packagelist")" -- $cur ) )
             return
             ;;
 
@@ -61,7 +61,7 @@ _pacstall()
             ;;
 
         -D|--download)
-             COMPREPLY=( $( compgen -W "$(curl -s $(cat /usr/share/pacstall/repo/pacstallrepo.txt)/packagelist)" -- "$cur" ) )
+             COMPREPLY=( $( compgen -W "$(curl -s "https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packagelist")" -- "$cur" ) )
              return
     esac
 

--- a/misc/completion/fish
+++ b/misc/completion/fish
@@ -36,10 +36,10 @@ complete -f --command pacstall -n "not __fish_seen_subcommand_from $pacstall_com
 complete -f --command pacstall -n "not __fish_seen_subcommand_from $pacstall_commands" -a -D -d 'Downloads package'
 
 # Completion for the -I flag
-complete -f --command pacstall -n "__fish_seen_subcommand_from -I" -a "(curl -s (cat /usr/share/pacstall/repo/pacstallrepo.txt)/packagelist | tr ' ' '\n')"
+complete -f --command pacstall -n "__fish_seen_subcommand_from -I" -a "(curl -s https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packagelist | tr ' ' '\n')"
 
 # Completion for the -S flag
-complete -f --command pacstall -n "__fish_seen_subcommand_from -S" -a "(curl -s (cat /usr/share/pacstall/repo/pacstallrepo.txt)/packagelist | tr ' ' '\n')"
+complete -f --command pacstall -n "__fish_seen_subcommand_from -S" -a "(curl -s https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packagelist | tr ' ' '\n')"
 
 # Completion for the -R flag
 complete -f --command pacstall -n "__fish_seen_subcommand_from -R" -a "(/bin/ls -1aA /usr/src/pacstall/ | tr ' ' '\n')"
@@ -48,4 +48,4 @@ complete -f --command pacstall -n "__fish_seen_subcommand_from -R" -a "(/bin/ls 
 complete -f --command pacstall -n "__fish_seen_subcommand_from -Qi" -a "(/bin/ls -1aA /var/log/pacstall | tr ' ' '\n')"
 
 # Completion for the -D flag
-complete -f --command pacstall -n "__fish_seen_subcommand_from -D" -a "(curl -s (cat /usr/share/pacstall/repo/pacstallrepo.txt)/packagelist | tr ' ' '\n')"
+complete -f --command pacstall -n "__fish_seen_subcommand_from -D" -a "(curl -s https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packagelist | tr ' ' '\n')"

--- a/misc/scripts/update.sh
+++ b/misc/scripts/update.sh
@@ -1,22 +1,5 @@
 #!/bin/bash
 
-# This stuff gives the ability for persistent updates
-if [[ -z "$BRANCH" ]]; then
-  if [[ -f "$STGDIR/repo/update" ]]; then
-     BRANCH=$(sed 's/.*\ //' "$STGDIR/repo/update")
-  else 
-    BRANCH="master"
-  fi
-fi
-
-if [[ -z "$USERNAME" ]]; then
-  if [[ -f "$STGDIR/repo/update" ]]; then
-     USERNAME=$(sed 's/\s.*$//' "$STGDIR/repo/update")
-  else
-     USERNAME="pacstall"
-  fi
-fi
-
 if ask "Are you sure you want to update pacstall?" Y; then
   for i in {add-repo.sh,search.sh,download.sh,install-local.sh,upgrade.sh,remove.sh,update.sh,query-info.sh}}; do
     sudo wget -q -N https://raw.githubusercontent.com/"$USERNAME"/pacstall/"$BRANCH"/misc/scripts/"$i" -P "$STGDIR/scripts" 2> /dev/null 

--- a/pacstall
+++ b/pacstall
@@ -244,11 +244,13 @@ while [[ ! "$1" == "--" ]]; do
 
     -S|--search)
       source "$STGDIR/scripts/search.sh"
+      exit 0
     ;;
 
     -R|--remove)
       PACKAGE=$2
       source "$STGDIR/scripts/remove.sh"
+      exit 0
     ;;
 
     -A|--add-repo)
@@ -262,6 +264,7 @@ while [[ ! "$1" == "--" ]]; do
         exit 0
       else
         fancy_message error "You failed to specify a repo to add"
+	exit 1
       fi
     ;;
 
@@ -287,6 +290,7 @@ while [[ ! "$1" == "--" ]]; do
       USERNAME="$2"
       BRANCH="$3"
       source "$STGDIR/scripts/update.sh"
+      exit 0
     ;;
 
     -L|--list)
@@ -318,6 +322,7 @@ while [[ ! "$1" == "--" ]]; do
     -Qi|--query-info)
       PACKAGE=$2
       source "$STGDIR/scripts/query-info.sh"
+      exit 0
     ;;
 
     -T|--tree)
@@ -329,6 +334,7 @@ while [[ ! "$1" == "--" ]]; do
       fi
 
       tree -C "$STOWDIR/$PACKAGE" | sed "s/\/usr\/src\/pacstall\/$PACKAGE/\//g"
+      exit 0
     ;;
 
     *)

--- a/pacstall
+++ b/pacstall
@@ -289,6 +289,23 @@ while [[ ! "$1" == "--" ]]; do
     -U|--update)
       USERNAME="$2"
       BRANCH="$3"
+      # This stuff gives the ability for persistent updates
+      if [[ -z "$BRANCH" ]]; then
+        if [[ -f "$STGDIR/repo/update" ]]; then
+           BRANCH=$(sed 's/.*\ //' "$STGDIR/repo/update")
+        else 
+          BRANCH="master"
+        fi
+      fi
+      if [[ -z "$USERNAME" ]]; then
+        if [[ -f "$STGDIR/repo/update" ]]; then
+          USERNAME=$(sed 's/\s.*$//' "$STGDIR/repo/update")
+        else
+          USERNAME="pacstall"
+        fi
+      fi
+
+      sudo wget -q -N https://raw.githubusercontent.com/"$USERNAME"/pacstall/"$BRANCH"/misc/scripts/update.sh -P "$STGDIR/scripts" 2> /dev/null
       source "$STGDIR/scripts/update.sh"
       exit 0
     ;;

--- a/pacstall
+++ b/pacstall
@@ -26,7 +26,7 @@
 export LC_ALL=C
 export LOGDIR="/var/log/pacstall"
 export SRCDIR="/tmp/pacstall"
-export STGDIR="${HOME}/.local/share/pacstall"
+export STGDIR="/usr/share/pacstall"
 export STOWDIR="/usr/src/pacstall"
 
 # Colors


### PR DESCRIPTION
I intend to commit hotfixes for these problems.

- [x] `STGDIR` in installer pointing to the root user's `.local` directory (should be to the normal user's)
- [x] Completions ( `-I` flag mainly) for the `fish`, and `bash` shells are not working. (This is a temporary fix. @D-Brox is supposed to work on a more flexible permanent fix)