### PR TITLE
fix: check if pacdep is already installed

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -343,7 +343,10 @@ if [[ -n "$pacdeps" ]]; then
 		sudo touch /tmp/pacstall-pacdeps-"$i"
 
 		[[ $KEEP ]] && cmd="-KPI" || cmd="-PI"
-		if ! pacstall "$cmd" "$i"; then
+		if pacstall -L | grep -E "(^| )${i}( |$)" > /dev/null 2>&1; then
+			fancy_message info "The pacstall dependency ${i} is already installed"
+			fancy_message warn "It's recommended to upgrade, as ${i} may have a newer version"
+		elif ! pacstall "$cmd" "$i"; then
 			fancy_message error "Failed to install pacstall dependencies"
 			error_log 8 "install $PACKAGE"
 			cleanup


### PR DESCRIPTION
## Purpose

Check if pacdep is already installed and skip if that's the case

## Approach

Add check and warning messages

## Addendum

Closes #539

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
