### PR TITLE
rem(scripts): Remove redundant confirmations

### DIFF
--- a/misc/scripts/update.sh
+++ b/misc/scripts/update.sh
@@ -25,13 +25,6 @@
 # Update should be self-contained and should use mutable functions or variables
 # Color variables are ok, while "$USERNAME" and "$BRANCH" are needed
 
-echo -ne "Are you sure you want to update pacstall? [${GREEN}y${NC}/${BIRed}N${NC}] "
-read -r reply < /dev/tty
-
-if [[ -z $reply ]] || [[ $reply == "N"* ]] || [[ $reply == "n"* ]]; then
-	exit 1
-fi
-
 sudo mkdir -p "/var/log/pacstall/metadata"
 sudo mkdir -p "/var/log/pacstall/error_log"
 find /var/log/pacstall/* -maxdepth 1 | grep -v metadata | grep -v error_log | xargs -I{} sudo mv {} /var/log/pacstall/metadata

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -132,10 +132,6 @@ else
 	${BOLD}$(cat /tmp/pacstall-up-print)${NORMAL}"
 	echo ""
 
-	ask "Do you want to continue?" N
-	if [[ $answer -eq 0 ]]; then
-		exit 1;
-	fi
 	upgrade=()
 	while IFS= read -r line; do
 		upgrade+=("$line")


### PR DESCRIPTION
# Purpose

There are two redundant confirmation requests in `update`, `upgrade`.`sh`es.

# Approach

This PR removes them

# Progress

- [x] Remove `update.sh` confirmation request
- [x] Remove `upgrade.sh` confirmation request
