### PR TITLE
Doc: Add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,17 @@
+# Purpose
+
+Describe the problem you are fixing or the feature you are adding.
+
+# Approach
+
+How does this address the problem?
+
+# Progress
+
+Make a checklist of your progress
+
+- [x] Example checklist
+
+# Addendum
+
+Link any issues with this PR and/or write something that you want to inform us about (optional)


### PR DESCRIPTION
# Purpose

Currently this project has no pull request templates, so the pull request descriptions are kind of all over the place.

# Approach

This PR solves this problem by adding a `pull_request_template.md` file under `.github/PULL_REQUEST_TEMPLATE`. People will be auto suggested by GitHub in the future to use the template defined in that file when creating pull requests. Hopefully bringing order to the pull request descriptions, once and for all.

# Progress

- [x] Make `pull_request_template.md`