### PR TITLE
ref(pacstall): Rename msg on updating APT list

### DIFF
--- a/src/pacstall.py
+++ b/src/pacstall.py
@@ -39,6 +39,6 @@ if not [
     for list in glob("/var/lib/apt/lists/*")
     if os.stat(list).st_mtime < time() - 604800
 ]:
-    message.fancy("info", "Last update was more than one week ago")
-    message.fancy("info", "Updating system")
+    message.fancy("info", "APT lists were updated more than a week ago")
+    message.fancy("info", "Updating APT lists")
     os.system("sudo apt-get -qq update")


### PR DESCRIPTION
## Purpose

<!--Describe the problem you are fixing or the feature you are adding.-->

The current message displayed on updating APT lists *incorrect* as it's not updating the system, instead only the APT lists.

## Approach

<!--How does this address the problem?-->

Refactor the message to reflect this.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
