### PR TITLE
fix(main, scripts): replace fragile logname/$USER

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ bash -c "$(curl -fsSL https://git.io/JEZbi || wget -q https://git.io/JEZbi -O -)
 ### Basic Commands
 ```bash
 pacstall -I foo
-``` 
+```
 This will install foo. Equivalent of apt install
 
 ```bash

--- a/misc/completion/bash
+++ b/misc/completion/bash
@@ -26,11 +26,11 @@ packages="$(compgen -W "$(sed -e 's/$/\/packagelist/' /usr/share/pacstall/repo/p
 _pacstall() {
 	cur=${COMP_WORDS[COMP_CWORD]}
 	prev=${COMP_WORDS[COMP_CWORD-1]}
-	
+
 	if [[ "-P --disable-prompts" =~ (^|[[:space:]])"$prev"($|[[:space:]]) ]]; then
 		prev=${COMP_WORDS[COMP_CWORD-2]}
 	fi
-	
+
 	case "$prev" in
 		-'?'|--help|-v|--version)
 			return
@@ -65,7 +65,7 @@ _pacstall() {
 			COMPREPLY=($packages)
 			return
 		;;
-		
+
 		-?(P)K?(P)|--keep)
 			COMPREPLY=( $( compgen -W "-I -Il -Up -PI -PIl -PUp" -- "$cur" ) )
 			return
@@ -98,7 +98,7 @@ _pacstall() {
 			if [[ "-P" =~ (^|[[:space:]])${COMP_WORDS[COMP_CWORD-1]}($|[[:space:]]) ]] || [[ "--disable-prompts" =~ (^|[[:space:]])${COMP_WORDS[COMP_CWORD-1]}($|[[:space:]]) ]]; then
 				COMPREPLY=( $( compgen -W "-I -Il -R -Up" -- "$cur" ) )
 				return
-			fi			
+			fi
 			COMPREPLY=( $( compgen -W "-I -Il -S -R -A -U -V -L -Up -Qi -T" -- "$cur" ) )
 			return
 		;;

--- a/misc/completion/fish
+++ b/misc/completion/fish
@@ -22,11 +22,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 set packages (sed -e 's/$/\/packagelist/' /usr/share/pacstall/repo/pacstallrepo.txt | xargs -n 1 curl -s | awk '!seen[$0]++')
-alias _seen "__fish_seen_subcommand_from"
+alias _seen __fish_seen_subcommand_from
 
 # Flag lists
 set -l pacstall_cmds -I --install -Il --install-local -S --search --remove -A --add-repo -U --update -V --version -L --list -Up --upgradee -Qi --query-info -D --download -T --tree -P --disable-prompts -K --keep -PI -PIl -PR -PUp -PK -PKI -PKIl -PKUp -KI -KIl -KUp -KP -KPI -KPIl -KPUp -IP -IlP -RP -UpP -IK -IlK -UpK -IPK -IlPK -UpPK -IKP -IlKP -UpKP
-set -l pacstall_p -P --disable-prompts 
+set -l pacstall_p -P --disable-prompts
 set -l pacstall_p_cmds -I --install -Il --install-local -R --remove -Up --upgrade
 set -l pacstall_p_grouped -PI -PIl -PR -PUp -PK -PKI -PKIl -PKUp -KP -KPI -KPIl -KPUp -IP -IlP -RP -UpP -IPK -IlPK -UpPK -IKP -IlKP -UpKP
 set -l pacstall_k -K --keep
@@ -62,19 +62,19 @@ complete -f --command pacstall -n "not _seen $pacstall_cmds || _seen $pacstall_k
 complete -f --command pacstall -n "not _seen $pacstall_cmds || _seen $pacstall_k && not _seen $pacstall_p $pacstall_p_cmds $pacstall_p_grouped" -o PUp -d 'Upgrade packages'
 
 complete -f --command pacstall -n "_seen $pacstall_p && not _seen $pacstall_p_cmds" -o I -l install -d 'Install package'
-complete -f --command pacstall -n "_seen $pacstall_p && not _seen $pacstall_p_cmds" -o Il -l install-local  -d 'Install local package'
-complete -f --command pacstall -n "_seen $pacstall_p && not _seen $pacstall_p_cmds" -o Up  -l upgrade -d 'Upgrade packages'
+complete -f --command pacstall -n "_seen $pacstall_p && not _seen $pacstall_p_cmds" -o Il -l install-local -d 'Install local package'
+complete -f --command pacstall -n "_seen $pacstall_p && not _seen $pacstall_p_cmds" -o Up -l upgrade -d 'Upgrade packages'
 
 
-# Completions for K commands 
+# Completions for K commands
 
 complete -f --command pacstall -n "not _seen $pacstall_cmds || _seen $pacstall_p && not _seen $pacstall_k $pacstall_k_cmds $pacstall_k_grouped" -o KI -d 'Install package'
 complete -f --command pacstall -n "not _seen $pacstall_cmds || _seen $pacstall_p && not _seen $pacstall_k $pacstall_k_cmds $pacstall_k_grouped" -o KIl -d 'Install local package'
 complete -f --command pacstall -n "not _seen $pacstall_cmds || _seen $pacstall_p && not _seen $pacstall_k $pacstall_k_cmds $pacstall_k_grouped" -o KUp -d 'Upgrade packages'
 
 complete -f --command pacstall -n "_seen $pacstall_k && not _seen $pacstall_k_cmds" -o I -l install -d 'Install package'
-complete -f --command pacstall -n "_seen $pacstall_k && not _seen $pacstall_k_cmds" -o Il -l install-local  -d 'Install local package'
-complete -f --command pacstall -n "_seen $pacstall_k && not _seen $pacstall_k_cmds" -o Up  -l upgrade -d 'Upgrade packages'
+complete -f --command pacstall -n "_seen $pacstall_k && not _seen $pacstall_k_cmds" -o Il -l install-local -d 'Install local package'
+complete -f --command pacstall -n "_seen $pacstall_k && not _seen $pacstall_k_cmds" -o Up -l upgrade -d 'Upgrade packages'
 
 
 # Completions for PK commands
@@ -91,13 +91,13 @@ complete -f --command pacstall -n "not _seen $pacstall_cmds" -o KPIl -d 'Install
 complete -f --command pacstall -n "not _seen $pacstall_cmds" -o KPUp -d 'Upgrade packages'
 
 complete -f --command pacstall -n "_seen $pacstall_pk && not _seen $pacstall_k_cmds" -o I -l install -d 'Install package'
-complete -f --command pacstall -n "_seen $pacstall_pk && not _seen $pacstall_k_cmds" -o Il -l install-local  -d 'Install local package'
-complete -f --command pacstall -n "_seen $pacstall_pk && not _seen $pacstall_k_cmds" -o Up  -l upgrade -d 'Upgrade packages'
+complete -f --command pacstall -n "_seen $pacstall_pk && not _seen $pacstall_k_cmds" -o Il -l install-local -d 'Install local package'
+complete -f --command pacstall -n "_seen $pacstall_pk && not _seen $pacstall_k_cmds" -o Up -l upgrade -d 'Upgrade packages'
 
 # Command type lists
 set -l package_cmds -I -PI -IP --install -S --search -D --download -KI -IK -KPI -KIP -PKI -PIK -IKP -IPK
 set -l log_cmds -R -PR -RP --remove -L --list -Qi --query-info -T --tree
-set -l pacscript_cmds -Il --install-local  -PIl -IlP -KIl -IlK -PKIl -PIlK -KIlP -KPIl -IlKP -IlPK
+set -l pacscript_cmds -Il --install-local -PIl -IlP -KIl -IlK -PKIl -PIlK -KIlP -KPIl -IlKP -IlPK
 
 # Completion for the package related flags
 complete -f --command pacstall -n "_seen $package_cmds" -a "$packages"

--- a/misc/scripts/download.sh
+++ b/misc/scripts/download.sh
@@ -37,7 +37,7 @@ if curl --output /dev/null --silent --head --fail "$URL" ; then
 			error_log 1 "install $PACKAGE"; fancy_message error "Could not enter ${SRCDIR}"; exit 1
 		fi
 	fi
-	
+
 	case "$URL" in
 		*.pacscript)
 			wget -q --show-progress --progress=bar:force "$URL" > /dev/null 2>&1

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -268,13 +268,9 @@ if [[ $answer -eq 1 ]]; then
 	fi
 fi
 
-if [[ $(logname 2>/dev/null) ]]; then
-    LOGNAME=$(logname)
-fi
-
 fancy_message info "Sourcing pacscript"
 DIR=$(pwd)
-export homedir="/home/$LOGNAME"
+export homedir="/home/$user"
 if ! source "$PACKAGE".pacscript > /dev/null; then
 	fancy_message error "Could not source pacscript"
 	error_log 12 "install $PACKAGE"
@@ -311,7 +307,7 @@ if [[ -n "$pacdeps" ]]; then
 		fancy_message info "Installing $i"
 		# If /tmp/pacstall-pacdeps-"$i" is available, it will trigger the logger to log it as a dependency
 		sudo touch /tmp/pacstall-pacdeps-"$i"
-		
+
 		[[ $KEEP ]] && cmd="-KPI" || cmd="-PI"
 		if ! pacstall "$cmd" "$i"; then
 			fancy_message error "Failed to install pacstall dependencies"

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -46,7 +46,7 @@ case "$url" in
 			error_log 1 "remove $PACKAGE"
 			return 1
 		fi
-		
+
 		if fn_exists removescript; then
 			fancy_message info "Running post removal script"
 			removescript

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -57,17 +57,17 @@ if [[ $PACKAGE == *@* ]]; then
 			if [[ "$LEN" -eq 0 ]]; then
 				fancy_message warn "There is no package with the name $IRed${PACKAGE%%@*}$NC in the repo $CYAN$REPONAME$NC"
 				error_log 3 "search $PACKAGE@$REPONAME"
-				return 1	
+				return 1
 			fi
 			export PACKAGE
 			export REPO="$URL"
 			return 0
 		fi
 	done < "$STGDIR/repo/pacstallrepo.txt"
-	
+
 	fancy_message warn "$IRed$REPONAME$NC is not on your repo list or does not exist"
 	error_log 3 "search $PACKAGE@$REPONAME"
-	return 1	
+	return 1
 fi
 
 # Makes array of packages and array

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -139,7 +139,7 @@ ${BOLD}$(cat /tmp/pacstall-up-print)${NORMAL}\n"
 
 	export local='no'
 	sudo mkdir -p "$SRCDIR"
-	sudo chown -R "$USER":"$USER" "$SRCDIR"
+	sudo chown -R "$user":"$user" "$SRCDIR"
 	if ! cd "$SRCDIR" 2> /dev/null; then
 		error_log 1 "upgrade"; fancy_message error "Could not enter ${SRCDIR}"; exit 1
 	fi

--- a/pacstall
+++ b/pacstall
@@ -30,6 +30,7 @@ export LOGFILE
 export SRCDIR="/tmp/pacstall"
 export STGDIR="/usr/share/pacstall"
 export STOWDIR="/usr/src/pacstall"
+export user="$(logname 2> /dev/null)" || "${SUDO_USER:-${USER}}"
 
 # Colors
 BOLD=$(tput bold)
@@ -300,7 +301,7 @@ while [[ ! "$1" == "--" ]]; do
 		;;
 
 		-I|--install)
