### PR TITLE
fix(pacstall): check gitlab on `check_url` failure

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -376,7 +376,7 @@ Options:
 				export type="install"
 				export local="no"
 
-				check_url "https://github.com" || check_url "https://github.com" || {
+				check_url "https://github.com" || check_url "https://gitlab.com" || {
 					fancy_message error "Could not connect to the internet"
 					exit 1
 				}
@@ -435,7 +435,7 @@ Options:
 				fi
 				shift
 
-				check_url "https://github.com" || check_url "https://github.com" || {
+				check_url "https://github.com" || check_url "https://gitlab.com" || {
 					fancy_message error "Could not connect to the internet"
 					exit 1
 				}
@@ -460,7 +460,7 @@ Options:
 				exit 1
 			fi
 
-			check_url "https://github.com" || check_url "https://github.com" || {
+			check_url "https://github.com" || check_url "https://gitlab.com" || {
 				fancy_message error "Could not connect to the internet"
 				exit 1
 			}
@@ -542,7 +542,7 @@ Options:
 				fi
 			fi
 
-			check_url "https://github.com" || check_url "https://github.com" || {
+			check_url "https://github.com" || check_url "https://gitlab.com" || {
 				fancy_message error "Could not connect to the internet"
 				exit 1
 			}
@@ -577,7 +577,7 @@ Options:
 				shift
 				export type="download"
 
-				check_url "https://github.com" || check_url "https://github.com" || {
+				check_url "https://github.com" || check_url "https://gitlab.com" || {
 					fancy_message error "Could not connect to the internet"
 					exit 1
 				}
@@ -605,7 +605,7 @@ Options:
 			;;
 
 		-Up | --upgrade)
-			check_url "https://github.com" || check_url "https://github.com" || {
+			check_url "https://github.com" || check_url "https://gitlab.com" || {
 				fancy_message error "Could not connect to the internet"
 				exit 1
 			}


### PR DESCRIPTION
## Purpose

<!--Describe the problem you are fixing or the feature you are adding.-->

Currently we check `github.com` twice on failure, this is unnecessary.

## Approach

<!--How does this address the problem?-->

Check `gitlab.com` instead on failure.


## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
