### PR TITLE
fix: messages on pacdep install/upgrade

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -356,15 +356,16 @@ fi
 
 if [[ -n $pacdeps ]]; then
 	for i in "${pacdeps[@]}"; do
-		fancy_message info "Installing $i"
 		# If /tmp/pacstall-pacdeps-"$i" is available, it will trigger the logger to log it as a dependency
 		touch /tmp/pacstall-pacdeps-"$i"
 
 		[[ $KEEP ]] && cmd="-KPI" || cmd="-PI"
 		if pacstall -L | grep -E "(^| )${i}( |$)" > /dev/null 2>&1; then
 			fancy_message info "The pacstall dependency ${i} is already installed"
-			fancy_message warn "It's recommended to upgrade, as ${i} may have a newer version"
-		elif ! pacstall "$cmd" "$i"; then
+			if [[ -z $UPGRADE ]]; then
+				fancy_message warn "It's recommended to upgrade, as ${i} may have a newer version"
+			fi
+		elif ! fancy_message info "Installing $i" && pacstall "$cmd" "$i"; then
 			fancy_message error "Failed to install pacstall dependencies"
 			error_log 8 "install $PACKAGE"
 			cleanup


### PR DESCRIPTION
## Purpose

Fix pacdep message on upgrade

![image](https://user-images.githubusercontent.com/65723952/172265027-4e919b65-4afd-46e2-97ad-322690a600b9.png)

## Approach

Rework the pacdep install checks and messages

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
