### PR TITLE
Feat: Unset variables in `install-local.sh` cleanup

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -29,8 +29,7 @@ function cleanup () {
 	if [ -f /tmp/pacstall-optdepends ]; then
 		sudo rm /tmp/pacstall-optdepends
 	fi
-	unset name version url build_depends depends breaks replace description hash removescript optdepends ppa maintainer pacdeps patch PACPATCH NOBUILDDEP optinstall
-	
+	unset name version url build_depends depends breaks replace description hash removescript optdepends ppa maintainer pacdeps patch PACPATCH NOBUILDDEP optinstall 2>/dev/null
 }
 
 function trap_ctrlc () {

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -29,24 +29,7 @@ function cleanup () {
 	if [ -f /tmp/pacstall-optdepends ]; then
 		sudo rm /tmp/pacstall-optdepends
 	fi
-	unset name
-	unset version
-	unset url
-	unset build_depends
-	unset depends
-	unset breaks
-	unset replace
-	unset description
-	unset hash
-	unset removescript
-	unset optdepends
-	unset ppa
-	unset maintainer
-	unset pacdeps
-	unset patch
-	unset PACPATCH
-	unset NOBUILDDEP
-	unset optinstall
+	unset name version url build_depends depends breaks replace description hash removescript optdepends ppa maintainer pacdeps patch PACPATCH NOBUILDDEP optinstall
 }
 
 function trap_ctrlc () {

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -30,6 +30,7 @@ function cleanup () {
 		sudo rm /tmp/pacstall-optdepends
 	fi
 	unset name version url build_depends depends breaks replace description hash removescript optdepends ppa maintainer pacdeps patch PACPATCH NOBUILDDEP optinstall
+	
 }
 
 function trap_ctrlc () {

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -29,6 +29,24 @@ function cleanup () {
 	if [ -f /tmp/pacstall-optdepends ]; then
 		sudo rm /tmp/pacstall-optdepends
 	fi
+	unset name
+	unset version
+	unset url
+	unset build_depends
+	unset depends
+	unset breaks
+	unset replace
+	unset description
+	unset hash
+	unset removescript
+	unset optdepends
+	unset ppa
+	unset maintainer
+	unset pacdeps
+	unset patch
+	unset PACPATCH
+	unset NOBUILDDEP
+	unset optinstall
 }
 
 function trap_ctrlc () {


### PR DESCRIPTION
# Purpose

When installing multiple programs at once, variables left over may affect later installs

# Approach

It unsets the affected variables in cleanup
