### PR TITLE
Fix: Caching

### DIFF
--- a/misc/scripts/download.sh
+++ b/misc/scripts/download.sh
@@ -33,7 +33,6 @@ fi
 if curl --output /dev/null --silent --head --fail "$URL" ; then
 	if [[ "$type" = "install" ]]; then
 		mkdir -p "/tmp/pacstall/pacscripts/" && cd "/tmp/pacstall/pacscripts/"
-		mkdir -p "$PACKAGE" && cd "$PACKAGE"
 	fi
 
 	download "$URL" > /dev/null 2>&1

--- a/misc/scripts/download.sh
+++ b/misc/scripts/download.sh
@@ -31,8 +31,10 @@ if ! wget -q --tries=10 --timeout=20 --spider https://github.com; then
 fi
 
 if curl --output /dev/null --silent --head --fail "$URL" ; then
-	mkdir -p "/tmp/pacstall/pacscripts/" && cd "/tmp/pacstall/pacscripts/"
-	mkdir -p "$PACKAGE" && cd "$PACKAGE"
+	if [[ "$type" = "install" ]]; then
+		mkdir -p "/tmp/pacstall/pacscripts/" && cd "/tmp/pacstall/pacscripts/"
+		mkdir -p "$PACKAGE" && cd "$PACKAGE"
+	fi
 
 	download "$URL" > /dev/null 2>&1
 	return 0

--- a/misc/scripts/download.sh
+++ b/misc/scripts/download.sh
@@ -31,7 +31,7 @@ if ! wget -q --tries=10 --timeout=20 --spider https://github.com; then
 fi
 
 if curl --output /dev/null --silent --head --fail "$URL" ; then
-	sudo mkdir -p "/tmp/pacstall/pacscripts/" && cd "/tmp/pacstall/pacscripts/"
+	mkdir -p "/tmp/pacstall/pacscripts/" && cd "/tmp/pacstall/pacscripts/"
 	mkdir -p "$PACKAGE" && cd "$PACKAGE"
 
 	download "$URL" > /dev/null 2>&1

--- a/misc/scripts/download.sh
+++ b/misc/scripts/download.sh
@@ -31,7 +31,7 @@ if ! wget -q --tries=10 --timeout=20 --spider https://github.com; then
 fi
 
 if curl --output /dev/null --silent --head --fail "$URL" ; then
-	mkdir -p "$HOME/.cache/pacstall" && cd "$HOME"/.cache/pacstall/
+	sudo mkdir -p "/tmp/pacstall/pacscripts/" && cd "/tmp/pacstall/pacscripts/"
 	mkdir -p "$PACKAGE" && cd "$PACKAGE"
 
 	download "$URL" > /dev/null 2>&1

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -28,6 +28,8 @@ function cleanup () {
 	if [ -f /tmp/pacstall-optdepends ]; then
 		sudo rm /tmp/pacstall-optdepends
 	fi
+
+	rm -rf "/tmp/pacstall/pacscripts/"
 }
 
 function trap_ctrlc () {

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -28,8 +28,6 @@ function cleanup () {
 	if [ -f /tmp/pacstall-optdepends ]; then
 		sudo rm /tmp/pacstall-optdepends
 	fi
-
-	rm -rf "/tmp/pacstall/pacscripts/"
 }
 
 function trap_ctrlc () {

--- a/pacstall
+++ b/pacstall
@@ -436,7 +436,7 @@ while [[ ! "$1" == "--" ]]; do
 					continue
 				fi
 				
-				fancy_message info "${GREEN}${PACKAGE}${NC}'s pacscript is downloaded in ${GREEN}$HOMEDIR/.cache/pacstall/$PACKAGE${NC}"
+				fancy_message info "${GREEN}${PACKAGE}${NC}'s pacscript is downloaded in ${GREEN}$(pwd)/$PACKAGE${NC}"
 			done
 
 			if [[ -s "LOGFILE" ]]; then

--- a/pacstall
+++ b/pacstall
@@ -185,6 +185,7 @@ function fancy_message() {
 # use axel if avaliable
 function download() {
 	fancy_message info "$2"
+	sudo rm -f "${1##*/}"
 	if command -v axel > /dev/null; then
 		sudo axel -n $(($(nproc) + 5)) -ao "${1##*/}" "$1"
 	else


### PR DESCRIPTION
# Purpose

Currently the caching in `download.sh` caches pacscripts to  `~/.cache/pacstall`, and it doesn't get cleaned after `install-local.sh` ends 

# Approach

This changes the caching directory to `/tmp/pacstall/pacscripts/`, and cleans it after `install-local` ends

# Progress

- [x] Change caching directory
- [x] Overwrite the file before downloading it
- [x] Change download dir based on `type` 

# Addendum

Fixes #160 
