### PR TITLE
fix: `-K` flag on pacdep fails (keep build dir)

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -26,25 +26,23 @@ function cleanup () {
 	if [[ -n $KEEP ]]; then
 		mkdir -p /"tmp/pacstall-keep/$name"
 		if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
-			sudo mv "/tmp/pacstall-pacdeps-$PACKAGE" "/tmp/pacstall-keep/$name/pacstall-pacdeps-$PACKAGE"
-			sudo mv "/tmp/pacstall-pacdep" "/tmp/pacstall-keep/$name/pacstall-pacdep"
+			sudo mv /tmp/pacstall-pacdep/* "/tmp/pacstall-keep/$name"
 		else
-			sudo mv "/tmp/pacstall" "/tmp/pacstall-keep/$name/pacstall"
+			sudo mv /tmp/pacstall/* "/tmp/pacstall-keep/$name"
 		fi
 		if [[ -f /tmp/pacstall-optdepends ]]; then
 			sudo mv "/tmp/pacstall-optdepends" "/tmp/pacstall-keep/$name/pacstall-optdepends"
 		fi
+	fi
+	if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
+		sudo rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
+		sudo rm -rf /tmp/pacstall-pacdep
 	else
-		if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
-			sudo rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
-			sudo rm -rf /tmp/pacstall-pacdep
-		else
-			sudo rm -rf "${SRCDIR:?}"/*
-			sudo rm -rf /tmp/pacstall/*
-		fi
-		if [[ -f /tmp/pacstall-optdepends ]]; then
-			sudo rm /tmp/pacstall-optdepends
-		fi
+		sudo rm -rf "${SRCDIR:?}"/*
+		sudo rm -rf /tmp/pacstall/*
+	fi
+	if [[ -f /tmp/pacstall-optdepends ]]; then
+		sudo rm /tmp/pacstall-optdepends
 	fi
 	unset name version url build_depends depends breaks replace description hash removescript optdepends ppa maintainer pacdeps patch PACPATCH NOBUILDDEP optinstall 2>/dev/null
 	unset -f pkgver 2>/dev/null
@@ -319,8 +317,9 @@ if [[ -n "$pacdeps" ]]; then
 		fancy_message info "Installing $i"
 		# If /tmp/pacstall-pacdeps-"$i" is available, it will trigger the logger to log it as a dependency
 		sudo touch /tmp/pacstall-pacdeps-"$i"
-
-		if ! pacstall -P -I "$i"; then
+		
+		[[ $KEEP ]] && k="-K"
+		if ! pacstall -P "$k" -I "$i"; then
 			fancy_message error "Failed to install pacstall dependencies"
 			error_log 8 "install $PACKAGE"
 			cleanup

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -312,8 +312,8 @@ if [[ -n "$pacdeps" ]]; then
 		# If /tmp/pacstall-pacdeps-"$i" is available, it will trigger the logger to log it as a dependency
 		sudo touch /tmp/pacstall-pacdeps-"$i"
 		
-		[[ $KEEP ]] && k="-K"
-		if ! pacstall -P "$k" -I "$i"; then
+		[[ $KEEP ]] && cmd="-KPI" || cmd="-PI"
+		if ! pacstall "$cmd" "$i"; then
 			fancy_message error "Failed to install pacstall dependencies"
 			error_log 8 "install $PACKAGE"
 			cleanup

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -30,9 +30,6 @@ function cleanup () {
 		else
 			sudo mv /tmp/pacstall/* "/tmp/pacstall-keep/$name"
 		fi
-		if [[ -f /tmp/pacstall-optdepends ]]; then
-			sudo mv "/tmp/pacstall-optdepends" "/tmp/pacstall-keep/$name/pacstall-optdepends"
-		fi
 	fi
 	if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
 		sudo rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
@@ -40,9 +37,6 @@ function cleanup () {
 	else
 		sudo rm -rf "${SRCDIR:?}"/*
 		sudo rm -rf /tmp/pacstall/*
-	fi
-	if [[ -f /tmp/pacstall-optdepends ]]; then
-		sudo rm /tmp/pacstall-optdepends
 	fi
 	unset name version url build_depends depends breaks replace description hash removescript optdepends ppa maintainer pacdeps patch PACPATCH NOBUILDDEP optinstall 2>/dev/null
 	unset -f pkgver 2>/dev/null

--- a/pacstall
+++ b/pacstall
@@ -260,11 +260,13 @@ function lock() {
 		return 1
 	elif [[ -f "/tmp/pacstall-pacdeps-$3" ]]; then
 		return 1
+	elif [[ -f "/tmp/pacstall-pacdeps-$4" ]]; then
+		return 1
 	fi
 	pidof -o %PPID -x $0 >/dev/null && return 0 || return 1
 }
 
-while lock $1 $2 $3; do
+while lock $1 $2 $3 $4; do
 	if [[ -z $first ]]; then
 		first=1
 		fancy_message warn "Pacstall is already running another instance"


### PR DESCRIPTION
## Purpose

Keep build dir files of pacdeps when installation fails

## Addendum

Closes #373

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