-			
+
 			function trap_ctrlc () {
 				fancy_message warn "The installation of $2 was interrupted, removing files"
 				rm -rf "${SRCDIR:?}"/* # :? makes bash error out in case SRCDIR is empty, saving us from yoinking /* directory by mistake

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -75,7 +75,7 @@ echo "	2. Remove Pacstall only (Keep installed packages)."
 while true; do
 	echo -ne "Type selection number [${BIRed}1${NC}/${BIGreen}2${NC}] "
 	read -r reply <&0
-	
+
 	if [[ "$reply" -eq 1 ]]; then
 		fancy_message info "Removing Pacstall and installed packages..."
 
@@ -108,9 +108,9 @@ while true; do
 		# Remove tmp files
 		fancy_message info "Removing temporary files"
 		sudo rm -rf /tmp/pacstall/
-		
+
 		break
-		
+
 	elif [[ "$reply" -eq 2 ]]; then
 		fancy_message info "Only uninstalling Pacstall..."
 		sudo rm "$(command -v pacstall)"
@@ -131,7 +131,7 @@ while true; do
 		# Remove tmp files
 		fancy_message info "Removing temporary files"
 		sudo rm -rf /tmp/pacstall/
-		
+
 		break
 	fi
 done


### PR DESCRIPTION
## Purpose

When logging into some systems, the `logname` command or `$USER` break sometimes

## Approach

Replace all instances of the previous commands with a single variable that tests for `logname` first (most reliable), then tries `$SUDO_USER`, then `$USER` finally.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.