### PR TITLE
fix(logger): error when log directory didn't exist

### DIFF
--- a/pacstall/api/logger.py
+++ b/pacstall/api/logger.py
@@ -108,6 +108,7 @@ def setup_logger(
     """
 
     LOGGING_DIR_PREFIX = Path("/var/log/pacstall/")
+    LOGGING_DIR_PREFIX.mkdir(exist_ok=True, parents=True)
 
     # Delete older logs
     for log_folder in LOGGING_DIR_PREFIX.glob("*"):


### PR DESCRIPTION
## Purpose

The logger fails, if the `LOGGING_DIR_PREFIX` directory doesn't exist.

## Approach

Make the directory as a fail-safe beforehand.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
