### PR TITLE
feat: prevent dummy deb from upgrading

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -238,6 +238,12 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" >"/dev/null"
 	export PACSTALL_INSTALL=1
 	sudo rm -rf "$SRCDIR/$name-pacstall"
 	sudo --preserve-env=PACSTALL_INSTALL dpkg -i "$SRCDIR/$name-pacstall.deb" 2> "/dev/null"
+	if ! [[ -d /etc/apt/preferences.d/ ]]; then
+		sudo mkdir -p /etc/apt/preferences.d
+	fi
+	echo "Package: ${name}
+Pin: version ${version}-1
+Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" >/dev/null
 
 
 	fancy_message info "Installing dependencies"
@@ -251,6 +257,12 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" >"/dev/null"
 	fi
 	sudo --preserve-env=PACSTALL_INSTALL dpkg -i "$SRCDIR/$name-pacstall.deb" > "/dev/null"
 	sudo rm "$SRCDIR/$name-pacstall.deb"
+	if ! [[ -d /etc/apt/preferences.d/ ]]; then
+		sudo mkdir -p /etc/apt/preferences.d
+	fi
+	echo "Package: ${name}
+Pin: version ${version}-1
+Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" >/dev/null
 	unset PACSTALL_INSTALL
 	return 0
 }

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -96,6 +96,7 @@ case "$url" in
 			error_log 1 "remove $PACKAGE"
 			return 1
 		fi
+		sudo rm -f /etc/apt/preferences.d/"${name}-pin"
 
 		sudo rm -f "$LOGDIR/$PACKAGE"
 		fancy_message info "Package removed successfully"


### PR DESCRIPTION
## Purpose

Prevent dummy debs from being able to upgrade, like the case with `neovim`

## Approach

Set a priority of `-1` for `$name`, which prevents $name from being upgradable

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.