### PR TITLE
ref(contributing): Change PR title requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,17 +145,9 @@ The footer is optional and is used to reference issue tracker IDs.
 
 #### Pull Requests
 
-##### Title prefix of pull request
+##### Title of pull request
 
-Pull request titles should contain one of these prefixes:
-
-* `Feat`: Adding new features.
-* `Chan`: Change default behaviors or the existing features.
-* `Fix`: Fix some bugs.
-* `Ref`: Refactor code.
-* `Style`: Change formatting etc; no production code change.
-* `Remove`: Remove some existing code.
-* `Doc`: Update the help files.
+Pull request titles should be structured like the commit messages, but the `Subject` portion should be a single high-level description of all the changes in it.
 
 ##### Draft pull requests
 


### PR DESCRIPTION
## Purpose

The current contributing guidelines state that people should use a different structure to name the pull requests, this is quite annoying both for the contributor and the project maintainers (as we have to rename the commit message during merge, to comply with the commit message guidelines).

## Approach

<!--How does this address the problem?-->

State that the pull request title should be structured like the commit messages, but the `Subject` portion should be a high-level description of all the changed made in it.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
