### PR TITLE
Fix: deb-control requires version to start with digit

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -119,8 +119,12 @@ function makeVirtualDeb {
 	# implements $(gives) variable
 	fancy_message info "Creating dummy package"
 	sudo mkdir -p "$SRCDIR/$name-pacstall/DEBIAN"
-	printf "Package: $name-pacstall
-Version: $version\n"| sudo tee "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
+	printf "Package: $name-pacstall\n" | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
+	if [[ $version =~ "^[0-9]" ]]; then
+		printf "Version: $version\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
+	else
+		printf "Version: 0-$version\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
+	fi
 	if [[ -n $depends ]]; then
 		printf "Depends: ${depends//' '/' | '}\n"| sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 	fi


### PR DESCRIPTION
# Purpose

Deb-control (dummy package) requires version to start with digit

# Approach

Add "0-" before version starting with letter
