### PR TITLE
fix: miscellaneous possible bugs due to possible dashes in inputs

### DIFF
--- a/misc/scripts/add-repo.sh
+++ b/misc/scripts/add-repo.sh
@@ -50,7 +50,7 @@ else
 fi
 
 
-if ! wget -q --spider "$REPO/packagelist"; then
+if ! wget -q --spider -- "$REPO/packagelist"; then
 	fancy_message warn "If the URL is a private repo, edit ${CYAN}\e]8;;file://$STGDIR/repo/pacstallrepo.txt\a$STGDIR/repo/pacstallrepo.txt\e]8;;\a${NC}"
 	fancy_message error "packagelist file not found"
 	exit 3

--- a/misc/scripts/download.sh
+++ b/misc/scripts/download.sh
@@ -30,7 +30,7 @@ if ! (command -v nm-online -qx > /dev/null || ping -c 1 github.com > /dev/null);
 	exit 2
 fi
 
-if curl --output /dev/null --silent --head --fail "$URL" ; then
+if curl --output /dev/null --silent --head --fail -- "$URL" ; then
 	if [[ "$type" = "install" ]]; then
 		mkdir -p "$SRCDIR"
 		if ! cd "$SRCDIR" ; then
@@ -40,10 +40,10 @@ if curl --output /dev/null --silent --head --fail "$URL" ; then
 	
 	case "$URL" in
 		*.pacscript)
-			wget -q --show-progress --progress=bar:force "$URL" > /dev/null 2>&1
+			wget -q --show-progress --progress=bar:force -- "$URL" > /dev/null 2>&1
 		;;
 		*)
-			download "$URL" > /dev/null 2>&1
+			download -- "$URL" > /dev/null 2>&1
 		;;
 	esac
 	return 0

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -50,7 +50,7 @@ if [[ $PACKAGE == *@* ]]; then
 	while IFS= read -r URL; do
 		specifyRepo "$URL"
 		if [[ "$URLNAME" == "$REPONAME" ]]; then
-			mapfile -t PACKAGELIST < <(curl -s "$URL"/packagelist)
+			mapfile -t PACKAGELIST < <(curl -s -- "$URL"/packagelist)
 			IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | grep -n -- "^${PACKAGE}$")
 			_LEN=($IDXSEARCH)
 			LEN=${#_LEN[@]}
@@ -75,7 +75,7 @@ fi
 PACKAGELIST=()
 URLLIST=()
 while IFS= read -r URL; do
-	mapfile -t PARTIALLIST < <(curl -s "$URL"/packagelist)
+	mapfile -t PARTIALLIST < <(curl -s -- "$URL"/packagelist)
 	URLLIST+=("${PARTIALLIST[@]/*/$URL}")
 	PACKAGELIST+=("${PARTIALLIST[@]}")
 done < "$STGDIR/repo/pacstallrepo.txt"

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -72,10 +72,10 @@ for i in "${list[@]}"; do
 
 	source "$STGDIR/scripts/search.sh"
 
-	IDXMATCH=$(printf "%s\n" "${REPOS[@]}"| grep -n "$remoterepo" | cut -d : -f1| awk '{print $0"-1"}'| bc)
+	IDXMATCH=$(printf "%s\n" "${REPOS[@]}"| grep -n -- "$remoterepo" | cut -d : -f1| awk '{print $0"-1"}'| bc)
 
 	if [[ -n $IDXMATCH ]]; then
-		remotever=$(source <(curl -s "$remoterepo"/packages/"$i"/"$i".pacscript) && type pkgver &>/dev/null && pkgver || echo "$version") >/dev/null
+		remotever=$(source <(curl -s -- "$remoterepo"/packages/"$i"/"$i".pacscript) && type pkgver &>/dev/null && pkgver || echo "$version") >/dev/null
 		remoteurl="${REPOS[$IDXMATCH]}"
 	else
 		fancy_message warning "Package ${GREEN}${i}${CYAN} is not on ${CYAN}$(parseRepo "${remoterepo}")${NC} anymore"
@@ -88,7 +88,7 @@ for i in "${list[@]}"; do
 			if [[ $IDX -eq $IDXMATCH ]]; then
 				continue
 			else
-				ver=$(source <(curl -s "${REPOS[$IDX]}"/packages/"$i"/"$i".pacscript) && type pkgver &>/dev/null && pkgver || echo "$version") >/dev/null
+				ver=$(source <(curl -s -- "${REPOS[$IDX]}"/packages/"$i"/"$i".pacscript) && type pkgver &>/dev/null && pkgver || echo "$version") >/dev/null
 				if ! ver_compare "$alterver" "$ver"; then
 					alterver="$ver"
 					alterurl="$REPO"

--- a/pacstall
+++ b/pacstall
@@ -200,7 +200,7 @@ function download() {
 	if command -v axel > /dev/null; then
 		axel -ao "${1##*/}" "$1"
 	else
-		wget -q --show-progress --progress=bar:force "$1" 2>&1
+		wget -q --show-progress --progress=bar:force -- "$1" 2>&1
 	fi
 }
 


### PR DESCRIPTION
## Purpose

To prevent bugs because of malformed input, like a dash, which would be evaluated by bash as a flag.

## Approach

Add `--` before inputs so bash evaluates them as inputs instead of flags

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.