### PR TITLE
Rem: remove architecture `:any` extention

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -137,7 +137,7 @@ function makeVirtualDeb {
 			optinstall='--install-suggests'
 		fi
 		printf "Suggests:" |sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
-		printf " %s\n" "${optdepends[@]}" | awk -F': ' '{print $1":any "}' | tr '\n' '|' | head -c -2 | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
+		printf " %s\n" "${optdepends[@]}" | awk -F': ' '{print $1}' | tr '\n' '|' | head -c -2 | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 		printf "\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 	fi
 	printf "Architecture: all


### PR DESCRIPTION
# Purpose

The extra `:any` extention on optdepends dummy deb line breaks `:i386` dependencies, for example. Removing it fixes the problem without causing new issues.

# Addendum

This was added while testing fixes and shouldn't be here anymore.
