### PR TITLE
fix(installer): Add `iputils-ping` dependency

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,7 @@ if [[ "$answer" -eq 1 ]]; then
     apt-get install -qq -y ripgrep
 fi
 
-apt-get install -qq -y curl wget stow build-essential unzip tree bc git
+apt-get install -qq -y curl wget stow build-essential unzip tree bc git iputils-ping
 
 
 LOGDIR="/var/log/pacstall/metadata"


### PR DESCRIPTION
## Purpose

<!--Describe the problem you are fixing or the feature you are adding.-->
adding ping as a dependency in the install script as it does not comes installed in a docker container and due to this the script the thinks the machine is not connected to the internet so it helps a little while testing

## Approach

<!--How does this address the problem?-->
added iputils-ping to be installed 
## Progress

<!--Make a checklist of your progress-->

- [x] Add iputils-ping 


## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
