### PR TITLE
bugfix/pacscript storage with pacdeps

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -23,8 +23,12 @@
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
 function cleanup () {
-	sudo rm -rf "${SRCDIR:?}"/*
-	sudo rm -rf /tmp/pacstall/*
+	if [ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]; then
+		sudo rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
+	else
+		sudo rm -rf "${SRCDIR:?}"/*
+		sudo rm -rf /tmp/pacstall/*
+	fi
 	if [ -f /tmp/pacstall-optdepends ]; then
 		sudo rm /tmp/pacstall-optdepends
 	fi


### PR DESCRIPTION
## Purpose

The pacscript was getting deleted before being stored when it contained pacdeps

## Approach

Fix the cleanup function so that it doesn't delete everything after installing a pacdep
