### PR TITLE
fix(bash): completions not working when multiple flags are present

### DIFF
--- a/misc/completion/bash
+++ b/misc/completion/bash
@@ -23,11 +23,14 @@
 
 _pacstall() {
 	cur=${COMP_WORDS[COMP_CWORD]}
-	prev=${COMP_WORDS[COMP_CWORD-1]}
-	
-	if [[ "-P --disable-prompts" =~ (^|[[:space:]])"$prev"($|[[:space:]]) ]]; then
-		prev=${COMP_WORDS[COMP_CWORD-2]}
-	fi
+	prev=${COMP_WORDS[1]}
+
+        if [[ "-P --disable-prompts -K --keep" =~ (^|[[:space:]])"$prev"($|[[:space:]]) ]]; then
+                prev=${COMP_WORDS[2]}
+                if [[ "-P --disable-prompts -K --keep" =~ (^|[[:space:]])"$prev"($|[[:space:]]) ]]; then
+                        prev=${COMP_WORDS[3]}
+                fi
+        fi
 	
 	case "$prev" in
 		-'?'|--help|-v|--version)


### PR DESCRIPTION
## Purpose

Fix bash completions not working in some cases

## Approach

Fix flag selection

## Addendum

Fixes #420 

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
