### PR TITLE
rem(readme): Unnecessary `sudo`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,32 +31,32 @@ sudo bash -c "$(curl -fsSL https://git.io/JsADh || wget -q https://git.io/JsADh 
 
 ### Basic Commands
 ```bash
-sudo pacstall -I foo
+pacstall -I foo
 ``` 
 This will install foo. Equivalent of apt install
 
 ```bash
-sudo pacstall -R foo
+pacstall -R foo
 ```
 This will remove foo. Equivalent of apt remove
 
 ```bash
-sudo pacstall -S foo
+pacstall -S foo
 ```
 This will search for foo in repositories. Equivalent of apt search
 
 ```bash
-sudo pacstall -A
+pacstall -A
 ```
 Run this command with a github/gitlab url to add a repo
 
 ```bash
-sudo pacstall -U
+pacstall -U
 ```
 This will update pacstall's scripts
 
 ```bash
-sudo pacstall -Up
+pacstall -Up
 ```
 
 This will update packages. Equivalent of apt upgrade


### PR DESCRIPTION
# Purpose

The current README file states commands with `sudo`s, which is wrong since v1.5

# Approach

Update the README
