### PR TITLE
feat(update)!: prevent updating to an incompatible release

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -488,7 +488,7 @@ while [[ ! "$1" == "--" ]]; do
 			fi
 			if curl --output /dev/null --silent --head --fail https://raw.githubusercontent.com/"$USERNAME"/pacstall/"$BRANCH"/pyproject.toml; then
 				fancy_message error "The repository you are trying to upgrade to contains a version of pacstall that cannot be updated from $(pacstall -V)"
-				fancy_message error "Visit https://github.com/$USERNAME/pacstall/tree/$BRANCH for more information on how to update"
+				fancy_message error "Visit https://github.com/$USERNAME/pacstall/tree/$BRANCH for more information on how to reinstall. Most packages will also need to be reinstalled"
 				exit 1
 			fi
 			sudo wget -q -N https://raw.githubusercontent.com/"$USERNAME"/pacstall/"$BRANCH"/misc/scripts/update.sh -P "$STGDIR/scripts" 2> /dev/null

--- a/pacstall
+++ b/pacstall
@@ -486,7 +486,11 @@ while [[ ! "$1" == "--" ]]; do
 					USERNAME="pacstall"
 				fi
 			fi
-
+			if curl --output /dev/null --silent --head --fail https://raw.githubusercontent.com/"$USERNAME"/pacstall/"$BRANCH"/pyproject.toml; then
+				fancy_message error "The repository you are trying to upgrade to contains a version of pacstall that cannot be updated from $(pacstall -V)"
+				fancy_message error "Visit https://github.com/$USERNAME/pacstall/tree/$BRANCH for more information on how to update"
+				exit 1
+			fi
 			sudo wget -q -N https://raw.githubusercontent.com/"$USERNAME"/pacstall/"$BRANCH"/misc/scripts/update.sh -P "$STGDIR/scripts" 2> /dev/null
 			source "$STGDIR/scripts/update.sh"
 			exit 0


### PR DESCRIPTION
## Purpose

When the python rewrite gets merged into master, 1.7.1 will still try to
upgrade to the python rewrite, even though the locations of certain code
will not be there anymore. This adds a check to make sure Pacstall can't
upgrade to a pythonic version.

## Approach

Check for the existence of `pyproject.toml`, and fail if it exists.

## Testing
Update to this branch
Run `pacstall -U pacstall python3-rewrite`

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.