### PR TITLE
Various deb-control fixes

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -121,9 +121,9 @@ function makeVirtualDeb {
 	sudo mkdir -p "$SRCDIR/$name-pacstall/DEBIAN"
 	printf "Package: $name\n" | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 	if [[ $version =~ ^[0-9] ]]; then
-		printf "Version: $version\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
+		printf "Version: $version-1\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 	else
-		printf "Version: 0-$version\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
+		printf "Version: 0$version-1\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 	fi
 	if [[ -n $depends ]]; then
 		printf "Depends: ${depends//' '/' | '}\n"| sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -146,7 +146,7 @@ Section: Pacstall
 Priority: optional\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 	if [[ -n $replace ]]; then
 		echo -e "Conflicts: ${replace//' '/', '}
-		Replace: ${replace//' '/', '}\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
+Replace: ${replace//' '/', '}\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 	fi
 	printf "Provides: ${gives:-$name}
 Maintainer: ${maintainer:-Pacstall <pacstall@pm.me>}

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -146,7 +146,7 @@ Section: Pacstall
 Priority: optional\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 	if [[ -n $replace ]]; then
 		echo -e "Conflicts: ${replace//' '/', '}
-Replace: ${replace//' '/', '}\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
+Replace: ${replace//' '/', '}" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 	fi
 	printf "Provides: ${gives:-$name}
 Maintainer: ${maintainer:-Pacstall <pacstall@pm.me>}


### PR DESCRIPTION
# Purpose

- .deb versions need to have a numerical revision number after the `-`
- the `replace` field starts with a lot of spaces and ends with `\n`, messing up dpkg

# Approach

- replace the `0-` before files with `0` and add `-1` after
- remove the leading spaces and the ending `\n` 