### PR TITLE
fix(upgrade): `ver_compare` issue

### DIFF
--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -24,7 +24,7 @@
 
 function ver_compare() {
 	local first="$(echo ${1} | sed 's/^[^0-9]*//')"
-	local second="$(echo ${1} | sed 's/^[^0-9]*//')"
+	local second="$(echo ${2} | sed 's/^[^0-9]*//')"
 	return $(dpkg --compare-versions $first "lt" $second)
 }
 


### PR DESCRIPTION
# Purpose

We found a bug in `ver_compare` function.
Link: https://discord.com/channels/839818021207801878/883613281514840105/883618948225060905

# Approach

Changes `second`'s operating parameter to `${2}`

# Addendum

Bug introduced in: https://github.com/pacstall/pacstall/commit/b98013c769c4b06f0cda244b7f7b046e45feb2a7
