### PR TITLE
Feat: Add fakeroot

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,7 +143,7 @@ if [[ "$answer" -eq 1 ]]; then
     sudo apt-get install -qq -y ripgrep
 fi
 
-sudo apt-get install -qq -y {curl,wget,stow,build-essential,unzip,tree,dialog,bc}
+sudo apt-get install -qq -y curl wget stow build-essential unzip tree dialog bc fakeroot
 
 
 export STGDIR="/usr/share/pacstall"
@@ -163,9 +163,9 @@ touch $STGDIR/repo/pacstallrepo.txt
 echo 'https://raw.githubusercontent.com/pacstall/pacstall-programs/master' > $STGDIR/repo/pacstallrepo.txt
 
 fancy_message info "Pulling scripts from GitHub "
-for i in {error_log.sh,add-repo.sh,search.sh,download.sh,install-local.sh,upgrade.sh,remove.sh,update.sh,query-info.sh}; do 
+for i in {error_log.sh,add-repo.sh,search.sh,download.sh,install-local.sh,upgrade.sh,remove.sh,update.sh,query-info.sh}; do
 	wget -q --show-progress -N https://raw.githubusercontent.com/pacstall/pacstall/master/misc/scripts/"$i" -P $STGDIR/scripts &
-done 
+done
 
 PID=$!
 i=1

--- a/install.sh
+++ b/install.sh
@@ -143,7 +143,7 @@ if [[ "$answer" -eq 1 ]]; then
     sudo apt-get install -qq -y ripgrep
 fi
 
-sudo apt-get install -qq -y curl wget stow build-essential unzip tree dialog bc fakeroot
+sudo apt-get install -qq -y curl wget stow build-essential unzip tree bc fakeroot
 
 
 export STGDIR="/usr/share/pacstall"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -139,9 +139,9 @@ if [[ $? -ne 0 ]]; then
 fi
 
 # export all variables from pacscript (fakeroot), and redirect to /dev/null in case of errors (because obviously no pacscript will contain every single available option)
-export {name,version,url,build_depends,depends,replace,description,hash,maintainer,optdepends,ppa,pacdeps,patch} > /dev/null
+export {name,version,url,build_depends,depends,replace,description,hash,maintainer,optdepends,ppa,pacdeps,patch} > /dev/null 2>&1
 # Do the same for functions
-export -f {prepare,build,install,postinst,removescript} > /dev/null
+export -f {prepare,build,install,postinst,removescript} > /dev/null 2>&1
 
 if type pkgver > /dev/null 2>&1; then
 	version=$(pkgver) > /dev/null

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -316,7 +316,9 @@ if [[ -n $patch ]]; then
 fi
 
 export pkgdir="/usr/src/pacstall/$name"
-fakeroot -- prepare
+tmp_prepare=$(declare -f prepare)
+fakeroot -- bash -c "$tmp_prepare; prepare"
+unset tmp_prepare
 
 # Check if build function doesn't exist
 if ! type -t build > /dev/null 2>&1; then
@@ -325,7 +327,10 @@ if ! type -t build > /dev/null 2>&1; then
 	return 1
 fi
 
