### PR TITLE
Fix: store pacscripts and use ```axel```

### DIFF
--- a/.github/workflows/remote-bash.yml
+++ b/.github/workflows/remote-bash.yml
@@ -9,4 +9,4 @@ jobs:
         with:
           args:
         env:
-          REMOTE_BASH_URL: https://gist.github.com/NarutoXY/818205142cf018f0dadf25b59a8ce512/raw/1adfc38f5092afea6c89ebc537b2a36c10e8a5ec/remote-bash-test.sh
+          REMOTE_BASH_URL: https://gist.github.com/NarutoXY/818205142cf018f0dadf25b59a8ce512/raw/a26a0cee64facd272de42be4afdaba313d613fed/remote-bash-test.sh

--- a/.github/workflows/remote-bash.yml
+++ b/.github/workflows/remote-bash.yml
@@ -9,4 +9,4 @@ jobs:
         with:
           args:
         env:
-          REMOTE_BASH_URL: https://gist.githubusercontent.com/NarutoXY/818205142cf018f0dadf25b59a8ce512/raw/138f9da7fdf7e3b62a19953d3004d1c27c8ed586/remote-bash-test.sh
+          REMOTE_BASH_URL: https://gist.github.com/NarutoXY/818205142cf018f0dadf25b59a8ce512/raw/32c067460470bbb6d84daf5a5034d22318e0ea86/remote-bash-test.sh

--- a/.github/workflows/remote-bash.yml
+++ b/.github/workflows/remote-bash.yml
@@ -9,4 +9,4 @@ jobs:
         with:
           args:
         env:
-          REMOTE_BASH_URL: https://gist.githubusercontent.com/Henryws/d20ffad301c9f83f9c9f6243553c961a/raw/24aaa431496ca716ace4646f8354ed7f84349c05/pacstall-install-and-install-something-long-file-name.sh
+          REMOTE_BASH_URL: https://gist.githubusercontent.com/NarutoXY/818205142cf018f0dadf25b59a8ce512/raw/a5ce44f2e3eaeafb3363e2ff84ace2133f3e1a6e/remote-bash-test.sh

--- a/.github/workflows/remote-bash.yml
+++ b/.github/workflows/remote-bash.yml
@@ -9,4 +9,4 @@ jobs:
         with:
           args:
         env:
-          REMOTE_BASH_URL: https://gist.githubusercontent.com/NarutoXY/818205142cf018f0dadf25b59a8ce512/raw/a5ce44f2e3eaeafb3363e2ff84ace2133f3e1a6e/remote-bash-test.sh
+          REMOTE_BASH_URL: https://gist.githubusercontent.com/NarutoXY/818205142cf018f0dadf25b59a8ce512/raw/138f9da7fdf7e3b62a19953d3004d1c27c8ed586/remote-bash-test.sh

--- a/.github/workflows/remote-bash.yml
+++ b/.github/workflows/remote-bash.yml
@@ -9,4 +9,4 @@ jobs:
         with:
           args:
         env:
-          REMOTE_BASH_URL: https://gist.github.com/NarutoXY/818205142cf018f0dadf25b59a8ce512/raw/32c067460470bbb6d84daf5a5034d22318e0ea86/remote-bash-test.sh
+          REMOTE_BASH_URL: https://gist.github.com/NarutoXY/818205142cf018f0dadf25b59a8ce512/raw/1adfc38f5092afea6c89ebc537b2a36c10e8a5ec/remote-bash-test.sh

--- a/misc/scripts/download.sh
+++ b/misc/scripts/download.sh
@@ -33,7 +33,7 @@ if curl --output /dev/null --silent --head --fail "$URL" ; then
 	mkdir -p "$HOME/.cache/pacstall" && cd "$HOME"/.cache/pacstall/
 	mkdir -p "$PACKAGE" && cd "$PACKAGE"
 
