### PR TITLE
FIx(scripts): add metadata removal for `-deb`

### DIFF
--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -50,6 +50,8 @@ case "$url" in
 			error_log 1 "remove $PACKAGE"
 			return 1
 		fi
+		
+		sudo rm -f "$LOGDIR/$PACKAGE"
 		return 0
 	;;
 


### PR DESCRIPTION
# Purpose

Pacstall is not removing the metadata of deb packages when uninstalling
