### PR TITLE
Fix/allow printing when sourcing

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -293,7 +293,7 @@ fi
 fancy_message info "Sourcing pacscript"
 DIR=$(pwd)
 export homedir="/home/$PACSTALL_USER"
-if ! source "$PACKAGE".pacscript > /dev/null; then
+if ! source "$PACKAGE".pacscript; then
 	fancy_message error "Could not source pacscript"
 	error_log 12 "install $PACKAGE"
 	fancy_message info "Cleaning up"


### PR DESCRIPTION
## Purpose

Allows printing messages when sourcing the pacscript

## Approach

Remove redirection to `/dev/null` when sourcing

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
