### PR TITLE
fix(pacstall): incorrect download message file path

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -520,7 +520,7 @@ while [[ ! "$1" == "--" ]]; do
 					continue
 				fi
 
-				fancy_message info "${GREEN}${PACKAGE}${NC}'s pacscript is downloaded in ${GREEN}$(pwd)/$PACKAGE${NC}"
+				fancy_message info "${GREEN}${PACKAGE}${NC}'s pacscript is downloaded in ${GREEN}$(pwd)/$PACKAGE.pacscript${NC}"
 			done
 
 			if [[ -s "LOGFILE" ]]; then

--- a/pacstall
+++ b/pacstall
@@ -520,7 +520,7 @@ while [[ ! "$1" == "--" ]]; do
 					continue
 				fi
 
-				fancy_message info "${GREEN}${PACKAGE}${NC}'s pacscript is downloaded in ${GREEN}$(pwd)/$PACKAGE.pacscript${NC}"
+				fancy_message info "${GREEN}${PACKAGE}${NC}'s pacscript is downloaded to ${GREEN}$(pwd)/$PACKAGE.pacscript${NC}"
 			done
 
 			if [[ -s "LOGFILE" ]]; then


### PR DESCRIPTION
## Purpose

<!--Describe the problem you are fixing or the feature you are adding.-->

Fixes #407

## Approach

<!--How does this address the problem?-->

Add missing `.pacscript` in the download message

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
