### PR TITLE
Fix (scripts): Copy from the correct location

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -404,7 +404,7 @@ fi
 fancy_message info "Storing pacscript"
 sudo mkdir -p /var/cache/pacstall/"$PACKAGE"/"$version"
 cd "$DIR"
-sudo cp -r /tmp/pacstall/"$PACKAGE".pacscript /var/cache/pacstall/"$PACKAGE"/"$version"
+sudo cp -r "$PACKAGE".pacscript /var/cache/pacstall/"$PACKAGE"/"$version"
 
 fancy_message info "Cleaning up"
 cleanup


### PR DESCRIPTION
# Purpose

Pacstall tries to copy from `$SRCDIR/$name.pacscript` instead of the location of the local pacscript

# Approach

Fix the copy command at the end of `install-local.sh`

# Addendum

#170 
