### PR TITLE
fix(scripts): fix clutter on download

### DIFF
--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -142,7 +142,7 @@ else
 	done < /tmp/pacstall-up-urls
 
 	export local='no'
-	cd $SRCDIR
+	cd "$SRCDIR"
 	for i in "${!upgrade[@]}"; do
 		PACKAGE=${upgrade[$i]}
 		ask "Do you want to upgrade ${GREEN}${PACKAGE}${NC}?" Y

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -142,6 +142,7 @@ else
 	done < /tmp/pacstall-up-urls
 
 	export local='no'
+	cd $SRCDIR
 	for i in "${!upgrade[@]}"; do
 		PACKAGE=${upgrade[$i]}
 		ask "Do you want to upgrade ${GREEN}${PACKAGE}${NC}?" Y


### PR DESCRIPTION
## Purpose

During upgrade, pacstall will dump pacscripts in the current dir, and when upgrading later on in the same directory, pacstall will attempt to install the pacscript, which would be the old one

## Approach

`cd` into `SRCDIR` on upgrade