### PR TITLE
fix(remove): source pacscript before running removescript

### DIFF
--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -85,7 +85,7 @@ case "$url" in
 		if fn_exists removescript; then
 			fancy_message info "Running post removal script"
 			export -f ask fancy_message removescript
-			bash -ce "/var/cache/pacstall/${PACKAGE}/${_version}/${PACKAGE}.pacscript; removescript" || {
+			bash -ce ". /var/cache/pacstall/${PACKAGE}/${_version}/${PACKAGE}.pacscript; removescript" || {
 				error_log 2 "removescript $PACKAGE"
 				fancy_message error "Could not run removescript properly"
 				exit 1


### PR DESCRIPTION
## Purpose

https://github.com/pacstall/pacstall/blob/08501b9cf793521ef23f743eb0fe0a795f471aca/misc/scripts/remove.sh#L88 doesn't actually source the file, meaning removescript always fails.

## Approach

Source it.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
