### PR TITLE
fix: prevent dummy deb from upgrading

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -258,9 +258,6 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
 	fi
 	sudo --preserve-env=PACSTALL_INSTALL dpkg -i "$SRCDIR/$name-pacstall.deb" > "/dev/null"
 	sudo rm "$SRCDIR/$name-pacstall.deb"
-	if ! [[ -d /etc/apt/preferences.d/ ]]; then
-		sudo mkdir -p /etc/apt/preferences.d
-	fi
 	echo "Package: ${name}
 Pin: version ${version}-1
 Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -31,7 +31,6 @@ function cleanup () {
 			sudo mv /tmp/pacstall/* "/tmp/pacstall-keep/$name"
 		fi
 	fi
-	sudo rm -f /etc/apt/preferences.d/"${name:-$PACKAGE}-pin"
 	if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
 		sudo rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
 		sudo rm -rf /tmp/pacstall-pacdep
@@ -49,6 +48,7 @@ function trap_ctrlc () {
 	if dpkg-query -W -f='${Status}' "$name" 2> /dev/null | grep -q -E "ok installed|ok unpacked" ; then
 		sudo dpkg -r --force-all "$name" > /dev/null
 	fi
+	sudo rm -f /etc/apt/preferences.d/"${name:-$PACKAGE}-pin"
 	cleanup
 	exit 1
 }

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -31,6 +31,7 @@ function cleanup () {
 			sudo mv /tmp/pacstall/* "/tmp/pacstall-keep/$name"
 		fi
 	fi
+	sudo rm -f /etc/apt/preferences.d/"${name:-$PACKAGE}-pin"
 	if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
 		sudo rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
 		sudo rm -rf /tmp/pacstall-pacdep

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -243,7 +243,7 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" >"/dev/null"
 		sudo mkdir -p /etc/apt/preferences.d
 	fi
 	echo "Package: ${name}
-Pin: version ${version}-1
+Pin: version *
 Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
 
 
@@ -259,7 +259,7 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
 	sudo --preserve-env=PACSTALL_INSTALL dpkg -i "$SRCDIR/$name-pacstall.deb" > "/dev/null"
 	sudo rm "$SRCDIR/$name-pacstall.deb"
 	echo "Package: ${name}
-Pin: version ${version}-1
+Pin: version *
 Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
 	unset PACSTALL_INSTALL
 	return 0

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -238,6 +238,12 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" >"/dev/null"
 	export PACSTALL_INSTALL=1
 	sudo rm -rf "$SRCDIR/$name-pacstall"
 	sudo --preserve-env=PACSTALL_INSTALL dpkg -i "$SRCDIR/$name-pacstall.deb" 2> "/dev/null"
+	if ! [[ -d /etc/apt/preferences.d/ ]]; then
+		sudo mkdir -p /etc/apt/preferences.d
+	fi
+	echo "Package: ${name}
+Pin: version ${version}-1
+Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" >/dev/null
 
 
 	fancy_message info "Installing dependencies"
@@ -251,6 +257,12 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" >"/dev/null"
 	fi
 	sudo --preserve-env=PACSTALL_INSTALL dpkg -i "$SRCDIR/$name-pacstall.deb" > "/dev/null"
 	sudo rm "$SRCDIR/$name-pacstall.deb"
+	if ! [[ -d /etc/apt/preferences.d/ ]]; then
+		sudo mkdir -p /etc/apt/preferences.d
+	fi
+	echo "Package: ${name}
+Pin: version ${version}-1
+Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" >/dev/null
 	unset PACSTALL_INSTALL
 	return 0
 }

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -243,7 +243,7 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" >"/dev/null"
 	fi
 	echo "Package: ${name}
 Pin: version ${version}-1
-Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" >/dev/null
+Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
 
 
 	fancy_message info "Installing dependencies"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -262,7 +262,7 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" >/dev/null
 	fi
 	echo "Package: ${name}
 Pin: version ${version}-1
-Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" >/dev/null
+Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
 	unset PACSTALL_INSTALL
 	return 0
 }

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -96,6 +96,7 @@ case "$url" in
 			error_log 1 "remove $PACKAGE"
 			return 1
 		fi
+		sudo rm -f /etc/apt/preferences.d/"${name}-pin"
 
 		sudo rm -f "$LOGDIR/$PACKAGE"
 		fancy_message info "Package removed successfully"


### PR DESCRIPTION
## Purpose

Prevents the local dummy deb from being upgraded because of the higher priority of a repo.

## Approach

Set the priority of `$name` to `-1`, which prevents all upgrades to that package.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.