### PR TITLE
fix(remove): purge without user input

### DIFF
--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -41,7 +41,7 @@ fi
 
 case "$url" in
 	*.deb)
-		if ! sudo apt remove "$gives" 2>/dev/null; then
+		if ! sudo apt remove -y "$gives" 2>/dev/null; then
 			fancy_message warn "Failed to remove the package"
 			error_log 1 "remove $PACKAGE"
 			exit 1

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -91,7 +91,7 @@ case "$url" in
 		fancy_message info "Removing dummy package"
 		export PACSTALL_REMOVE=1
 
-		if ! sudo --preserve-env=PACSTALL_REMOVE apt-get purge "$name" 2> /dev/null; then
+		if ! sudo --preserve-env=PACSTALL_REMOVE apt-get purge -y "$name" 2> /dev/null; then
 			fancy_message error "Failed to remove dummy package"
 			error_log 1 "remove $PACKAGE"
 			exit 1


### PR DESCRIPTION
## Purpose

Removes dummy deb without interaction

## Approach

Adding `-y` to the arguments for `apt`

## Addendum
https://discord.com/channels/839818021207801878/866673569521991700/943956875307778051

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.