### PR TITLE
fix: remove useless sudos

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -32,7 +32,7 @@ function cleanup() {
 		fi
 	fi
 	if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
-		sudo rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
+		rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
 		sudo rm -rf /tmp/pacstall-pacdep
 	else
 		sudo rm -rf "${SRCDIR:?}"/*
@@ -339,7 +339,7 @@ if [[ -n $pacdeps ]]; then
 	for i in "${pacdeps[@]}"; do
 		fancy_message info "Installing $i"
 		# If /tmp/pacstall-pacdeps-"$i" is available, it will trigger the logger to log it as a dependency
-		sudo touch /tmp/pacstall-pacdeps-"$i"
+		touch /tmp/pacstall-pacdeps-"$i"
 
 		[[ $KEEP ]] && cmd="-KPI" || cmd="-PI"
 		if pacstall -L | grep -E "(^| )${i}( |$)" > /dev/null 2>&1; then
@@ -351,6 +351,7 @@ if [[ -n $pacdeps ]]; then
 			cleanup
 			return 1
 		fi
+		rm /tmp/pacstall-pacdeps-"$i"
 	done
 fi
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -32,7 +32,7 @@ function cleanup() {
 		fi
 	fi
 	if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
-		sudo rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
+		rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
 		sudo rm -rf /tmp/pacstall-pacdep
 	else
 		sudo rm -rf "${SRCDIR:?}"/*
@@ -339,7 +339,7 @@ if [[ -n $pacdeps ]]; then
 	for i in "${pacdeps[@]}"; do
 		fancy_message info "Installing $i"
 		# If /tmp/pacstall-pacdeps-"$i" is available, it will trigger the logger to log it as a dependency
-		sudo touch /tmp/pacstall-pacdeps-"$i"
+		touch /tmp/pacstall-pacdeps-"$i"
 
 		[[ $KEEP ]] && cmd="-KPI" || cmd="-PI"
 		if pacstall -L | grep -E "(^| )${i}( |$)" > /dev/null 2>&1; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -32,7 +32,7 @@ function cleanup() {
 		fi
 	fi
 	if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
-		rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
+		sudo rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
 		sudo rm -rf /tmp/pacstall-pacdep
 	else
 		sudo rm -rf "${SRCDIR:?}"/*
@@ -339,7 +339,7 @@ if [[ -n $pacdeps ]]; then
 	for i in "${pacdeps[@]}"; do
 		fancy_message info "Installing $i"
 		# If /tmp/pacstall-pacdeps-"$i" is available, it will trigger the logger to log it as a dependency
-		touch /tmp/pacstall-pacdeps-"$i"
+		sudo touch /tmp/pacstall-pacdeps-"$i"
 
 		[[ $KEEP ]] && cmd="-KPI" || cmd="-PI"
 		if pacstall -L | grep -E "(^| )${i}( |$)" > /dev/null 2>&1; then

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -34,20 +34,20 @@ export UPGRADE="yes"
 # Get the list of the installed packages
 mapfile -t list < <(pacstall -L)
 if [[ -f /tmp/pacstall-up-list ]]; then
-	sudo rm /tmp/pacstall-up-list
+	rm /tmp/pacstall-up-list
 fi
 
 if [[ -f /tmp/pacstall-up-print ]]; then
-	sudo rm /tmp/pacstall-up-print
+	rm /tmp/pacstall-up-print
 fi
 
 if [[ -f /tmp/pacstall-up-urls ]]; then
-	sudo rm /tmp/pacstall-up-urls
+	rm /tmp/pacstall-up-urls
 fi
 
-sudo touch /tmp/pacstall-up-list
-sudo touch /tmp/pacstall-up-print
-sudo touch /tmp/pacstall-up-urls
+touch /tmp/pacstall-up-list
+touch /tmp/pacstall-up-print
+touch /tmp/pacstall-up-urls
 
 fancy_message info "Checking for updates"
 
@@ -162,14 +162,14 @@ ${BOLD}$(cat /tmp/pacstall-up-print)${NORMAL}\n"
 fi
 
 if [[ -f "/tmp/pacstall-up-list" ]]; then
-	sudo rm -f /tmp/pacstall-up-list
+	rm -f /tmp/pacstall-up-list
 fi
 
 if [[ -f "/tmp/pacstall-up-print" ]]; then
-	sudo rm -f /tmp/pacstall-up-print
+	rm -f /tmp/pacstall-up-print
 fi
 
 if [[ -f "/tmp/pacstall-up-urls" ]]; then
-	sudo rm -f /tmp/pacstall-up-urls
+	rm -f /tmp/pacstall-up-urls
 fi
 # vim:set ft=sh ts=4 sw=4 noet:

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -106,9 +106,9 @@ for i in "${list[@]}"; do
 
 	if [[ -n $remotever ]]; then
 		if [[ $i == *"-git" ]] || ver_compare "$localver" "$remotever"; then
-			echo "$i" | sudo tee -a /tmp/pacstall-up-list > /dev/null
-			echo "\t${GREEN}${i}${CYAN} @ $(parseRepo "${remoteurl}") ${NC}" | sudo tee -a /tmp/pacstall-up-print > /dev/null
-			echo "$remoteurl" | sudo tee -a /tmp/pacstall-up-urls > /dev/null
+			echo "$i" | tee -a /tmp/pacstall-up-list > /dev/null
+			echo "\t${GREEN}${i}${CYAN} @ $(parseRepo "${remoteurl}") ${NC}" | tee -a /tmp/pacstall-up-print > /dev/null
+			echo "$remoteurl" | tee -a /tmp/pacstall-up-urls > /dev/null
 		fi
 	fi
 done

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -33,17 +33,9 @@ export UPGRADE="yes"
 
 # Get the list of the installed packages
 mapfile -t list < <(pacstall -L)
-if [[ -f /tmp/pacstall-up-list ]]; then
-	rm /tmp/pacstall-up-list
-fi
-
-if [[ -f /tmp/pacstall-up-print ]]; then
-	rm /tmp/pacstall-up-print
-fi
-
-if [[ -f /tmp/pacstall-up-urls ]]; then
-	rm /tmp/pacstall-up-urls
-fi
+rm -f /tmp/pacstall-up-list
+rm -f /tmp/pacstall-up-print
+rm -f /tmp/pacstall-up-urls
 
 touch /tmp/pacstall-up-list
 touch /tmp/pacstall-up-print
@@ -161,15 +153,7 @@ ${BOLD}$(cat /tmp/pacstall-up-print)${NORMAL}\n"
 	done
 fi
 
-if [[ -f "/tmp/pacstall-up-list" ]]; then
-	rm -f /tmp/pacstall-up-list
-fi
-
-if [[ -f "/tmp/pacstall-up-print" ]]; then
-	rm -f /tmp/pacstall-up-print
-fi
-
-if [[ -f "/tmp/pacstall-up-urls" ]]; then
-	rm -f /tmp/pacstall-up-urls
-fi
+rm -f /tmp/pacstall-up-list
+rm -f /tmp/pacstall-up-print
+rm -f /tmp/pacstall-up-urls
 # vim:set ft=sh ts=4 sw=4 noet:


### PR DESCRIPTION
## Purpose

Many places in the codebase call unnecessary `sudo`s 

## Approach

It removes the offending `sudo`s.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.