### PR TITLE
fix(scripts): `-Qi` size for `*-deb`s

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -108,7 +108,10 @@ function log() {
 	fi
 
 	# Metadata writing
-	echo "_version=\"$version"\" | sudo tee "$LOGDIR"/"$PACKAGE" > /dev/null
+	if [[ -n ${gives} ]]; then
+		echo "_gives=\"${gives}"\" | sudo tee "$LOGDIR"/"$PACKAGE" > /dev/null
+	fi
+	echo "_version=\"$version"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
 	echo "_description=\"$description"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
 	echo "_date=\"$(date)"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null
 	echo "_maintainer=\"$maintainer"\" | sudo tee -a "$LOGDIR"/"$PACKAGE" > /dev/null

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -27,19 +27,19 @@ if [[ -z "$PACKAGE" ]]; then
 	exit 1
 fi
 
-if [[ ! -f "$LOGDIR/$PACKAGE" ]] && ! apt-cache show "${PACKAGE/-deb/}" 2> /dev/null; then
+if [[ ! -f "$LOGDIR/$PACKAGE" ]]; then
 	fancy_message error "Package does not exist"
 	exit 1
 fi
 
+source "$LOGDIR/$PACKAGE"
+
 if [[ "$PACKAGE" == *-deb ]]; then
-	size="$(numfmt --to=iec $(apt-cache --no-all-versions show "${PACKAGE/-deb/}" | grep Installed-Size | cut -d' ' -f 2))"
+	size="$(numfmt --to=iec $(apt-cache --no-all-versions show "${_gives}" | grep Installed-Size | cut -d' ' -f 2))"
 else
 	size="$(du -sh "$STOWDIR"/"$PACKAGE" 2> /dev/null | awk '{print $1}')"
 fi
 
-
-source "$LOGDIR/$PACKAGE"
 echo -e "${BGreen}name${NORMAL}: $PACKAGE"
 echo -e "${BGreen}version${NORMAL}: $_version"
 echo -e "${BGreen}size${NORMAL}: $size"


### PR DESCRIPTION
## Purpose

<!--Describe the problem you are fixing or the feature you are adding.-->

`-Qi` is broken for `*-deb` packages that don't have a corresponding `${PACKAGE/-deb/} installed. Such as `heroic-games-launcher-deb`

## Approach

<!--How does this address the problem?-->

1. Log the `gives` ( `_gives` ) variable, as it provides accurate name of the installed `*-deb` package
2. Use that to find the size of the package
