### PR TITLE
fix(pacstall): missing `-T` flag in help section

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -330,6 +330,8 @@ Commands:
 		Upgrade all installed packages.
 	${BOLD}-Qi${NC}, ${BOLD}--query-info${NC} <package>
 		Query information about a package.
+	${BOLD}-T${NC}, ${BOLD}--tree${NC} <package>
+		Display a tree list of a packages files
 
 Options:
 	${BOLD}-P${NC}, ${BOLD}--disable-prompts${NC}


### PR DESCRIPTION
## Purpose

It's missing.

## Approach

Add it.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
