### PR TITLE
perf: remove dependency on `aiofiles`

### DIFF
--- a/pacstall/cmds/download.py
+++ b/pacstall/cmds/download.py
@@ -29,7 +29,7 @@ from logging import getLogger
 from pathlib import Path
 from typing import List
 
-import aiofiles
+from anyio import open_file
 from httpx import AsyncClient, HTTPStatusError, RequestError
 from rich import print as rprint
 from rich.progress import (
@@ -82,7 +82,7 @@ async def download(
     try:
         response = await client.get(url)
         response.raise_for_status()
-        async with aiofiles.open(Path.cwd() / url.split("/")[-1], mode="wb") as file:
+        async with await open_file(Path.cwd() / url.split("/")[-1], mode="wb") as file:
             await file.write(response.content)
 
         progress_bar.update(download_task, advance=1, filename=filename)

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,12 +1,4 @@
 [[package]]
-name = "aiofiles"
-version = "0.8.0"
-description = "File support for asyncio."
-category = "main"
-optional = false
-python-versions = ">=3.6,<4.0"
-
-[[package]]
 name = "anyio"
 version = "3.5.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
@@ -381,14 +373,6 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "types-aiofiles"
-version = "0.8.3"
-description = "Typing stubs for aiofiles"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "typing-extensions"
 version = "4.0.1"
 description = "Backported and Experimental Type Hints for Python 3.6+"
@@ -417,13 +401,9 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "382325d1a8ca4e3c9b4aac65e27446cc5cf3f02a54a909e62d951c2599e7e132"
+content-hash = "58112033be7d11770487787a0287d4eeb8e63779b2e9762517486f37404d36f3"
 
 [metadata.files]
-aiofiles = [
-    {file = "aiofiles-0.8.0-py3-none-any.whl", hash = "sha256:7a973fc22b29e9962d0897805ace5856e6a566ab1f0c8e5c91ff6c866519c937"},
-    {file = "aiofiles-0.8.0.tar.gz", hash = "sha256:8334f23235248a3b2e83b2c3a78a22674f39969b96397126cc93664d9a901e59"},
-]
 anyio = [
     {file = "anyio-3.5.0-py3-none-any.whl", hash = "sha256:b5fa16c5ff93fa1046f2eeb5bbff2dad4d3514d6cda61d02816dba34fa8c3c2e"},
     {file = "anyio-3.5.0.tar.gz", hash = "sha256:a0aeffe2fb1fdf374a8e4b471444f0f3ac4fb9f5a5b542b48824475e0042a5a6"},
@@ -625,10 +605,6 @@ toml = [
 tomli = [
     {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
     {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
-]
-types-aiofiles = [
-    {file = "types-aiofiles-0.8.3.tar.gz", hash = "sha256:77c455ecfb08a81e39441ce35697870bcba8f2682baad4408b5eb48d9efb02c2"},
-    {file = "types_aiofiles-0.8.3-py3-none-any.whl", hash = "sha256:e261d6c0fafc3303c40cab64872609af8c702f6ec6590dc9f04a9bb8aaccc7b2"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ classifiers = [
 python = "^3.8"
 rich = "^11.1.0"
 httpx = "^0.22.0"
-aiofiles = "^0.8.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22.1"
@@ -60,7 +59,6 @@ isort = "^5.10.1"
 pyupgrade = "^2.29.1"
 mypy = "^0.931"
 codespell = "^2.1.0"
-types-aiofiles = "^0.8.3"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Purpose

Increases speed of downloads from 5-6 secs to 3-4 secs.

## Approach

Uses `anyio` to accomplish this (which is a dependency of `httpx`, therefore no additional dependencies required to achieve this).

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
