### PR TITLE
fix: inconsistent user account detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -97,6 +97,8 @@ apt-get install -qq -y curl wget stow build-essential unzip tree bc git iputils-
 LOGDIR="/var/log/pacstall/metadata"
 STGDIR="/usr/share/pacstall"
 SRCDIR="/tmp/pacstall"
+PACSTALL_USER=$(logname 2> /dev/null || echo "${SUDO_USER:-${USER}}")
+
 
 fancy_message info "Making directories"
 mkdir -p "$STGDIR"
@@ -104,11 +106,11 @@ mkdir -p "$STGDIR/scripts"
 mkdir -p "$STGDIR/repo"
 
 mkdir -p "$SRCDIR"
-chown "$(logname)" -R "$SRCDIR"
+chown "$PACSTALL_USER" -R "$SRCDIR"
 
 mkdir -p "$LOGDIR"
 mkdir -p "/var/log/pacstall/error_log"
-chown "$(logname)" -R "/var/log/pacstall/error_log"
+chown "$PACSTALL_USER" -R "/var/log/pacstall/error_log"
 
 mkdir -p "/usr/share/man/man8"
 mkdir -p "/usr/share/bash-completion/completions"

--- a/misc/scripts/error_log.sh
+++ b/misc/scripts/error_log.sh
@@ -24,7 +24,7 @@
 
 if [[ ! -d "/var/log/pacstall/error_log" ]]; then
 	sudo mkdir -p "/var/log/pacstall/error_log"
-	sudo chown "$LOGNAME" -R /var/log/pacstall/error_log
+	sudo chown "$PACSTALL_USER" -R /var/log/pacstall/error_log
 fi
 
 function error_log() {

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -268,11 +268,9 @@ if [[ $answer -eq 1 ]]; then
 	fi
 fi
 
-LOGNAME="$user"
-
 fancy_message info "Sourcing pacscript"
 DIR=$(pwd)
-export homedir="/home/$LOGNAME"
+export homedir="/home/$PACSTALL_USER"
 if ! source "$PACKAGE".pacscript > /dev/null; then
 	fancy_message error "Could not source pacscript"
 	error_log 12 "install $PACKAGE"
@@ -420,7 +418,7 @@ else
 fi
 
 sudo mkdir -p "/tmp/pacstall"
-sudo chown "$LOGNAME" -R /tmp/pacstall
+sudo chown "$PACSTALL_USER" -R /tmp/pacstall
 
 case "$url" in
 	*.git)
@@ -495,7 +493,7 @@ case "$url" in
 esac
 
 export srcdir="$PWD"
-sudo chown -R "$LOGNAME":"$LOGNAME" . 2>/dev/null
+sudo chown -R "$PACSTALL_USER":"$PACSTALL_USER" . 2>/dev/null
 
 if [[ -n $patch ]]; then
 	fancy_message info "Downloading patches"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -268,9 +268,7 @@ if [[ $answer -eq 1 ]]; then
 	fi
 fi
 
-if [[ $(logname 2>/dev/null) ]]; then
-    LOGNAME=$(logname)
-fi
+LOGNAME="$user"
 
 fancy_message info "Sourcing pacscript"
 DIR=$(pwd)

--- a/misc/scripts/update.sh
+++ b/misc/scripts/update.sh
@@ -28,9 +28,9 @@
 sudo mkdir -p "/var/log/pacstall/metadata"
 sudo mkdir -p "/var/log/pacstall/error_log"
 find /var/log/pacstall/* -maxdepth 1 | grep -v metadata | grep -v error_log | xargs -I{} sudo mv {} /var/log/pacstall/metadata
-sudo chown "$LOGNAME" -R /var/log/pacstall/error_log
+sudo chown "$PACSTALL_USER" -R /var/log/pacstall/error_log
 sudo mkdir -p "/tmp/pacstall"
-sudo chown "$LOGNAME" -R /tmp/pacstall
+sudo chown "$PACSTALL_USER" -R /tmp/pacstall
 
 STGDIR="/usr/share/pacstall"
 

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -139,7 +139,7 @@ ${BOLD}$(cat /tmp/pacstall-up-print)${NORMAL}\n"
 
 	export local='no'
 	sudo mkdir -p "$SRCDIR"
-	sudo chown -R "$USER":"$USER" "$SRCDIR"
+	sudo chown -R "$user":"$user" "$SRCDIR"
 	if ! cd "$SRCDIR" 2> /dev/null; then
 		error_log 1 "upgrade"; fancy_message error "Could not enter ${SRCDIR}"; exit 1
 	fi

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -139,7 +139,7 @@ ${BOLD}$(cat /tmp/pacstall-up-print)${NORMAL}\n"
 
 	export local='no'
 	sudo mkdir -p "$SRCDIR"
-	sudo chown -R "$user":"$user" "$SRCDIR"
+	sudo chown -R "$PACSTALL_USER":"$PACSTALL_USER" "$SRCDIR"
 	if ! cd "$SRCDIR" 2> /dev/null; then
 		error_log 1 "upgrade"; fancy_message error "Could not enter ${SRCDIR}"; exit 1
 	fi

--- a/pacstall
+++ b/pacstall
@@ -31,7 +31,7 @@ export SRCDIR="/tmp/pacstall"
 export STGDIR="/usr/share/pacstall"
 export STOWDIR="/usr/src/pacstall"
 
-export user=$(logname 2> /dev/null || echo "${SUDO_USER:-${USER}}")
+export PACSTALL_USER=$(logname 2> /dev/null || echo "${SUDO_USER:-${USER}}")
 
 # Colors
 BOLD=$(tput bold)

--- a/pacstall
+++ b/pacstall
@@ -31,6 +31,8 @@ export SRCDIR="/tmp/pacstall"
 export STGDIR="/usr/share/pacstall"
 export STOWDIR="/usr/src/pacstall"
 
+export user=$(logname 2> /dev/null || echo "${SUDO_USER:-${USER}}")
+
 # Colors
 BOLD=$(tput bold)
 export BOLD


### PR DESCRIPTION
## Purpose

When logging into some systems with a display manager, the `logname` command or `$USER` break sometimes due to unset variables usually handled by the DM.

## Approach

Replace all instances of the previous commands with a single variable that tests for `logname` first (most reliable), then tries `$SUDO_USER`, then `$USER` finally.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.