### PR TITLE
feat: Download optimizations

### DIFF
--- a/misc/scripts/download.sh
+++ b/misc/scripts/download.sh
@@ -34,8 +34,15 @@ if curl --output /dev/null --silent --head --fail "$URL" ; then
 	if [[ "$type" = "install" ]]; then
 		mkdir -p "/tmp/pacstall/" && cd "/tmp/pacstall/"
 	fi
-
-	download "$URL" > /dev/null 2>&1
+	
+	case "$URL" in
+		*.pacscript)
+			wget -q --show-progress --progress=bar:force "$URL" > /dev/null 2>&1
+		;;
+		*)
+			download "$URL" > /dev/null 2>&1
+		;;
+	esac
 	return 0
 else
 	error_log 1 "get $PACKAGE pacscript"

--- a/misc/scripts/download.sh
+++ b/misc/scripts/download.sh
@@ -24,7 +24,7 @@
 
 # This script downloads pacscripts from the interwebs
 
-if ! wget -q --tries=10 --timeout=20 --spider https://github.com; then
+if ! (command -v nm-online -qx > /dev/null || ping -c 1 github.com > /dev/null); then
 	fancy_message error "Not connected to internet"
 	error_log 1 "get $PACKAGE pacscript"
 	exit 2

--- a/pacstall
+++ b/pacstall
@@ -186,7 +186,7 @@ function fancy_message() {
 function download() {
 	sudo rm -f "${1##*/}"
 	if command -v axel > /dev/null; then
-		axel -n $(($(nproc) + 5)) -ao "${1##*/}" "$1"
+		axel -ao "${1##*/}" "$1"
 	else
 		wget -q --show-progress --progress=bar:force "$1" 2>&1
 	fi


### PR DESCRIPTION
# Purpose

Some portions of the code base concerned with downloading stuff from the internet can be optimized for greater speed.

# Approach

Replace current code with speed efficient code.

# Progress

- [x] Remove manual core assignment for `axel`
- [x] Use `nm-online` instead of `wget` in `download.sh` to check internet connectivity (40 times faster on average!!!)
- [x] Download pacscripts only using `wget` as it's faster than `axel` for small files.
