### PR TITLE
Fix(installer): remove extra `"`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -83,7 +83,7 @@ fi
 
 fancy_message info "Installing packages"
 
-echo -ne ""Do you want to install axel (faster downloads)?" [${BIGreen}Y${NC}/${RED}n${NC}] "
+echo -ne "Do you want to install axel (faster downloads)? [${BIGreen}Y${NC}/${RED}n${NC}] "
 read -r reply <&0
 case "$reply" in
 	N*|n*) ;;


### PR DESCRIPTION
## Purpose

<!--Describe the problem you are fixing or the feature you are adding.-->
Installer had extra double quotes and Wizard didn't do a shellcheck

## Approach

<!--How does this address the problem?-->
Remove extra `"`

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
