### PR TITLE
dpkg gives error when lt is quoted

### DIFF
--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -25,7 +25,7 @@
 function ver_compare() {
 	local first="$(echo ${1} | sed 's/^[^0-9]*//')"
 	local second="$(echo ${2} | sed 's/^[^0-9]*//')"
-	return $(dpkg --compare-versions $first "lt" $second)
+	return $(dpkg --compare-versions "$first" lt "$second")
 }
 
 export UPGRADE="yes"


### PR DESCRIPTION
## before
```bash
henry@twilight ~ % ››› pacstall -Up
[+] INFO: Checking for updates
dpkg: error: --compare-versions takes three arguments: <version> <relation> <version>

Type dpkg --help for help about installing and deinstalling packages [*];
Use 'apt' or 'aptitude' for user-friendly package management;
Type dpkg -Dhelp for a list of dpkg debug flag values;
Type dpkg --force-help for a list of forcing options;
Type dpkg-deb --help for help about manipulating *.deb files;

Options marked [*] produce a lot of output - pipe it through 'less' or 'more' !
[+] INFO: Nothing to upgrade
```

## after
```bash
henry@twilight ~ % ››› pacstall -Up
[+] INFO: Checking for updates
[+] INFO: Nothing to upgrade
```