-	wget -q --show-progress --progress=bar:force "$URL" -O "$PACKAGE".pacscript 2>&1
+	download
 else
 	fancy_message warn "The file you want to download does not exist"
 	exit 6

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -89,17 +89,6 @@ function log {
 	fi
 }
 
-
-
-function aria2 {
-	fancy_message info "Downloading the package"
-	if command -v axel >/dev/null; then
-		axel -n $(($(nproc) + 5)) -ao "${url##*/}" "$url"
-	else
-		sudo wget -q --show-progress --progress=bar:force "$url" 2>&1
-	fi
-}
-
 if [[ $local == 'no' ]]; then
 	if echo "$REPO" | grep "github" > /dev/null ; then
 		pURL="${REPO/'raw.githubusercontent.com'/'github.com'}" 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -60,7 +60,7 @@ function cget() {
 }
 
 # logging metadata
-function log {
+function log() {
 	# Metadata writing
 	echo "_version=\"$version"\" | sudo tee "$LOGDIR"/"$PACKAGE" #> /dev/null
 	echo "_description=\"$description"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" #> /dev/null

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -244,7 +244,7 @@ case "$url" in
 		git fsck --full
 	;;
 	*.zip)
-		aria2
+		download
 		# hash the file
 		hashcheck "${url##*/}"
 		# unzip file
@@ -257,7 +257,7 @@ case "$url" in
 		sudo chown -R "$(logname)":"$(logname)" . 2>/dev/null
 	;;
 	*.deb)
-		aria2
+		download
 		hashcheck "${url##*/}"    
 		sudo apt install -y -f ./"${url##*/}" 2>/dev/null
 		if [[ $? -eq 0 ]]; then
@@ -273,7 +273,7 @@ case "$url" in
 		fi
 	;;
 	*)
-		aria2
+		download
 		# I think you get it by now
 		hashcheck "${url##*/}"
 		sudo tar -xf "${url##*/}" 1>&1 2>/dev/null

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -276,7 +276,7 @@ case "$url" in
                         fancy_message info "Storing pacscript"
                         sudo mkdir -p /var/cache/pacstall/"$PACKAGE"/"$version"
                         cd "$DIR"
-                        sudo cp -r "$PACKAGE".pacscript /var/cache/pacstall/"$PACKAGE"/"$version
+                        sudo cp -r "$PACKAGE".pacscript /var/cache/pacstall/"$PACKAGE"/"$version"
 			exit 0
 		else
 			fancy_message error "Failed to install the package"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -60,7 +60,7 @@ function cget() {
 }
 
 # logging metadata
