### PR TITLE
fix(install): Don't split on `-` while checking `breaks`

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -327,7 +327,7 @@ if [[ -n "$breaks" ]]; then
 			cleanup
 			return 1
 		fi
-		if [[ "${pkg}" != "${name}" ]] && pacstall -L | grep "${pkg}" > /dev/null 2>&1; then
+		if [[ "${pkg}" != "${name}" ]] && pacstall -L | grep -E "(^| )${pkg}( |$)" > /dev/null 2>&1; then
 			# Same thing, but check if anything is installed with pacstall
 			fancy_message error "${RED}$name${NC} breaks $pkg, which is currently installed by pacstall"
 			error_log 13 "install $PACKAGE"


### PR DESCRIPTION
## Purpose

Fix `$breaks` check when re-installing or updating a package

## Approach

Replace check's regrex to not split on `-`, only on spaces

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
