### PR TITLE
fix: make apt install optdepends when asked

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@
 
 *  Supports binary, git, appimage, building and `.deb` packages
 *  Accelerated package download using [axel](https://github.com/axel-download-accelerator/axel) (optional)
-*  Auto update checks for git packages, so you always get the latest build of your favourite program off the latest commit by the developer
-*  Over 175 packages available to install in the official programs repository
+*  Checks for the latest commit on git packages, so you always get the latest build of your favourite program straight from the developer
 *  Ability to install programs from multiple repositories
 *  Ability to track Pacstall updates from any fork/branch easily
 *  Completions available for `bash` (`ZSH`), and `fish`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 *  Supports binary, git, appimage, building and `.deb` packages
 *  Accelerated package download using [axel](https://github.com/axel-download-accelerator/axel) (optional)
-*  Checks for the latest commit on git packages, so you always get the latest build of your favourite program straight from the developer
+*  During upgrades, you always get the latest build off of the latest commit from the developer for `-git` packages. No need to wait for the pacscript maintainer to update the script!
 *  Ability to install programs from multiple repositories
 *  Ability to track Pacstall updates from any fork/branch easily
 *  Completions available for `bash` (`ZSH`), and `fish`

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -246,7 +246,7 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" >"/dev/null"
 	export PACSTALL_INSTALL=1
 	sudo rm -rf "$SRCDIR/$name-pacstall"
 	# --allow-downgrades is to allow git packages to "downgrade", because the commits aren't necessarily a higher number than the last version
-	sudo --preserve-env=PACSTALL_INSTALL apt-get --install-recommends install "$SRCDIR/$name-pacstall.deb" -y --allow-downgrades 2> "/dev/null"
+	sudo --preserve-env=PACSTALL_INSTALL apt-get install $optinstall "$SRCDIR/$name-pacstall.deb" -y --allow-downgrades 2> "/dev/null"
 	if ! [[ -d /etc/apt/preferences.d/ ]]; then
 		sudo mkdir -p /etc/apt/preferences.d
 	fi
@@ -256,7 +256,7 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
 
 
 	fancy_message info "Installing dependencies"
-	if ! sudo --preserve-env=PACSTALL_INSTALL apt-get install $optinstall -f -y -qq -o=Dpkg::Use-Pty=0; then
+	if ! sudo --preserve-env=PACSTALL_INSTALL apt-get install $optinstall -f -y -qq -o=Dpkg::Use-Pty=0 "${depends}"; then
 		fancy_message error "Failed to install dependencies"
 		error_log 8 "install $PACKAGE"
 		sudo dpkg -r --force-all "$name" > /dev/null
@@ -264,7 +264,7 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
 		cleanup
 		return 1
 	fi
-	sudo --preserve-env=PACSTALL_INSTALL apt-get --install-recommends install "$SRCDIR/$name-pacstall.deb" -y > "/dev/null"
+	sudo --preserve-env=PACSTALL_INSTALL apt-get install $optinstall "$SRCDIR/$name-pacstall.deb" -y > "/dev/null"
 	sudo rm "$SRCDIR/$name-pacstall.deb"
 	echo "Package: ${name}
 Pin: version *

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -186,7 +186,7 @@ function makeVirtualDeb {
 	fi
 	dependency_string="$(printf "%s\n" "${dependency_array[@]}" | awk -F': ' '{print $1}' | sed ':a;N;$!ba;s/\n/, /g' | head -c -1)"
 	if (( ${#dependency_array[@]} != 0 )); then
-		printf "Depends: %s\n" "${dependency_string}" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control"
+		printf "Depends: %s\n" "${dependency_string}" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 	fi
 	printf "\n" | sudo tee -a "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 	printf "Architecture: all

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -246,7 +246,7 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" >"/dev/null"
 	export PACSTALL_INSTALL=1
 	sudo rm -rf "$SRCDIR/$name-pacstall"
 	# --allow-downgrades is to allow git packages to "downgrade", because the commits aren't necessarily a higher number than the last version
-	sudo --preserve-env=PACSTALL_INSTALL apt-get install "$SRCDIR/$name-pacstall.deb" -y --allow-downgrades 2> "/dev/null"
+	sudo --preserve-env=PACSTALL_INSTALL apt-get --install-recommends install "$SRCDIR/$name-pacstall.deb" -y --allow-downgrades 2> "/dev/null"
 	if ! [[ -d /etc/apt/preferences.d/ ]]; then
 		sudo mkdir -p /etc/apt/preferences.d
 	fi
@@ -264,7 +264,7 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
 		cleanup
 		return 1
 	fi
-	sudo --preserve-env=PACSTALL_INSTALL apt-get install "$SRCDIR/$name-pacstall.deb" -y > "/dev/null"
+	sudo --preserve-env=PACSTALL_INSTALL apt-get --install-recommends install "$SRCDIR/$name-pacstall.deb" -y > "/dev/null"
 	sudo rm "$SRCDIR/$name-pacstall.deb"
 	echo "Package: ${name}
 Pin: version *


### PR DESCRIPTION
## Purpose

Currently optdepends do not get installed by apt, even though they are listed as recommended in the dummy deb.

## Approach

Allow installing recommended packages

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.