### PR TITLE
Feat: Error out when running pacstall as root

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -22,6 +22,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
+# Error out when run as root
+if [[ "$EUID" -eq 0 ]]; then
+	echo "Pacstall can't be run as root. Please run as a normal user."
+	exit
+fi
 # Configuration
 export LC_ALL=C
 export LOGDIR="/var/log/pacstall/metadata"

--- a/pacstall
+++ b/pacstall
@@ -24,7 +24,7 @@
 
 # Error out when run as root
 if [[ "$EUID" -eq 0 ]]; then
-	echo "Pacstall can't be run as root. Please run as a normal user."
+	fancy_message error "Pacstall can't be run as root. Please run as a normal user."
 	exit 1
 fi
 # Configuration

--- a/pacstall
+++ b/pacstall
@@ -22,11 +22,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-# Error out when run as root
-if [[ "$EUID" -eq 0 ]]; then
-	fancy_message error "Pacstall can't be run as root. Please run as a normal user."
-	exit 1
-fi
 # Configuration
 export LC_ALL=C
 export LOGDIR="/var/log/pacstall/metadata"
@@ -196,6 +191,13 @@ function download() {
 		sudo wget -q --show-progress --progress=bar:force "$1" 2>&1
 	fi
 }
+
+
+# Error out when run as root
+if [[ "$EUID" -eq 0 ]]; then
+	fancy_message error "Pacstall can't be run as root. Please run as a normal user."
+	exit 1
+fi
 
 # run sudo apt update if it's been more than a week
 [ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -7)" ] && sudo apt-get update -qq

--- a/pacstall
+++ b/pacstall
@@ -25,7 +25,7 @@
 # Error out when run as root
 if [[ "$EUID" -eq 0 ]]; then
 	echo "Pacstall can't be run as root. Please run as a normal user."
-	exit
+	exit 1
 fi
 # Configuration
 export LC_ALL=C


### PR DESCRIPTION
It's not recommended to run community scripts as root. So error out like AUR.

# Purpose

Error out when EUID is 0, i.e. user is root

# Approach

Use EUID, which is equal to 0 when root

# Progress


- [x] Error out when run as root
