### PR TITLE
fix(install-local): silently remove pacdep file if it still exists

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -371,7 +371,7 @@ if [[ -n $pacdeps ]]; then
 			cleanup
 			return 1
 		fi
-		rm /tmp/pacstall-pacdeps-"$i"
+		rm -f /tmp/pacstall-pacdeps-"$i"
 	done
 fi
 


### PR DESCRIPTION
## Purpose

When removing a pacdep file (`/tmp/pacstall-pacdeps-$i`), the file may already be deleted, so just in case it is, silently "remove" the file.

## Approach

Add `-f` to `rm`

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
