### PR TITLE
fix(install-local): download patches before downloading package

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -437,6 +437,16 @@ fi
 sudo mkdir -p "/tmp/pacstall"
 sudo chown "$PACSTALL_USER" -R /tmp/pacstall
 
+if [[ -n $patch ]]; then
+	fancy_message info "Downloading patches"
+	mkdir -p PACSTALL_patchesdir
+	for i in "${patch[@]}"; do
+		wget -q "$i" -P PACSTALL_patchesdir &
+	done
+	wait
+	export PACPATCH=$(pwd)/PACSTALL_patchesdir
+fi
+
 case "$url" in
 	*.git)
 		# git clone quietly, with no history, and if submodules are there, download with 10 jobs
@@ -511,16 +521,6 @@ esac
 
 export srcdir="$PWD"
 sudo chown -R "$PACSTALL_USER":"$PACSTALL_USER" . 2>/dev/null
-
-if [[ -n $patch ]]; then
-	fancy_message info "Downloading patches"
-	mkdir -p PACSTALL_patchesdir
-	for i in "${patch[@]}"; do
-		wget -q "$i" -P PACSTALL_patchesdir &
-	done
-	wait
-	export PACPATCH=$(pwd)/PACSTALL_patchesdir
-fi
 
 export pkgdir="/usr/src/pacstall/$name"
 


### PR DESCRIPTION
## Purpose

<!--Describe the problem you are fixing or the feature you are adding.-->

Fixes #512 

## Approach

<!--How does this address the problem?-->

Move the patch downloader above the package downloader

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
