### PR TITLE
Fix: Install `fakeroot` if it's not present

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -320,15 +320,15 @@ export pkgdir="/usr/src/pacstall/$name"
 # fakeroot is weird but this method works
 # create tmp variable that is the output of what prepare function is (it prints out function)
 
-if command -v fakeroot > /dev/null; then
-	tmp_prepare=$(declare -f prepare)
-	# We run fakeroot, BUT, we don't actually pass any variables through to fakeroot. In other words, bash works with the tmp_prepare, instead of fakeroot
-	fakeroot -- bash -c "$tmp_prepare; prepare"
-	# Unset because it's a tmp variable
-	unset tmp_prepare
-else
-	prepare
+if ! command -v fakeroot > /dev/null; then
+	sudo apt install fakeroot
 fi
+
+tmp_prepare=$(declare -f prepare)
+# We run fakeroot, BUT, we don't actually pass any variables through to fakeroot. In other words, bash works with the tmp_prepare, instead of prepare. 
+fakeroot -- bash -c "$tmp_prepare; prepare"
+# Unset because it's a tmp variable
+unset tmp_prepare
 
 # Check if build function doesn't exist
 if ! type -t build > /dev/null 2>&1; then
@@ -337,13 +337,9 @@ if ! type -t build > /dev/null 2>&1; then
 	return 1
 fi
 
-if command -v fakeroot > /dev/null; then
-	tmp_build=$(declare -f build)
-	fakeroot -- bash -c "$tmp_build; build"
-	unset tmp_build
-else
-	build
-fi
+tmp_build=$(declare -f build)
+fakeroot -- bash -c "$tmp_build; build"
+unset tmp_build
 
 # Trap so that we can clean up (hopefully without messing up anything)
 trap - SIGINT


### PR DESCRIPTION
# Purpose

Compiling in root environment, without fakeroot, can be a security issue.


# Approach

How does this address the problem?
Compiling in root environment, without fakeroot, can be a security issue. It checks if fakeroot is not present and then installs it using `apt`. 

# Progress

- [x] Install Fakeroot if it's not present

