### PR TITLE
fix(upgrade): `sed` errors when package is non-existent

### DIFF
--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -79,7 +79,7 @@ for i in "${list[@]}"; do
 		remoteurl="${REPOS[$IDXMATCH]}"
 	else
 		fancy_message warn "Package ${GREEN}${i}${CYAN} is not on ${CYAN}$(parseRepo "${remoterepo}")${NC} anymore"
-		sed -i "/_remote/d" "$LOGDIR/$i"
+		sudo sed -i "/_remote/d" "$LOGDIR/$i"
 	fi
 
 	if [[ $i != *"-git" ]]; then


### PR DESCRIPTION
## Purpose

When upgrading, and you have a package not found in a repo, sed will give an error like this:
```bash
sed: couldn't open temporary file /var/log/pacstall/metadata/sedqIEaPr: Permission denied
```

## Approach

Give it permission

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.

Closes #446 