### PR TITLE
perf(completions): stop `curl`ing `packagelist` needlessly

### DIFF
--- a/misc/completion/bash
+++ b/misc/completion/bash
@@ -25,8 +25,6 @@ _pacstall() {
 	cur=${COMP_WORDS[COMP_CWORD]}
 	prev=${COMP_WORDS[COMP_CWORD-1]}
 	
-	packages=$(compgen -W "$(sed -e 's/$/\/packagelist/' /usr/share/pacstall/repo/pacstallrepo.txt | xargs -n 1 curl -s | awk '!seen[$0]++')" -- "$cur")
-	
 	if [[ "-P --disable-prompts" =~ (^|[[:space:]])"$prev"($|[[:space:]]) ]]; then
 		prev=${COMP_WORDS[COMP_CWORD-2]}
 	fi
@@ -37,12 +35,12 @@ _pacstall() {
 		;;
 
 		-?(P)S?(P)|--search)
-			COMPREPLY=($packages)
+			COMPREPLY=( $(compgen -W "$(sed -e 's/$/\/packagelist/' /usr/share/pacstall/repo/pacstallrepo.txt | xargs -n 1 curl -s | awk '!seen[$0]++')" -- "$cur") )
 			return
 		;;
 
 		-?(P)I?(P)|-?(K)I?(K)|-?(PK)I?(PK)|-?(KP)I?(KP)|--install)
-			COMPREPLY=($packages)
+			COMPREPLY=( $(compgen -W "$(sed -e 's/$/\/packagelist/' /usr/share/pacstall/repo/pacstallrepo.txt | xargs -n 1 curl -s | awk '!seen[$0]++')" -- "$cur") )
 			return
 		;;
 
@@ -62,7 +60,7 @@ _pacstall() {
 		;;
 
 		-?(P)D?(P)|--download)
-			COMPREPLY=($packages)
+			COMPREPLY=( $(compgen -W "$(sed -e 's/$/\/packagelist/' /usr/share/pacstall/repo/pacstallrepo.txt | xargs -n 1 curl -s | awk '!seen[$0]++')" -- "$cur") )
 			return
 		;;
 		

--- a/misc/completion/fish
+++ b/misc/completion/fish
@@ -21,7 +21,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
-set packages (sed -e 's/$/\/packagelist/' /usr/share/pacstall/repo/pacstallrepo.txt | xargs -n 1 curl -s | awk '!seen[$0]++')
 alias _seen "__fish_seen_subcommand_from"
 
 # Flag lists
@@ -100,7 +99,7 @@ set -l log_cmds -R -PR -RP --remove -L --list -Qi --query-info -T --tree
 set -l pacscript_cmds -Il --install-local  -PIl -IlP -KIl -IlK -PKIl -PIlK -KIlP -KPIl -IlKP -IlPK
 
 # Completion for the package related flags
-complete -f --command pacstall -n "_seen $package_cmds" -a "$packages"
+complete -f --command pacstall -n "_seen $package_cmds" -a "(sed -e 's/\$/\/packagelist/' /usr/share/pacstall/repo/pacstallrepo.txt | xargs -n 1 curl -s | awk '!seen[\$0]++')"
 
 # Completion for the log related flags
 complete -f --command pacstall -n "_seen $log_cmds" -a "(\ls -1aA /var/log/pacstall/metadata | tr ' ' '\n')"


### PR DESCRIPTION
## Purpose

<!--Describe the problem you are fixing or the feature you are adding.-->

Fixes #415

## Approach

<!--How does this address the problem?-->

Only `curl` `packagelist` when needed.

## Progress

<!--Make a checklist of your progress-->

- [x] Optimize `fish` completions
- [x] Optimize `bash` completions

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
