### PR TITLE
Fix: editing pacscript during install

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -208,13 +208,13 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" >"/dev/null"
 ask "Do you want to view/edit the pacscript" N
 if [[ $answer -eq 1 ]]; then
 	if [[ -n $PACSTALL_EDITOR ]]; then
-		$PACSTALL_EDITOR "$PACKAGE".pacscript
+		sudo $PACSTALL_EDITOR "$PACKAGE".pacscript
 	elif [[ -n $EDITOR ]]; then
-		$EDITOR "$PACKAGE".pacscript
+		sudo $EDITOR "$PACKAGE".pacscript
 	elif [[ -n $VISUAL ]]; then
-		$VISUAL "$PACKAGE".pacscript
+		sudo $VISUAL "$PACKAGE".pacscript
 	else
-		sensible-editor "$PACKAGE".pacscript
+		sudo sensible-editor "$PACKAGE".pacscript
 	fi
 fi
 


### PR DESCRIPTION
# Purpose

During install of a package, your editor of choice will fail with a permissions error during editing