### PR TITLE
fix(install-local): skip `$breaks` check for  `-deb` upgrades

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -336,7 +336,7 @@ if [[ -n "$pacdeps" ]]; then
 	done
 fi
 
-if [[ -n "$breaks" ]]; then
+if [[ -n "$breaks" ]] && ! pacstall -L | grep -E "(^| )${name}( |$)" > /dev/null 2>&1; then
 	for pkg in $breaks; do
 		if dpkg-query -W -f='${Status} ${Section}' "${pkg}" 2> /dev/null | grep "^install ok installed" | grep -v "Pacstall" > /dev/null 2>&1; then
 			# Check if anything in breaks variable is installed already


### PR DESCRIPTION
## Purpose

Fix for the upgrade command of some `-deb` packages installed through pacstall, which were unable to upgrade due to the `$breaks` variable

## Approach

Skip $breaks check if package already installed

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
