### PR TITLE
feat(api): Add config module

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,28 @@
+#!/bin/env python3
+
+#     ____                  __        ____
+#    / __ \____ ___________/ /_____ _/ / /
+#   / /_/ / __ `/ ___/ ___/ __/ __ `/ / /
+#  / ____/ /_/ / /__(__  ) /_/ /_/ / / /
+# /_/    \__,_/\___/____/\__/\__,_/_/_/
+#
+# Copyright (C) 2020-2021
+#
+# This file is part of Pacstall
+#
+# Pacstall is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3 of the License
+#
+# Pacstall is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
+
+LOGDIR = "/var/log/pacstall"  # Logging directory
+SRCDIR = "/tmp/pacstall"  # Building directory
+STGDIR = "/usr/share/pacstall"  # Scripts storage directory
+STOWDIR = "/usr/src/pacstall"  # Stowing directory


### PR DESCRIPTION
# Purpose

Writing the config directories, and possibly other stuff in the future in the main pacstall file would entail that every other file trying to access those values would have to import a *possibly* giant file. Which is not good for performance, and logistics.

# Approach

Write the configuration stuff in `api/config.py` module, so in future we can import this shorter file.
