### PR TITLE
fix(search): fail out on no package

### DIFF
--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -57,7 +57,7 @@ if [[ $PACKAGE == *@* ]]; then
 			if [[ "$LEN" -eq 0 ]]; then
 				fancy_message warn "There is no package with the name $IRed${PACKAGE%%@*}$NC in the repo $CYAN$REPONAME$NC"
 				error_log 3 "search $PACKAGE@$REPONAME"
-				return 1	
+				exit 1
 			fi
 			export PACKAGE
 			export REPO="$URL"
@@ -67,7 +67,7 @@ if [[ $PACKAGE == *@* ]]; then
 	
 	fancy_message warn "$IRed$REPONAME$NC is not on your repo list or does not exist"
 	error_log 3 "search $PACKAGE@$REPONAME"
-	return 1	
+	exit 1
 fi
 
 # Makes array of packages and array

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -114,8 +114,10 @@ if [[ "$LEN" -eq 0 ]]; then
 	if [[ -z "$SEARCH" ]]; then
 		fancy_message warn "There is no package with the name $IRed$PACKAGE$NC"
 		error_log 3 "search $PACKAGE"
+		exit 1
 	else
 		fancy_message warn "There is no package with the name $IRed$SEARCH$NC"
+		exit 1
 	fi
 
 	return 1


### PR DESCRIPTION
## Purpose

Currently `search.sh` uses `return` instead of `exit` to signify a non existent package, but that doesn't work, which gives an exit code of zero instead of one.

## Approach

Replace certain `return`s with `exit`s

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.