### PR TITLE
fix(pacstall): export `DISABLE_PROMPTS`

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -301,7 +301,7 @@ while [[ $1 != "--" ]]; do
 	case "$1" in
 		-P | --disable-prompts)
 			fancy_message warn "Prompts are disabled"
-			DISABLE_PROMPTS=yes
+			export DISABLE_PROMPTS=yes
 			;;
 
 		-h | --help)


### PR DESCRIPTION
## Purpose

When #543 was introduced, all variables not exported would be unusable inside pacscripts, including the DISABLE_PROMPTS variable.

## Approach

Export it.

## Addendum

Fixes bug in of #543.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
