### PR TITLE
dpkg ignore dependency "errors"

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -187,7 +187,7 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" >"/dev/null"
 	fi
 
 	sudo rm -rf "$SRCDIR/$name-pacstall"
-	sudo dpkg -i "$SRCDIR/$name-pacstall.deb" &> "/dev/null"
+	sudo dpkg -i "$SRCDIR/$name-pacstall.deb" 2 > "/dev/null"
 
 
 	fancy_message info "Installing dependencies"


### PR DESCRIPTION
# Purpose

&> was not able to ignore the "errors" so I suggest using 2> instead