### PR TITLE
fix(main): `--disable-prompts` placement in arg list

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -237,7 +237,7 @@ for i in "${@}"; do
 	# We remove the '-' prefix as we'll add it later.
 	for j in $(echo "${i}" | sed 's|^-||' | sed 's|[[:upper:]]| &|g'); do
 		# If current string is 'P', add to beginning of argument list.
-		if [[ "${j}" == "P" ]]; then
+		if [[ "${j}" == "P" ]] || [[ "${j}" == "-disable-prompts" ]]; then
 			argument_list=("-${j}" "${argument_list[@]}")
 		else
 			argument_list+=("-${j}")


### PR DESCRIPTION
## Purpose

Fix argument order for `--disable-prompts`

## Approach

Add check in argument split-and-sort routine

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
