### PR TITLE
Fix: (scripts): Fix package install past letter p

### DIFF
--- a/misc/scripts/download.sh
+++ b/misc/scripts/download.sh
@@ -32,7 +32,7 @@ fi
 
 if curl --output /dev/null --silent --head --fail "$URL" ; then
 	if [[ "$type" = "install" ]]; then
-		mkdir -p "/tmp/pacstall/pacscripts/" && cd "/tmp/pacstall/pacscripts/"
+		mkdir -p "/tmp/pacstall/" && cd "/tmp/pacstall/"
 	fi
 
 	download "$URL" > /dev/null 2>&1

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -372,7 +372,6 @@ if [[ $REMOVE_DEPENDS = y ]]; then
 	sudo apt-get remove $build_depends
 fi
 
-sudo rm -rf "${SRCDIR:?}"/*
 cd "$HOME"
 
 # Metadata writing

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -405,7 +405,7 @@ fi
 fancy_message info "Storing pacscript"
 sudo mkdir -p /var/cache/pacstall/"$PACKAGE"/"$version"
 cd "$DIR"
-sudo cp -r "$PACKAGE".pacscript /var/cache/pacstall/"$PACKAGE"/"$version"
+sudo cp -r /tmp/pacstall/"$PACKAGE".pacscript /var/cache/pacstall/"$PACKAGE"/"$version"
 
 fancy_message info "Cleaning up"
 cleanup


### PR DESCRIPTION
In pr #161 (caching), the pacscript is downloaded to
/tmp/pacstall/pacscripts, but during the install, there is a cd to `./*/`, which means that any package past the letter `p` will be unable to cd into