### PR TITLE
fix(pacstall): missing `-I` error message when no packages are specified

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -302,6 +302,11 @@ while [[ ! "$1" == "--" ]]; do
 		;;
 
 		-I|--install)
+
+			if [[ -z "$2" ]]; then
+				fancy_message error "You failed to specify a package"
+				exit 1
+			fi
 			
 			function trap_ctrlc () {
 				fancy_message warn "The installation of $2 was interrupted, removing files"


### PR DESCRIPTION
## Purpose

<!--Describe the problem you are fixing or the feature you are adding.-->

Fixes #412

## Approach

<!--How does this address the problem?-->

Adds the missing error message in `-I` flag when no packages are specified.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
