### PR TITLE
Fix(scripts): `-L` not listing deb packages

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -412,9 +412,8 @@ while [[ ! "$1" == "--" ]]; do
 		;;
 
 		-L|--list)
-			if [[ -d "$STOWDIR" ]]; then
-				/bin/ls -1aA "$STOWDIR"
-			else
+			/bin/ls -1aA "$LOGDIR"
+			if [[ $? -ne 0 ]]; then
 				fancy_message error "Nothing installed yet"
 				exit 1
 			fi


### PR DESCRIPTION
# Purpose

`pacstall -L` does not list deb packages installed with pacstall