### PR TITLE
fix(install-local): `dpkg-query` false positives

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -279,7 +279,7 @@ fi
 
 if echo -n "$depends" > /dev/null 2>&1; then
 	if [[ -n "$breaks" ]]; then
-		if dpkg-query -l "$breaks" > /dev/null 2>&1; then
+		if dpkg-query -W -f='${Status}' "${breaks}" | grep "^install ok installed" > /dev/null 2>&1; then
 			# Check if anything in breaks variable is installed already
 			fancy_message error "${RED}$name${NC} breaks $breaks, which is currently installed by apt"
 			error_log 13 "install $PACKAGE"


### PR DESCRIPTION
## Purpose

`dpkg-query -l "${breaks}"` also returns positive if status is `unknown ok not-installed`, or/and similar statuses

## Approach

Change  the `dpkg-query` command to fix the false positives