### PR TITLE
fix(pacstall): installation failure when a directory of the same name is present

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -376,8 +376,8 @@ while [[ ! "$1" == "--" ]]; do
 				INPUT="$(basename "$2" ".pacscript")" # Removes the suffix
 				export local="yes"
 
-				# Enter directory if exists
-				if [[ -d "$INPUT" ]]; then
+				# Check if we need to cd into the directory first, and also check that $INPUT.pacscript does not exist
+				if [[ -d "$INPUT" ]] && [[ ! -f "$INPUT".pacscript ]]; then
 					cd "$(basename "$INPUT")" || exit
 				fi
 				# Check if the file exist


### PR DESCRIPTION
## Purpose
If a directory `$name` and `$name.pacscript` exist, and you attempt to run `pacstall -Il $name`, it would fail and report that `$name does not exist`

## Approach

Add an extra check to the directory checker to ensure Pacstall won't `cd` into the directory `$name` if `$name.pacscript` exists

## Addendum
Fixes #408

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