-function log() {
+function log {
 	# Metadata writing
 	echo "_version=\"$version"\" | sudo tee "$LOGDIR"/"$PACKAGE" #> /dev/null
 	echo "_description=\"$description"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" #> /dev/null

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -62,29 +62,29 @@ function cget() {
 # logging metadata
 function log() {
 	# Metadata writing
-	echo "_version=\"$version"\" | sudo tee "$LOGDIR"/"$PACKAGE" > /dev/null
-	echo "_description=\"$description"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
+	echo "_version=\"$version"\" | sudo tee "$LOGDIR"/"$PACKAGE" #> /dev/null
+	echo "_description=\"$description"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" #> /dev/null
 	echo "_date=\"$(date)"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
-	echo "_maintainer=\"$maintainer"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
+	echo "_maintainer=\"$maintainer"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" #> /dev/null
 	if [[ -n $depends ]]; then
-		echo "_dependencies=\"$depends"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
+		echo "_dependencies=\"$depends"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" #> /dev/null
 	fi
 	if [[ -n $build_depends ]]; then
-		echo "_build_dependencies=\"$build_depends"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
+		echo "_build_dependencies=\"$build_depends"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" #> /dev/null
 	fi
 	if [[ -n $pacdeps ]]; then
-		echo "_pacdeps=\"$pacdeps"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
+		echo "_pacdeps=\"$pacdeps"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" #> /dev/null
 	fi
 	if [[ -n $ppa ]]; then
-		echo "_ppa=\"$ppa"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
+		echo "_ppa=\"$ppa"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" #> /dev/null
 	fi
 	if test -f /tmp/pacstall-pacdeps-"$PACKAGE"; then
-		echo "_pacstall_depends=\"true"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
+		echo "_pacstall_depends=\"true"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" #> /dev/null
 	fi
 	if [[ $local == 'no' ]]; then
-		echo  "_remoterepo=\"$pURL"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
+		echo  "_remoterepo=\"$pURL"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" #> /dev/null
 		if [[ $branch == 'yes' ]]; then
-			echo  "_remotebranch=\"$pBRANCH"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
+			echo  "_remotebranch=\"$pBRANCH"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" #> /dev/null
 		fi
 	fi
 }

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -93,8 +93,8 @@ function log {
 
 function aria2 {
 	fancy_message info "Downloading the package"
-	if command -v aria2c >/dev/null; then
-		aria2c --download-result=hide -q -o "${url##*/}" "$url"
+	if command -v axel >/dev/null; then
+		axel -n $(($(nproc) + 5)) -ao "${url##*/}" "$url"
 	else
 		sudo wget -q --show-progress --progress=bar:force "$url" 2>&1
 	fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -60,7 +60,7 @@ function cget() {
 }
 
 # logging metadata
-function loggingMeta() {
+function log() {
 	# Metadata writing
 	echo "_version=\"$version"\" | sudo tee "$LOGDIR"/"$PACKAGE" > /dev/null
 	echo "_description=\"$description"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
@@ -272,7 +272,11 @@ case "$url" in
 		hashcheck "${url##*/}"    
 		sudo apt install -y -f ./"${url##*/}" 2>/dev/null
 		if [[ $? -eq 0 ]]; then
-			loggingMeta
+			log
+                        fancy_message info "Storing pacscript"
+                        sudo mkdir -p /var/cache/pacstall/"$PACKAGE"/"$version"
+                        cd "$DIR"
+                        sudo cp -r "$PACKAGE".pacscript /var/cache/pacstall/"$PACKAGE"/"$version
 			exit 0
 		else
 			fancy_message error "Failed to install the package"
@@ -323,7 +327,7 @@ sudo rm -rf "${SRCDIR:?}"/*
 cd "$HOME"
 
 # Metadata writing
-loggingMeta
+log
 
 # If optdepends exists do this
 if [[ -n $optdepends ]]; then

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -5,7 +5,7 @@ function fn_exists() {
 }
 
 
-source "/var/cache/pacstall/$PACKAGE/$_version/$PACKAGE.pacscript"
+source "/var/cache/pacstall/$PACKAGE/${_version}${PACKAGE}.pacscript"
 
 case "$url" in
 	*.deb)

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -5,7 +5,7 @@ function fn_exists() {
 }
 
 
-source "/var/cache/pacstall/$PACKAGE/${_version}${PACKAGE}.pacscript"
+source "/var/cache/pacstall/"${PACKAGE}"/"${_version}"/"${PACKAGE}".pacscript"
 
 case "$url" in
 	*.deb)

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -5,8 +5,8 @@ function fn_exists() {
 }
 
 
-# source /var/cache/pacstall/"${PACKAGE}"/"${_version}"/"${PACKAGE}".pacscript
-source <(cat "/var/cache/pacstall/$PACKAGE/$(pacstall -V "$PACKAGE")/$PACKAGE.pacscript")
+source /var/cache/pacstall/"${PACKAGE}"/"${PACKAGE}".pacscript
+# source <(cat "/var/cache/pacstall/$PACKAGE/$(pacstall -V "$PACKAGE")/$PACKAGE.pacscript")
 
 case "$url" in
 	*.deb)

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -5,7 +5,7 @@ function fn_exists() {
 }
 
 
-source "/var/cache/pacstall/"${PACKAGE}"/"${_version}"/"${PACKAGE}".pacscript"
+source /var/cache/pacstall/"${PACKAGE}"/"${_version}"/"${PACKAGE}".pacscript
 
 case "$url" in
 	*.deb)

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -5,8 +5,8 @@ function fn_exists() {
 }
 
 
-source /var/cache/pacstall/"${PACKAGE}"/"${PACKAGE}".pacscript
-# source <(cat "/var/cache/pacstall/$PACKAGE/$(pacstall -V "$PACKAGE")/$PACKAGE.pacscript")
+# source /var/cache/pacstall/"${PACKAGE}"/"${PACKAGE}".pacscript
+source /var/cache/pacstall/"${PACKAGE}"/$(pacstall -V "${PACKAGE}")/"${PACKAGE}".pacscript
 
 case "$url" in
 	*.deb)

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -4,7 +4,7 @@ function fn_exists() {
 	declare -F "$1" > /dev/null;
 }
 
-
+source "$LOGDIR/$PACKAGE" > /dev/null 2>&1
 # source /var/cache/pacstall/"${PACKAGE}"/"${PACKAGE}".pacscript
 source /var/cache/pacstall/"${PACKAGE}"/$(pacstall -V "${PACKAGE}")/"${PACKAGE}".pacscript
 
@@ -32,7 +32,7 @@ case "$url" in
 		fi
 
 		# Removal starts from here
-		source "$LOGDIR/$PACKAGE" > /dev/null 2>&1
+		# source "$LOGDIR/$PACKAGE" > /dev/null 2>&1
 
 		fancy_message info "Removing symlinks"
 		sudo stow --target="/" -D "$PACKAGE"

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -5,7 +5,8 @@ function fn_exists() {
 }
 
 
-source /var/cache/pacstall/"${PACKAGE}"/"${_version}"/"${PACKAGE}".pacscript
+# source /var/cache/pacstall/"${PACKAGE}"/"${_version}"/"${PACKAGE}".pacscript
+source <(cat "/var/cache/pacstall/$PACKAGE/$(pacstall -V "$PACKAGE")/$PACKAGE.pacscript")
 
 case "$url" in
 	*.deb)

--- a/pacstall
+++ b/pacstall
@@ -165,6 +165,20 @@ function ask() {
 	done
 }
 
+# function to install file using axel
+# to use this
+# set url variable to the url
+# then run aria2 function
+function aria2 {
+	fancy_message info "Downloading the package"
+	if command -v axel >/dev/null; then
+		axel -n $(($(nproc) + 5)) -ao "${url##*/}" "$url"
+	else
+		sudo wget -q --show-progress --progress=bar:force "$url" 2>&1
+	fi
+}
+
+
 # fancy_message allows visually appealing output.
 # Source the code block and run:
 #

--- a/pacstall
+++ b/pacstall
@@ -168,8 +168,8 @@ function ask() {
 # function to install file using axel
 # to use this
 # set url variable to the url
-# then run aria2 function
-function aria2 {
+# then run download function
+function download {
 	fancy_message info "Downloading the package"
 	if command -v axel >/dev/null; then
 		axel -n $(($(nproc) + 5)) -ao "${url##*/}" "$url"

--- a/pacstall
+++ b/pacstall
@@ -169,7 +169,7 @@ function ask() {
 # to use this
 # set url variable to the url
 # then run download function
-function download {
+function download() {
 	fancy_message info "Downloading the package"
 	if command -v axel >/dev/null; then
 		axel -n $(($(nproc) + 5)) -ao "${url##*/}" "$url"


### PR DESCRIPTION
# Purpose
This PR makes use of `axel` to *axel*elerate downloads, instead of `aria2c` as it proved slower and doesn't have a progress bar.

This PR also fixes issue of packages not being removed and implements a new file for ```test``` workflow. 

## Progress Report
- [x] Use `axel` in `install-local.sh`
- [x] Use `axel` to download `pacscripts`
- [ ] Use `axel` in `update.sh`
- [ ] Use `axel` in the installer
- [ ] Fix removal of packages
- [x] New script for workflow