### PR TITLE
Fix: remove unneeded sudo from download

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -187,9 +187,9 @@ function download() {
 	fancy_message info "$2"
 	sudo rm -f "${1##*/}"
 	if command -v axel > /dev/null; then
-		sudo axel -n $(($(nproc) + 5)) -ao "${1##*/}" "$1"
+		axel -n $(($(nproc) + 5)) -ao "${1##*/}" "$1"
 	else
-		sudo wget -q --show-progress --progress=bar:force "$1" 2>&1
+		wget -q --show-progress --progress=bar:force "$1" 2>&1
 	fi
 }
 


### PR DESCRIPTION
# Purpose

Due to the pacscripts being downloaded as root, we couldn't edit it during install.

# Approach

Removing the `sudo` from download function solves the issue

# Progress

- [x] Remove `sudo`s from download
