### PR TITLE
fix(bash): missing `-T` completions

### DIFF
--- a/misc/completion/bash
+++ b/misc/completion/bash
@@ -70,7 +70,11 @@ _pacstall() {
 			COMPREPLY=( $( compgen -W "-I -Il -Up -PI -PIl -PUp" -- "$cur" ) )
 			return
 		;;
-
+		
+		-T|--tree)
+			COMPREPLY=( $( compgen -W "$(\ls -1aAp /var/log/pacstall/metadata)" -- $cur ) )
+			return
+		;;
 	esac
 
 	case "$cur" in


### PR DESCRIPTION
## Purpose

Add missing case on bash completions

## Addendum

Closes #413

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
