### PR TITLE
fix(check_url): add http code 301 to permitted list

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@
 
 *  Supports binary, git, appimage, building and `.deb` packages
 *  Accelerated package download using [axel](https://github.com/axel-download-accelerator/axel) (optional)
-*  Auto update checks for git packages, so you always get the latest build of your favourite program off the latest commit by the developer
-*  Over 175 packages available to install in the official programs repository
+*  Checks for the latest commit on git packages, so you always get the latest build of your favourite program straight from the developer
 *  Ability to install programs from multiple repositories
 *  Ability to track Pacstall updates from any fork/branch easily
 *  Completions available for `bash` (`ZSH`), and `fish`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 *  Supports binary, git, appimage, building and `.deb` packages
 *  Accelerated package download using [axel](https://github.com/axel-download-accelerator/axel) (optional)
-*  Checks for the latest commit on git packages, so you always get the latest build of your favourite program straight from the developer
+*  During upgrades, you always get the latest build off of the latest commit from the developer for `-git` packages. No need to wait for the pacscript maintainer to update the script!
 *  Ability to install programs from multiple repositories
 *  Ability to track Pacstall updates from any fork/branch easily
 *  Completions available for `bash` (`ZSH`), and `fish`

--- a/pacstall
+++ b/pacstall
@@ -205,7 +205,7 @@ function check_url() {
             fancy_message error "The URL cannot be found"
             return 1
         ;;
-        200|302)
+        200|301|302)
             true
         ;;
         *)


### PR DESCRIPTION
## Purpose

Allows http code 301 (moved permanently). This is most notably seen with github clone URLs as seen below
```
$ curl -o /dev/null -s -w "%{http_code}\n" -- https://github.com/pacstall/pacstall.git
301
```

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.