### PR TITLE
rem(installer): `ripgrep` installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,13 +143,8 @@ ask "Do you want to install axel?" Y
 if [[ "$answer" -eq 1 ]]; then
     apt-get install -qq -y axel
 fi
-ask "Do you want to install ripgrep?" Y
-if [[ "$answer" -eq 1 ]]; then
-    apt-get install -qq -y ripgrep
-fi
 
 apt-get install -qq -y curl wget stow build-essential unzip tree bc git
-
 
 LOGDIR="/var/log/pacstall/metadata"
 STGDIR="/usr/share/pacstall"


### PR DESCRIPTION
## Purpose

Ripgrep is not used in the code base anymore, but its still present in the installer

## Approach

<!--How does this address the problem?-->

Removes ripgrep installation code block

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
