### PR TITLE
fix(update): add guard for missing update file

### DIFF
--- a/misc/scripts/update.sh
+++ b/misc/scripts/update.sh
@@ -40,7 +40,7 @@ tabs -4
 
 tty_settings=$(stty -g)
 old_version=($(pacstall -V))
-old_info=($(cat $STGDIR/repo/update || echo no default))
+old_info=($(cat $STGDIR/repo/update 2>/dev/null || echo no default))
 
 old_username="${old_info[0]}"
 old_branch="${old_info[1]}"

--- a/misc/scripts/update.sh
+++ b/misc/scripts/update.sh
@@ -40,7 +40,7 @@ tabs -4
 
 tty_settings=$(stty -g)
 old_version=($(pacstall -V))
-old_info=($(cat $STGDIR/repo/update))
+old_info=($(cat $STGDIR/repo/update || echo no default))
 
 old_username="${old_info[0]}"
 old_branch="${old_info[1]}"


### PR DESCRIPTION
## Purpose

Currently, if you update to the develop branch without running `-U` at any point, it displays a `cat` error.

## Approach

Fix by redirecting the stderr of the offending `cat` command to /dev/null, and adding a `||` to make sure that something is passed along.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.