### PR TITLE
fix: accept paths with `-Il` command

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -394,23 +394,27 @@ while [[ ! "$1" == "--" ]]; do
 			fi
 
 			while [[ -n "$2" ]]; do
-				INPUT="$(basename "$2" ".pacscript")" # Removes the suffix
 				export local="yes"
-
-				# Check if we need to cd into the directory first, and also check that $INPUT.pacscript does not exist
-				if [[ -d "$INPUT" ]] && [[ ! -f "$INPUT".pacscript ]]; then
-					cd "$(basename "$INPUT")" || exit
+				
+				PATH="$(dirname "$2")"
+				PACKAGE="$(basename "$2" ".pacscript")" # Removes the suffix
+				export PACKAGE
+				
+				# Check if we need to cd into the directory first
+				if [[ "$PATH" != "." ]] && [[ -d "$PACKAGE" ]]; then
+					cd $PACKAGE
+				elif [[ -d "$PATH" ]]; then
+					cd "$PATH"
 				fi
+				
 				# Check if the file exist
-				if [[ ! -f "$2".pacscript ]]; then
+				if [[ ! -f "$INPUT".pacscript ]]; then
 					fancy_message error "$2 does not exist"
 					shift
 					continue
 				fi
 				shift
 
-				PACKAGE="$(basename "$INPUT")"
-				export PACKAGE
 				if ! source "$STGDIR/scripts/install-local.sh"; then
 					fancy_message error "Failed to install ${GREEN}${PACKAGE}${NC}"
 					continue

--- a/pacstall
+++ b/pacstall
@@ -396,15 +396,15 @@ while [[ ! "$1" == "--" ]]; do
 			while [[ -n "$2" ]]; do
 				export local="yes"
 				
-				PATH="$(dirname "$2")"
+				PKGPATH="$(dirname "$2")"
 				PACKAGE="$(basename "$2" ".pacscript")" # Removes the suffix
 				export PACKAGE
 				
 				# Check if we need to cd into the directory first
-				if [[ "$PATH" != "." ]] && [[ -d "$PACKAGE" ]]; then
+				if [[ "$PKGPATH" != "." ]] && [[ -d "$PACKAGE" ]]; then
 					cd $PACKAGE
-				elif [[ -d "$PATH" ]]; then
-					cd "$PATH"
+				elif [[ -d "$PKGPATH" ]]; then
+					cd "$PKGPATH"
 				fi
 				
 				# Check if the file exist

--- a/pacstall
+++ b/pacstall
@@ -401,7 +401,7 @@ while [[ ! "$1" == "--" ]]; do
 				export PACKAGE
 				
 				# Check if we need to cd into the directory first
-				if [[ "$PKGPATH" != "." ]] && [[ -d "$PACKAGE" ]]; then
+				if [[ "$PKGPATH" == "." ]] && [[ -d "$PACKAGE" ]]; then
 					cd "$PACKAGE"
 				elif [[ -d "$PKGPATH" ]]; then
 					cd "$PKGPATH"

--- a/pacstall
+++ b/pacstall
@@ -402,13 +402,13 @@ while [[ ! "$1" == "--" ]]; do
 				
 				# Check if we need to cd into the directory first
 				if [[ "$PKGPATH" != "." ]] && [[ -d "$PACKAGE" ]]; then
-					cd $PACKAGE
+					cd "$PACKAGE"
 				elif [[ -d "$PKGPATH" ]]; then
 					cd "$PKGPATH"
 				fi
 				
 				# Check if the file exist
-				if [[ ! -f "$INPUT".pacscript ]]; then
+				if [[ ! -f "$PACKAGE".pacscript ]]; then
 					fancy_message error "$2 does not exist"
 					shift
 					continue


### PR DESCRIPTION
## Purpose

The install-local command didn't accept paths to pacscripts since a bug introduced in #97

## Approach

Fix `cd` into the pacscript directory and the file checks

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
