### PR TITLE
feat(api): Make `ask()` read from pipe

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -53,6 +53,11 @@ function fancy_message() {
 	esac
 }
 
+if [[ ! -t 0 ]]; then
+	NON_INTERACTIVE=true
+	fancy_message warn "Reading input from pipe"
+fi
+
 function ask() {
 	local prompt default reply
 
@@ -73,7 +78,7 @@ function ask() {
 		read -r reply <&0
 		# Detect if script is running non-interactively
 		# Which implies that the input is being piped into the script
-		if [[ ! -t 0 ]]; then
+		if [[ $NON_INTERACTIVE ]]; then
 			if [[ -z "$reply" ]]; then
 				printf "%s" "$default"
 			fi

--- a/install.sh
+++ b/install.sh
@@ -69,9 +69,16 @@ function ask() {
 	# Ask the question (not using "read -p" as it uses stderr not stdout)
 	echo -ne "$1 [$prompt] "
 
-	# Read the answer (use /dev/tty in case stdin is redirected from somewhere else)
 	if [[ -z "$DISABLE_PROMPTS" ]]; then
-		read -r reply < /dev/tty
+		read -r reply <&0
+		# Detect if script is running non-interactively
+		# Which implies that the input is being piped into the script
+		if [[ ! -t 0 ]]; then
+			if [[ -z "$reply" ]]; then
+				printf "%s" "$default"
+			fi
+			echo "$reply"
+		fi
 	else
 		echo "$default"
 		reply=$default
@@ -86,12 +93,12 @@ function ask() {
 		# Check if the reply is valid
 		case "$reply" in
 			Y*|y*)
-				answer=1
+				export answer=1
 				return 0	#return code for backwards compatibility
 				break
 			;;
 			N*|n*)
-				answer=0
+				export answer=0
 				return 1	#return code
 				break
 			;;

--- a/pacstall
+++ b/pacstall
@@ -135,9 +135,16 @@ function ask() {
 	# Ask the question (not using "read -p" as it uses stderr not stdout)
 	echo -ne "$1 [$prompt] "
 
-	# Read the answer (use /dev/tty in case stdin is redirected from somewhere else)
 	if [[ -z "$DISABLE_PROMPTS" ]]; then
-		read -r reply < /dev/tty
+		read -r reply <&0
+		# Detect if script is running non-interactively
+		# Which implies that the input is being piped into the script
+		if [[ ! -t 0 ]]; then
+			if [[ -z "$reply" ]]; then
+				printf "%s" "$default"
+			fi
+			echo "$reply"
+		fi
 	else
 		echo "$default"
 		reply=$default

--- a/pacstall
+++ b/pacstall
@@ -109,6 +109,22 @@ export On_IPurple='\033[0;105m'  # Purple
 export On_ICyan='\033[0;106m'    # Cyan
 export On_IWhite='\033[0;107m'   # White
 
+# fancy_message allows visually appealing output.
+# Source the code block and run:
+#
+# `fancy_message {info,warn,error} "What you want to say"`
+function fancy_message() {
+	local MESSAGE_TYPE="${1}"
+	local MESSAGE="${2}"
+
+	case ${MESSAGE_TYPE} in
+		info) echo -e "[${BGreen}+${NC}] INFO: ${MESSAGE}";;
+		warn) echo -e "[${BYellow}*${NC}] WARNING: ${MESSAGE}";;
+		error) echo -e "[${BRed}!${NC}] ERROR: ${MESSAGE}";;
+		*) echo -e "[${BOLD}?${NORMAL}] UNKNOWN: ${MESSAGE}";;
+	esac
+}
+
 # This is the ask function. You can source this code block and then run something like:
 # ask "Do you like the color blue? " Y
 # if [[ $answer -eq 1 ]]; then
@@ -119,6 +135,11 @@ export On_IWhite='\033[0;107m'   # White
 #
 # Y=1 and N=0
 # You can specify {Y,N} or leave it out to prevent entering the default but this is not allowed in pacstall because of the -P flag which gives unattended installs
+if [[ ! -t 0 ]]; then
+	NON_INTERACTIVE=true
+	fancy_message warn "Reading input from pipe"
+fi
+
 function ask() {
 	local prompt default reply
 
@@ -139,7 +160,7 @@ function ask() {
 		read -r reply <&0
 		# Detect if script is running non-interactively
 		# Which implies that the input is being piped into the script
-		if [[ ! -t 0 ]]; then
+		if [[ $NON_INTERACTIVE ]]; then
 			if [[ -z "$reply" ]]; then
 				printf "%s" "$default"
 			fi
@@ -174,22 +195,6 @@ function ask() {
 			;;
 		esac
 	done
-}
-
-# fancy_message allows visually appealing output.
-# Source the code block and run:
-#
-# `fancy_message {info,warn,error} "What you want to say"`
-function fancy_message() {
-	local MESSAGE_TYPE="${1}"
-	local MESSAGE="${2}"
-
-	case ${MESSAGE_TYPE} in
-		info) echo -e "[${BGreen}+${NC}] INFO: ${MESSAGE}";;
-		warn) echo -e "[${BYellow}*${NC}] WARNING: ${MESSAGE}";;
-		error) echo -e "[${BRed}!${NC}] ERROR: ${MESSAGE}";;
-		*) echo -e "[${BOLD}?${NORMAL}] UNKNOWN: ${MESSAGE}";;
-	esac
 }
 
 # use axel if avaliable

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -54,6 +54,11 @@ function fancy_message() {
 	esac
 }
 
+if [[ ! -t 0 ]]; then
+	NON_INTERACTIVE=true
+	fancy_message warn "Reading input from pipe"
+fi
+
 function ask() {
 	local prompt default reply
 
@@ -74,7 +79,7 @@ function ask() {
 		read -r reply <&0
 		# Detect if script is running non-interactively
 		# Which implies that the input is being piped into the script
-		if [[ ! -t 0 ]]; then
+		if [[ $NON_INTERACTIVE ]]; then
 			if [[ -z "$reply" ]]; then
 				printf "%s" "$default"
 			fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -70,9 +70,16 @@ function ask() {
 	# Ask the question (not using "read -p" as it uses stderr not stdout)
 	echo -ne "$1 [$prompt] "
 
-	# Read the answer (use /dev/tty in case stdin is redirected from somewhere else)
 	if [[ -z "$DISABLE_PROMPTS" ]]; then
-		read -r reply < /dev/tty
+		read -r reply <&0
+		# Detect if script is running non-interactively
+		# Which implies that the input is being piped into the script
+		if [[ ! -t 0 ]]; then
+			if [[ -z "$reply" ]]; then
+				printf "%s" "$default"
+			fi
+			echo "$reply"
+		fi
 	else
 		echo "$default"
 		reply=$default
@@ -87,12 +94,12 @@ function ask() {
 		# Check if the reply is valid
 		case "$reply" in
 			Y*|y*)
-				answer=1
+				export answer=1
 				return 0	#return code for backwards compatibility
 				break
 			;;
 			N*|n*)
-				answer=0
+				export answer=0
 				return 1	#return code
 				break
 			;;


### PR DESCRIPTION
## Purpose

Currently our `ask()` is unable to read input which is piped into Pacstall. This greatly reduces scriptability. 

## Approach

Modify `ask()` to accept input from pipe, and also do some cosmetic/QOL changes ( such as printing the piped input on the prompt etc ) when doing the same.

## Progress

<!--Make a checklist of your progress-->

- [x] Modify `ask()` in `pacstall`
- [x] Modify `ask()` in `install.sh`
- [x] Modify `ask()` in `uninstall.sh`
