### PR TITLE
fix(installer): missing directory permissions on installation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -134,4 +134,5 @@ wait
 
 chmod +x "/bin/pacstall"
 chmod +x $STGDIR/scripts/*
+sudo chown -R "$USER":"$USER" {/var/log/pacstall/,/tmp/pacstall/}
 # vim:set ft=sh ts=4 sw=4 noet:


### PR DESCRIPTION
## Purpose

During install, the directories `/tmp/pacstall` and `/var/log/pacstall` do not have the proper permissions, which means on a clean install of pacstall, it refuses to install anything

## Approach

Correct permissions during install of pacstall

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
