### PR TITLE
fix(install): ambiguous error message when `$gives` contains multiple fields

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -68,7 +68,7 @@ function checks() {
 		exit 1
 	fi
 	if echo "$gives" | grep -q ",\|\\s"; then
-		fancy_message error "Expected argument \"gives\" to only contain one word but has multiple"
+		fancy_message error "\"gives\" supports only one field"
 		exit 1
 	fi
 	if [[ -z "$url" ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -68,8 +68,8 @@ function checks() {
 		exit 1
 	fi
 	if echo "$gives" | grep -q ",\|\\s"; then
-        fancy_message error "Expected argument \"gives\" to only contain one word but has multiple"
-        exit 1
+		fancy_message error "Expected argument \"gives\" to only contain one word but has multiple"
+		exit 1
 	fi
 	if [[ -z "$url" ]]; then
 		fancy_message error "Package does not contain URL"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -67,6 +67,10 @@ function checks() {
 		fancy_message error "Package does not contain version"
 		exit 1
 	fi
+	if echo "$gives" | grep -q ",\|\\s"; then
+        fancy_message error "Expected argument \"gives\" to only contain one word but has multiple"
+        exit 1
+	fi
 	if [[ -z "$url" ]]; then
 		fancy_message error "Package does not contain URL"
 		exit 1


### PR DESCRIPTION
Logs an error message when `$gives` contains multiple words by checking for whitespaces and commas.

## Purpose

Fixes issue #443.

## Approach

Checks if `$gives` contains whitespace or commas.

## Progress

- [x] Add check condition
- [x] log the error and `exit 1` if multiple words are found.

## Addendum

Issue #443 

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
- [x] ~I will not be sued if I forgot something.~ I approve to be punished on the rack, if I falter in abiding by the clauses!
