### PR TITLE
ref(search): Rework

### DIFF
--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -102,9 +102,9 @@ function parseRepo() {
 	SPLIT=($(echo "$REPO" | tr "/" "\n"))
 
 	if command echo "$REPO" |grep "github" &> /dev/null; then
-		echo -e "\e]8;;https://github.com/${SPLIT[-3]}/${SPLIT[-2]}\a${SPLIT[-3]}\e]8;;\a"
+		echo -e "\e]8;;https://github.com/${SPLIT[-3]}/${SPLIT[-2]}\a${SPLIT[-3]}/${SPLIT[-2]}\e]8;;\a"
 	elif command echo "$REPO" |grep "gitlab" &> /dev/null; then
-		echo -e "\e]8;;https://gitlab.com/${SPLIT[-4]}/${SPLIT[-3]}\a${SPLIT[-4]}\e]8;;\a"
+		echo -e "\e]8;;https://gitlab.com/${SPLIT[-4]}/${SPLIT[-3]}\a${SPLIT[-4]}/${SPLIT[-3]}\e]8;;\a"
 	else
 		echo "\e]8;;$REPO\a$REPO\e]8;;\a"
 	fi
@@ -146,43 +146,37 @@ else
 		# If there are multiple results, ask
 	else
 		echo -e "There are $LEN package(s) with the name $GREEN$PACKAGE$NC."
-
-		ask "Do you want to continue?" Y
-		if [[ $answer -eq 1 ]]; then
-			# Pacstall repo first
-			for IDX in $IDXSEARCH ; do
-				if [[ "${URLLIST[$IDX]}" == 'https://raw.githubusercontent.com/pacstall/pacstall-programs/master' ]]; then
-					PACSTALLREPO=$IDX
-					break
-				fi
-			done
-			if [[ -n "$PACSTALLREPO" ]]; then
-				# Overwrite last question
-				ask "\e[1A\e[KDo you want to $type $GREEN${PACKAGELIST[$IDX]}$NC from the repo $CYAN$(parseRepo "${URLLIST[$IDX]}")$NC?" Y
-				if [[ $answer -eq 1 ]];then
-					export PACKAGE=${PACKAGELIST[$PACSTALLREPO]}
-					export REPO=${URLLIST[$PACSTALLREPO]}
-					unset PACSTALLREPO
-					return 0
-				fi
-			# If other repos, ask, if Pacstall repo, skip
-			else
-				for IDX in $IDXSEARCH ; do
-					if [[ "$IDX" == "$PACSTALLREPO" ]]; then
-						continue
-					fi
-					# Overwrite last question
-					ask "\e[1A\e[KDo you want to $type $GREEN${PACKAGELIST[$IDX]}$NC from the repo $CYAN$(parseRepo "${URLLIST[$IDX]}")$NC?" Y
-					if [[ $answer -eq 1 ]];then
-						export PACKAGE=${PACKAGELIST[$IDX]}
-						export REPO=${URLLIST[$IDX]}
-						return 0
-					fi
-				done
+		echo
+		# Pacstall repo first
+		for IDX in $IDXSEARCH ; do
+			if [[ "${URLLIST[$IDX]}" == 'https://raw.githubusercontent.com/pacstall/pacstall-programs/master' ]]; then
+				PACSTALLREPO=$IDX
+				break
 			fi
-		else
-			return 1 # No
+		done
+		if [[ -n "$PACSTALLREPO" ]]; then
+			# Overwrite last question
+			ask "\e[1A\e[KDo you want to $type $GREEN${PACKAGELIST[$IDX]}$NC from the official repo?" Y
+			if [[ $answer -eq 1 ]];then
+				export PACKAGE=${PACKAGELIST[$PACSTALLREPO]}
+				export REPO=${URLLIST[$PACSTALLREPO]}
+				unset PACSTALLREPO
+				return 0
+			fi
 		fi
+		# If other repos, ask, if Pacstall repo, skip
+		for IDX in $IDXSEARCH ; do
+			if [[ "$IDX" == "$PACSTALLREPO" ]]; then
+				continue
+			fi
+			# Overwrite last question
+			ask "\e[1A\e[KDo you want to $type $GREEN${PACKAGELIST[$IDX]}$NC from the repo $CYAN$(parseRepo "${URLLIST[$IDX]}")$NC?" Y
+			if [[ $answer -eq 1 ]];then
+				export PACKAGE=${PACKAGELIST[$IDX]}
+				export REPO=${URLLIST[$IDX]}
+				return 0
+			fi
+		done
 	fi
 fi
 

--- a/pacstall
+++ b/pacstall
@@ -291,7 +291,6 @@ while [[ ! "$1" == "--" ]]; do
 				fi
 
 				specifyRepo $REPO
-				fancy_message info "Downloading $GREEN${PACKAGE}.pacscript$NC from $CYAN$URLNAME$NC"
 				URL="$REPO/packages/$PACKAGE/$PACKAGE.pacscript"
 				source "$STGDIR/scripts/download.sh"
 

--- a/pacstall
+++ b/pacstall
@@ -470,7 +470,6 @@ while [[ ! "$1" == "--" ]]; do
 				fi
 
 				specifyRepo $REPO
-				fancy_message info "Downloading $GREEN${PACKAGE}.pacscript$NC from $CYAN$URLNAME$NC"
 				export URL="$REPO/packages/$PACKAGE/$PACKAGE.pacscript"
 				source "$STGDIR/scripts/download.sh"
 

--- a/pacstall
+++ b/pacstall
@@ -290,6 +290,8 @@ while [[ ! "$1" == "--" ]]; do
 					continue
 				fi
 
+				specifyRepo $REPO
+				fancy_message info "Downloading $GREEN${PACKAGE}.pacscript$NC from $CYAN$URLNAME$NC"
 				URL="$REPO/packages/$PACKAGE/$PACKAGE.pacscript"
 				source "$STGDIR/scripts/download.sh"
 
@@ -467,6 +469,8 @@ while [[ ! "$1" == "--" ]]; do
 					continue
 				fi
 
+				specifyRepo $REPO
+				fancy_message info "Downloading $GREEN${PACKAGE}.pacscript$NC from $CYAN$URLNAME$NC"
 				export URL="$REPO/packages/$PACKAGE/$PACKAGE.pacscript"
 				source "$STGDIR/scripts/download.sh"
 


### PR DESCRIPTION
## Purpose

Add, fix and rework the messages for searching and downloading pacscripts

## Approach

Add downloading message on the main script and replace `repo pacstall` with `official repo`. Fix the `if` statement in search related to this. Change the repo names from `user` to `user/repo` when searching.

