### PR TITLE
Fix: chown uses $(logname) instead of $LOGNAME

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -251,7 +251,7 @@ case "$url" in
 		# The srcdir is /tmp/pacstall/foo
 		export srcdir="/tmp/pacstall/$PWD"
 		# Make the directory available for users
-		sudo chown -R "$(logname)":"$(logname)" . 2>/dev/null
+		sudo chown -R "$LOGNAME":"$LOGNAME" . 2>/dev/null
 		# Check the integrity
 		git fsck --full
 	;;


### PR DESCRIPTION
# Purpose

`logname` is broken on some systems (like mine) but `$LOGNAME` is not.

# Approach

change `$(logname)` to `$LOGNAME`.
