### PR TITLE
feat(scripts): Ability to specify target repo when installing

### DIFF
--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -54,7 +54,8 @@ if [[ $PACKAGE == *@* ]]; then
 		if [[ $URLNAME == $REPONAME ]]; then
 			PACKAGELIST=($(curl -s "$URL"/packagelist))
 			IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | grep -n "^${PACKAGE}$")
-			LEN=${#IDXSEARCH[@]}
+			LEN=($IDXSEARCH)
+			LEN=${#LEN[@]}
 			if [[ "$LEN" -eq 0 ]]; then
 				fancy_message warn "There is no package with the name $IRed${PACKAGE%%@*}$CYAN @ $REPONAME$NC"
 				error_log 3 "search $PACKAGE@$REPONAME"

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -31,6 +31,36 @@ if [[ -n "$UPGRADE" ]]; then
 	PACKAGE=$i
 fi
 
+function specifyRepo() {
+	SPLIT=($(echo "$REPO" | tr "/" "\n"))
+
+	if command echo "$REPO" |grep "github" &> /dev/null; then
+		echo "${SPLIT[-3]}/${SPLIT[-2]}"
+	elif command echo "$REPO" |grep "gitlab" &> /dev/null; then
+		echo "${SPLIT[-4]}/${SPLIT[-3]}"
+	else
+		echo "$REPO"
+	fi
+
+}
+
+
+if [[ $PACKAGE == *@* ]]; then
+	REPONAME=${PACKAGE#*@}
+	
+	while IFS= read -r URL; do
+		if [[ $(specifyRepo "$REPONAME") == $REPONAME ]]; then
+			export PACKAGE=${PACKAGE%%@*}
+			export REPO=$URL
+			return 0
+		fi
+	done < "$STGDIR/repo/pacstallrepo.txt"
+	
+	fancy_message warn "There is no package with the name $IRed${PACKAGE%%@*}$CYAN @ $REPONAME $NC"
+	error_log 3 "search $PACKAGE"
+	return 1	
+fi
+
 # Makes array of packages and array
 # of their respective URL's
 PACKAGELIST=()

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -57,7 +57,7 @@ if [[ $PACKAGE == *@* ]]; then
 			LEN=($IDXSEARCH)
 			LEN=${#LEN[@]}
 			if [[ "$LEN" -eq 0 ]]; then
-				fancy_message warn "There is no package with the name $IRed${PACKAGE%%@*}$CYAN @ $REPONAME$NC"
+				fancy_message warn "There is no package with the name $IRed${PACKAGE%%@*}$NC in the repo $CYAN$REPONAME$NC"
 				error_log 3 "search $PACKAGE@$REPONAME"
 				return 1	
 			fi
@@ -67,7 +67,7 @@ if [[ $PACKAGE == *@* ]]; then
 		fi
 	done < "$STGDIR/repo/pacstallrepo.txt"
 	
-	fancy_message warn "There is no repo with the name $RED$REPONAME$NC"
+	fancy_message warn "$IRed$REPONAME$NC is not on your repo list or does not exist"
 	error_log 3 "search $PACKAGE@$REPONAME"
 	return 1	
 fi

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -49,7 +49,7 @@ if [[ $PACKAGE == *@* ]]; then
 	REPONAME=${PACKAGE#*@}
 	
 	while IFS= read -r URL; do
-		if [[ $(specifyRepo "$REPONAME") == $REPONAME ]]; then
+		if [[ $(specifyRepo "$URL") == $REPONAME ]]; then
 			export PACKAGE=${PACKAGE%%@*}
 			export REPO=$URL
 			return 0

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -32,14 +32,14 @@ if [[ -n "$UPGRADE" ]]; then
 fi
 
 function specifyRepo() {
-	SPLIT=($(echo "$REPO" | tr "/" "\n"))
+	SPLIT=($(echo "$1" | tr "/" "\n"))
 
-	if command echo "$REPO" |grep "github" &> /dev/null; then
-		echo "${SPLIT[-3]}/${SPLIT[-2]}"
-	elif command echo "$REPO" |grep "gitlab" &> /dev/null; then
-		echo "${SPLIT[-4]}/${SPLIT[-3]}"
+	if [[ "$1" == *"github"* ]]; then
+		export URLNAME="${SPLIT[-3]}/${SPLIT[-2]}"
+	elif [[ "$1" == *"gitlab"* ]]; then
+		export URLNAME="${SPLIT[-4]}/${SPLIT[-3]}"
 	else
-		echo "$REPO"
+		export URLNAME="$REPO"
 	fi
 
 }
@@ -49,7 +49,8 @@ if [[ $PACKAGE == *@* ]]; then
 	REPONAME=${PACKAGE#*@}
 	
 	while IFS= read -r URL; do
-		if [[ $(specifyRepo "$URL") == $REPONAME ]]; then
+		specifyRepo "$URL"
+		if [[ $URLNAME == $REPONAME ]]; then
 			export PACKAGE=${PACKAGE%%@*}
 			export REPO=$URL
 			return 0

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -67,7 +67,7 @@ if [[ $PACKAGE == *@* ]]; then
 		fi
 	done < "$STGDIR/repo/pacstallrepo.txt"
 	
-	fancy_message warn "There is no repo with the name $CYAN$REPONAME$NC"
+	fancy_message warn "There is no repo with the name $RED$REPONAME$NC"
 	error_log 3 "search $PACKAGE@$REPONAME"
 	return 1	
 fi


### PR DESCRIPTION
## Purpose

Specify from which repo to install for use in scripting

## Approach

Add the possibility to specify from which repo to install before searching then with `pacstall -I package@user/reponame` for github and gitlab repos or `pacstall -I package@repourl` for other git-like repos.

## Addendum

Fixes #126 
