### PR TITLE
fix(install-local): Change `SRCDIR` for pacdeps

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -25,7 +25,7 @@
 function cleanup () {
 	if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
 		sudo rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
-		sudo rm -rf /tmp/pacstall-pacdeps
+		sudo rm -rf /tmp/pacstall-pacdep
 	else
 		sudo rm -rf "${SRCDIR:?}"/*
 		sudo rm -rf /tmp/pacstall/*


### PR DESCRIPTION
## Purpose

Change the `SRCDIR` of pacdeps to avoid conflict with main installation

## Approach

Use the directory `/tmp/pacstall-pacdeps` instead of `/tmp/pacstall`

## Addendum

#295 

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
