### PR TITLE
fix(pacstall): outdated version printer for scripting

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -458,9 +458,8 @@ while [[ ! "$1" == "--" ]]; do
 				echo -e "1.7 \033[1m\x1b[38;2;160;82;45mSienna${NC}"
 				exit 0
 			else
-				# If pacstall -V was called with an argument, it's a package, so get the package version (usful for scripting)
 				if ! source "$LOGDIR/$PACKAGE"; then
-					fancy_message error "${GREEN}${PACKAGE}${NC} ins not installed"
+					fancy_message error "${GREEN}${PACKAGE}${NC} is not installed"
 					exit 1
 				else
 					echo "${_version}"

--- a/pacstall
+++ b/pacstall
@@ -459,11 +459,12 @@ while [[ ! "$1" == "--" ]]; do
 				exit 0
 			else
 				# If pacstall -V was called with an argument, it's a package, so get the package version (usful for scripting)
-				if pacstall -Qi "$PACKAGE" | grep 'version' | cut -d ":" -f2 | sed 's/ //g'; then
-					exit 0
-				else
+				if ! source "$LOGDIR/$PACKAGE"; then
 					fancy_message error "${GREEN}${PACKAGE}${NC} ins not installed"
 					exit 1
+				else
+					echo "${_version}"
+					exit
 				fi
 			fi
 		;;


### PR DESCRIPTION
## Purpose

The version printer `pacstall -V $package` is outdated and was never fixed for newer version of Pacstall leading to weird and breaking output when run.

## Approach

Rework the system

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
