### PR TITLE
ci(dependabot): add config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "python3-rewrite"
+    commit-message:
+      prefix: "build(deps)"
+      prefix-development: "build(deps-dev)"
+      include: "scope"


### PR DESCRIPTION
## Purpose

The `python3-rewrite` branch can't leverage dependabot for dependency updates, so we are having to do so manually. This is very inefficient

## Approach

Add the dependabot config to the `develop` branch but make it target the `python3-rewrite` branch. (@Henryws insists on the existence of `develop` as of now).

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
