### PR TITLE
fix(query-info): frozen `-Qi` when deb contains no size variable

### DIFF
--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -36,16 +36,15 @@ source "$LOGDIR/$PACKAGE"
 
 if [[ "$PACKAGE" == *-deb ]]; then
 	size="$(apt-cache --no-all-versions show "${_gives}" | grep Installed-Size | cut -d' ' -f 2 | numfmt --to=iec)"
-	if [[ -z "${size}" ]]; then
-		size="invalid"
-	fi
 else
 	size="$(du -sh "$STOWDIR"/"$PACKAGE" 2> /dev/null | awk '{print $1}')"
 fi
 
 echo -e "${BGreen}name${NORMAL}: $PACKAGE"
 echo -e "${BGreen}version${NORMAL}: $_version"
-echo -e "${BGreen}size${NORMAL}: $size"
+if [[ -n "${size}" ]]; then
+	echo -e "${BGreen}size${NORMAL}: $size"
+fi
 echo -e "${BGreen}description${NORMAL}: ""$_description"""
 echo -e "${BGreen}date installed${NORMAL}: ""$_date"""
 

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -35,7 +35,10 @@ fi
 source "$LOGDIR/$PACKAGE"
 
 if [[ "$PACKAGE" == *-deb ]]; then
-	size="$(numfmt --to=iec $(apt-cache --no-all-versions show "${_gives}" | grep Installed-Size | cut -d' ' -f 2))"
+	size="$(apt-cache --no-all-versions show "${_gives}" | grep Installed-Size | cut -d' ' -f 2 | numfmt --to=iec)"
+	if [[ -z "${size}" ]]; then
+		size="invalid"
+	fi
 else
 	size="$(du -sh "$STOWDIR"/"$PACKAGE" 2> /dev/null | awk '{print $1}')"
 fi


### PR DESCRIPTION
## Purpose

When `numfmt` is given a blank input, it freezes, which can be observed by running `numfmt --to=iec`. The package `git-delta-deb` package contains no size variable, so `numfmt` is given no input, causing the freezing.

## Approach

Move `numfmt` so it is piped into, instead of given input. Then if the `size` variable is empty, replace it with the text `invalid` to show the user

## Addendum

Fixes #442

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.