### PR TITLE
fix(upgrade): error when specifying multiple args

### DIFF
--- a/pacstall/parser.py
+++ b/pacstall/parser.py
@@ -195,7 +195,7 @@ def parse_arguments() -> Namespace:
         help="Upgrade packages",
         epilog="Leave argument blank to upgrade all packages interactively",
     )
-    upgrade_parser.add_argument("packages", nargs="?", help="Packages to upgrade")
+    upgrade_parser.add_argument("packages", nargs="*", help="Packages to upgrade")
     upgrade_parser.add_argument(
         "-P",
         "--disable-prompts",


### PR DESCRIPTION
## Purpose

The `upgrade` command parser fails when multiple arguments are specified.

## Approach

Switch from `?` -> `*` [nargs](https://docs.python.org/3/library/argparse.html#nargs)

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