-fakeroot -- build
+tmp_build=$(declare -f build)
+fakeroot -- bash -c "$tmp_build; build"
+unset tmp_build
+
 trap - SIGINT
 
 fancy_message info "Installing"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -64,7 +64,7 @@ function cget() {
 
 # Logging metadata
 function log() {
-	
+
 	# Origin repo info parsing
 	if [[ $local == 'no' ]]; then
 		if echo "$REPO" | grep "github" > /dev/null ; then
@@ -137,6 +137,11 @@ if [[ $? -ne 0 ]]; then
 	error_log 12 "install $PACKAGE"
 	return 1
 fi
+
+# export all variables from pacscript (fakeroot), and redirect to /dev/null in case of errors (because obviously no pacscript will contain every single available option)
+export {name,version,url,build_depends,depends,replace,description,hash,maintainer,optdepends,ppa,pacdeps,patch} > /dev/null
+# Do the same for functions
+export -f {prepare,build,install,postinst,removescript} > /dev/null
 
 if type pkgver > /dev/null 2>&1; then
 	version=$(pkgver) > /dev/null
@@ -274,7 +279,7 @@ case "$url" in
 		sudo apt install -y -f ./"${url##*/}" 2>/dev/null
 		if [[ $? -eq 0 ]]; then
 			log
-			
+
 			fancy_message info "Storing pacscript"
 			sudo mkdir -p /var/cache/pacstall/"$PACKAGE"/"$version"
 			cd "$DIR"
@@ -311,7 +316,7 @@ if [[ -n $patch ]]; then
 fi
 
 export pkgdir="/usr/src/pacstall/$name"
-prepare
+fakeroot -- prepare
 
 # Check if build function doesn't exist
 if ! type -t build > /dev/null 2>&1; then
@@ -320,7 +325,7 @@ if ! type -t build > /dev/null 2>&1; then
 	return 1
 fi
 
-build
+fakeroot -- build
 trap - SIGINT
 
 fancy_message info "Installing"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -320,14 +320,14 @@ export pkgdir="/usr/src/pacstall/$name"
 # fakeroot is weird but this method works
 # create tmp variable that is the output of what prepare function is (it prints out function)
 
-if command -v fakeroot > /dev/null; then
+if ! command -v fakeroot > /dev/null; then
+	sudo apt-get install fakeroot -y
+else
 	tmp_prepare=$(declare -f prepare)
 	# We run fakeroot, BUT, we don't actually pass any variables through to fakeroot. In other words, bash works with the tmp_prepare, instead of fakeroot
 	fakeroot -- bash -c "$tmp_prepare; prepare"
 	# Unset because it's a tmp variable
 	unset tmp_prepare
-else
-	prepare
 fi
 
 # Check if build function doesn't exist
@@ -337,12 +337,12 @@ if ! type -t build > /dev/null 2>&1; then
 	return 1
 fi
 
-if command -v fakeroot > /dev/null; then
+if ! command -v fakeroot > /dev/null; then
+	sudo apt-get install fakeroot -y
+else
 	tmp_build=$(declare -f build)
 	fakeroot -- bash -c "$tmp_build; build"
 	unset tmp_build
-else
-	build
 fi
 
 # Trap so that we can clean up (hopefully without messing up anything)

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -319,11 +319,16 @@ export pkgdir="/usr/src/pacstall/$name"
 
 # fakeroot is weird but this method works
 # create tmp variable that is the output of what prepare function is (it prints out function)
-tmp_prepare=$(declare -f prepare)
-# We run fakeroot, BUT, we don't actually pass any variables through to fakeroot. In other words, bash works with the tmp_prepare, instead of fakeroot
-fakeroot -- bash -c "$tmp_prepare; prepare"
-# Unset because it's a tmp variable
-unset tmp_prepare
+
+if command -v fakeroot > /dev/null; then
+	tmp_prepare=$(declare -f prepare)
+	# We run fakeroot, BUT, we don't actually pass any variables through to fakeroot. In other words, bash works with the tmp_prepare, instead of fakeroot
+	fakeroot -- bash -c "$tmp_prepare; prepare"
+	# Unset because it's a tmp variable
+	unset tmp_prepare
+else
+	prepare
+fi
 
 # Check if build function doesn't exist
 if ! type -t build > /dev/null 2>&1; then
@@ -332,9 +337,13 @@ if ! type -t build > /dev/null 2>&1; then
 	return 1
 fi
 
-tmp_build=$(declare -f build)
-fakeroot -- bash -c "$tmp_build; build"
-unset tmp_build
+if command -v fakeroot > /dev/null; then
+	tmp_build=$(declare -f build)
+	fakeroot -- bash -c "$tmp_build; build"
+	unset tmp_build
+else
+	build
+fi
 
 # Trap so that we can clean up (hopefully without messing up anything)
 trap - SIGINT

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -324,6 +324,7 @@ if ! command -v fakeroot > /dev/null; then
 fi
 tmp_prepare=$(declare -f prepare)
 # We run fakeroot, BUT, we don't actually pass any variables through to fakeroot. In other words, bash works with the tmp_prepare, instead of fakeroot
+fancy_message info "Running prepare in fakeroot. Do not enter password if prompted"
 fakeroot -- bash -c "$tmp_prepare; prepare"
 # Unset because it's a tmp variable
 unset tmp_prepare
@@ -339,6 +340,7 @@ if ! command -v fakeroot > /dev/null; then
 	sudo apt-get install fakeroot -y
 fi
 tmp_build=$(declare -f build)
+fancy_message info "Running build in fakeroot. Do not enter password if prompted"
 fakeroot -- bash -c "$tmp_build; build"
 unset tmp_build
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -319,16 +319,14 @@ export pkgdir="/usr/src/pacstall/$name"
 
 # fakeroot is weird but this method works
 # create tmp variable that is the output of what prepare function is (it prints out function)
-
 if ! command -v fakeroot > /dev/null; then
 	sudo apt-get install fakeroot -y
-else
-	tmp_prepare=$(declare -f prepare)
-	# We run fakeroot, BUT, we don't actually pass any variables through to fakeroot. In other words, bash works with the tmp_prepare, instead of fakeroot
-	fakeroot -- bash -c "$tmp_prepare; prepare"
-	# Unset because it's a tmp variable
-	unset tmp_prepare
 fi
+tmp_prepare=$(declare -f prepare)
+# We run fakeroot, BUT, we don't actually pass any variables through to fakeroot. In other words, bash works with the tmp_prepare, instead of fakeroot
+fakeroot -- bash -c "$tmp_prepare; prepare"
+# Unset because it's a tmp variable
+unset tmp_prepare
 
 # Check if build function doesn't exist
 if ! type -t build > /dev/null 2>&1; then
@@ -339,11 +337,10 @@ fi
 
 if ! command -v fakeroot > /dev/null; then
 	sudo apt-get install fakeroot -y
-else
-	tmp_build=$(declare -f build)
-	fakeroot -- bash -c "$tmp_build; build"
-	unset tmp_build
 fi
+tmp_build=$(declare -f build)
+fakeroot -- bash -c "$tmp_build; build"
+unset tmp_build
 
 # Trap so that we can clean up (hopefully without messing up anything)
 trap - SIGINT

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -316,8 +316,13 @@ if [[ -n $patch ]]; then
 fi
 
 export pkgdir="/usr/src/pacstall/$name"
+
+# fakeroot is weird but this method works
+# create tmp variable that is the output of what prepare function is (it prints out function)
 tmp_prepare=$(declare -f prepare)
+# We run fakeroot, BUT, we don't actually pass any variables through to fakeroot. In other words, bash works with the tmp_prepare, instead of fakeroot
 fakeroot -- bash -c "$tmp_prepare; prepare"
+# Unset because it's a tmp variable
 unset tmp_prepare
 
 # Check if build function doesn't exist
@@ -331,6 +336,7 @@ tmp_build=$(declare -f build)
 fakeroot -- bash -c "$tmp_build; build"
 unset tmp_build
 
+# Trap so that we can clean up (hopefully without messing up anything)
 trap - SIGINT
 
 fancy_message info "Installing"


### PR DESCRIPTION
# Purpose

This pr will make packages prepare and build inside of fakeroot, allowing for better security

# Approach

Pacstall will export all possible variables and functions a pacscript can have (obviously some will error, but as long as every variable/function that is in the script is exported, it's fine). Then it can pass into fakeroot
