### PR TITLE
fix(install-local): error out if optdepends has no description

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -178,7 +178,14 @@ function makeVirtualDeb {
 		fi
 
 		printf "Suggests:" |sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
-		printf " %s\n" "${optdepends[@]}" | awk -F': ' '{print $1}' | tr '\n' ',' | head -c -2 | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
+		for i in "${optdepends[@]}"; do
+			if ! grep -q ':' <<< "${i}"; then
+				fancy_message error "${i} does not have a description"
+				cleanup
+				return 1
+			fi
+		done
+		printf " %s\n" "${optdepends[@]}" | awk -F': ' '{print $1}' | tr '\n' ',' | head -c -1 | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 		printf "\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 	fi
 


### PR DESCRIPTION
## Purpose

Fail if `optdepends` key's do not have a description, and cut to correct character.

## Approach

Check the keys with a for loop.

## Addendum

Fixes #507

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.