### PR TITLE
fix(completions): bash completions not filtering packages

### DIFF
--- a/misc/completion/bash
+++ b/misc/completion/bash
@@ -21,11 +21,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-packages="$(compgen -W "$(sed -e 's/$/\/packagelist/' /usr/share/pacstall/repo/pacstallrepo.txt | xargs -n 1 curl -s | awk '!seen[$0]++')" -- "$cur")"
-
 _pacstall() {
 	cur=${COMP_WORDS[COMP_CWORD]}
 	prev=${COMP_WORDS[COMP_CWORD-1]}
+	
+	packages=$(compgen -W "$(sed -e 's/$/\/packagelist/' /usr/share/pacstall/repo/pacstallrepo.txt | xargs -n 1 curl -s | awk '!seen[$0]++')" -- "$cur")
 	
 	if [[ "-P --disable-prompts" =~ (^|[[:space:]])"$prev"($|[[:space:]]) ]]; then
 		prev=${COMP_WORDS[COMP_CWORD-2]}


### PR DESCRIPTION

## Purpose

Bash completions list all packages instead of filtering

## Approach

Fix variable placement and remove the extra `"`s that break the `compgen` command

## Addendum

Closes #410

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
