### PR TITLE
Feat: moves optdepends to before building

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -230,6 +230,24 @@ if [[ $? -eq 1 ]]; then
 	exit 8
 fi
 
+# If optdepends exists do this
+if [[ -n $optdepends ]]; then
+	sudo rm -f /tmp/pacstall-optdepends
+
+	fancy_message info "$name has optional dependencies that can enhance its functionalities"
+	echo "Optional dependencies:"
+	printf '    %s\n' "${optdepends[@]}"
+	ask "Do you want to install them" Y
+	if [[ $answer -eq 1 ]]; then
+		for items in "${optdepends[*]}"; do
+			# output the name of the apt thing without the description, EI: `foo: not bar` -> `foo`
+			printf "%s\n" "${optdepends[@]}" | cut -f1 -d":" | tr '\n' ' ' >> /tmp/pacstall-optdepends
+			# Install
+			sudo apt-get install -y -qq $(cat /tmp/pacstall-optdepends)
+		done
+	fi
+fi
+
 fancy_message info "Retrieving packages"
 mkdir -p "$SRCDIR"
 cd "$SRCDIR"
@@ -324,24 +342,6 @@ cd "$HOME"
 
 # Metadata writing
 log
-
-# If optdepends exists do this
-if [[ -n $optdepends ]]; then
-	sudo rm -f /tmp/pacstall-optdepends
-
-	fancy_message info "$name has optional dependencies that can enhance its functionalities"
-	echo "Optional dependencies:"
-	printf '    %s\n' "${optdepends[@]}"
-	ask "Do you want to install them" Y
-	if [[ $answer -eq 1 ]]; then
-		for items in "${optdepends[*]}"; do
-			# output the name of the apt thing without the description, EI: `foo: not bar` -> `foo`
-			printf "%s\n" "${optdepends[@]}" | cut -f1 -d":" | tr '\n' ' ' >> /tmp/pacstall-optdepends
-			# Install
-			sudo apt-get install -y -qq $(cat /tmp/pacstall-optdepends)
-		done
-	fi
-fi
 
 fancy_message info "Symlinking files"
 cd /usr/src/pacstall/ || sudo mkdir -p /usr/src/pacstall && cd /usr/src/pacstall


### PR DESCRIPTION

# Purpose
Sometimes optional dependencies in are used during building [(like ones in wine)](https://wiki.winehq.org/Building_Wine).
# Approach
Moves the code which interprets `optdepends` from after building to before.

# Addendum

Fixes #150