### PR TITLE
feat: add `fancy_message sub` for cleaner output

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -179,7 +179,7 @@ function makeVirtualDeb {
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
 			sub_message "Optional dependencies"
 			for i in "${optdeps[@]}"; do
-				printf '		%s\n' "${BOLD}${i%%: *}: ${i#*:}${NC}"
+				echo -e "\t\t${BOLD}${i%%:*}: ${i#*:}${NC}"
 			done
 			# tab over the next line
 			echo -ne "\t"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -174,8 +174,10 @@ function makeVirtualDeb {
 			fi
 		done
 
+		fancy_message info "Installing dependencies"
+
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
-			fancy_message info "$name has optional dependencies that can enhance its functionalities"
+			sub_message "$name has optional dependencies that can enhance its functionalities"
 			echo "Optional dependencies:"
 			printf '    %s\n' "${optdeps[@]}"
 			ask "Do you want to install them" Y
@@ -279,7 +281,7 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" > /dev/null
 	fi
 	export PACSTALL_INSTALL=1
 
-	fancy_message info "Installing dependencies"
+	sub_message "Installing required dependencies"
 	# --allow-downgrades is to allow git packages to "downgrade", because the commits aren't necessarily a higher number than the last version
 	if ! sudo --preserve-env=PACSTALL_INSTALL apt-get install "$SRCDIR/$name-pacstall.deb" -y --allow-downgrades 2> /dev/null; then
 		fancy_message error "Failed to install dependencies"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -631,6 +631,7 @@ build; fancy_message sub "install"
 echo "install" > /tmp/pacstall-func
 install' || {
 	error_log 5 "$(< "/tmp/pacstall-func") $PACKAGE"
+	echo -ne "\t"
 	fancy_message error "Could not $(< "/tmp/pacstall-func") $PACKAGE properly"
 	sudo dpkg -r "$name" > /dev/null
 	fancy_message info "Cleaning up"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -178,8 +178,8 @@ function makeVirtualDeb {
 
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
 			sub_message "$name has optional dependencies that can enhance its functionalities"
-			echo "Optional dependencies:"
-			printf '    %s\n' "${optdeps[@]}"
+			echo -e "\tOptional dependencies:"
+			printf '        %s\n' "${optdeps[@]}"
 			ask "Do you want to install them" Y
 			if [[ $answer -eq 1 ]]; then
 				for optdep in "${optdeps[@]}"; do

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -143,7 +143,6 @@ function makeVirtualDeb {
 	# creates empty .deb package (with only the control file) for apt integration
 	# implements $(gives) variable
 	fancy_message info "Preparing package"
-	sub_message "Creating dummy package"
 	sudo mkdir -p "$SRCDIR/$name-pacstall/DEBIAN"
 	printf "Package: %s\n" "$name" | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 
@@ -176,7 +175,7 @@ function makeVirtualDeb {
 		done
 
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
-			sub_message "$name has optional dependencies that can enhance its functionalities"
+			fancy_message info "$name has optional dependencies that can enhance its functionalities"
 			echo "Optional dependencies:"
 			printf '    %s\n' "${optdeps[@]}"
 			ask "Do you want to install them" Y

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -179,7 +179,7 @@ function makeVirtualDeb {
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
 			sub_message "Optional dependencies"
 			for i in "${optdeps[@]}"; do
-				echo -e "\t\t${BOLD}${i%%:*}${NC}: ${i#*:}"
+				echo -e "\t\t${BOLD}${i%%:*}${NC}:${i#*:}"
 			done
 			# tab over the next line
 			echo -ne "\t"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -177,9 +177,9 @@ function makeVirtualDeb {
 		fancy_message info "Installing dependencies"
 
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
-			sub_message "$name has optional dependencies that can enhance its functionalities"
-			echo -e "\tOptional dependencies:"
-			printf '        %s\n' "${optdeps[@]}"
+			sub_message "Optional dependencies"
+			echo -e "\t\t$name has optional dependencies that can enhance its functionalities"
+			printf '			%s\n' "${optdeps[@]}"
 			ask "Do you want to install them" Y
 			if [[ $answer -eq 1 ]]; then
 				for optdep in "${optdeps[@]}"; do
@@ -281,7 +281,7 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" > /dev/null
 	fi
 	export PACSTALL_INSTALL=1
 
-	sub_message "Installing required dependencies"
+	sub_message "Required dependencies"
 	# --allow-downgrades is to allow git packages to "downgrade", because the commits aren't necessarily a higher number than the last version
 	if ! sudo --preserve-env=PACSTALL_INSTALL apt-get install "$SRCDIR/$name-pacstall.deb" -y --allow-downgrades 2> /dev/null; then
 		fancy_message error "Failed to install dependencies"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -179,7 +179,9 @@ function makeVirtualDeb {
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
 			sub_message "Optional dependencies"
 			printf '		%s\n' "${optdeps[@]}"
-			ask "Do you want to install them" Y
+			# tab over the next line
+			echo -ne "\t"
+			ask "Do you want to install optional dependencies" Y
 			if [[ $answer -eq 1 ]]; then
 				for optdep in "${optdeps[@]}"; do
 					deps+=" ${optdep%%: *}"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -177,7 +177,7 @@ function makeVirtualDeb {
 		fancy_message info "Installing dependencies"
 
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
-			sub_message "Optional dependencies"
+			fancy_message sub "Optional dependencies"
 			for i in "${optdeps[@]}"; do
 				echo -e "\t\t${BOLD}${i%%:*}${NC}:${i#*:}"
 			done
@@ -284,7 +284,7 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" > /dev/null
 	fi
 	export PACSTALL_INSTALL=1
 
-	sub_message "Required dependencies"
+	fancy_message sub "Required dependencies"
 	# --allow-downgrades is to allow git packages to "downgrade", because the commits aren't necessarily a higher number than the last version
 	if ! sudo --preserve-env=PACSTALL_INSTALL apt-get install "$SRCDIR/$name-pacstall.deb" -y --allow-downgrades 2> /dev/null; then
 		fancy_message error "Failed to install dependencies"
@@ -614,7 +614,7 @@ export srcdir="$PWD"
 sudo chown -R "$PACSTALL_USER":"$PACSTALL_USER" . 2> /dev/null
 
 export pkgdir="/usr/src/pacstall/$name"
-export -f ask fancy_message sub_message
+export -f ask fancy_message
 
 # Trap so that we can clean up (hopefully without messing up anything)
 trap cleanup ERR
@@ -622,11 +622,11 @@ trap - SIGINT
 
 fancy_message info "Running functions"
 bash -ceuo pipefail 'source "$pacfile";
-sub_message "prepare";
+fancy_message sub "prepare";
 echo "prepare" > /tmp/pacstall-func
-prepare; sub_message "build"
+prepare; fancy_message sub "build"
 echo "build" > /tmp/pacstall-func
-build; sub_message "install"
+build; fancy_message sub "install"
 echo "install" > /tmp/pacstall-func
 install' || {
 	error_log 5 "$(< "/tmp/pacstall-func") $PACKAGE"
@@ -703,7 +703,7 @@ if type -t postinst > /dev/null 2>&1; then
 fi
 
 fancy_message info "Performing post install operations"
-sub_message "Storing pacscript"
+fancy_message sub "Storing pacscript"
 sudo mkdir -p /var/cache/pacstall/"$PACKAGE"/"$version"
 if ! cd "$DIR" 2> /dev/null; then
 	error_log 1 "install $PACKAGE"
@@ -717,7 +717,7 @@ fi
 sudo cp -r "$PACKAGE".pacscript /var/cache/pacstall/"$PACKAGE"/"$version"
 sudo chmod o+r /var/cache/pacstall/"$PACKAGE"/"$version"/"$PACKAGE".pacscript
 
-sub_message "Cleaning up"
+fancy_message sub "Cleaning up"
 cleanup
 return 0
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -610,7 +610,7 @@ export srcdir="$PWD"
 sudo chown -R "$PACSTALL_USER":"$PACSTALL_USER" . 2> /dev/null
 
 export pkgdir="/usr/src/pacstall/$name"
-export -f ask fancy_message
+export -f ask fancy_message sub_message
 
 # Trap so that we can clean up (hopefully without messing up anything)
 trap cleanup ERR

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -288,6 +288,7 @@ fi' | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/postrm" > /dev/null
 	fancy_message sub "Required dependencies"
 	# --allow-downgrades is to allow git packages to "downgrade", because the commits aren't necessarily a higher number than the last version
 	if ! sudo --preserve-env=PACSTALL_INSTALL apt-get install "$SRCDIR/$name-pacstall.deb" -y --allow-downgrades 2> /dev/null; then
+		echo -ne "\t"
 		fancy_message error "Failed to install dependencies"
 		error_log 8 "install $PACKAGE"
 		sudo dpkg -r --force-all "$name" > /dev/null

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -178,7 +178,9 @@ function makeVirtualDeb {
 
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
 			sub_message "Optional dependencies"
-			printf '		%s\n' "${optdeps[@]}"
+			for i in "${optdeps[@]}"; do
+				printf '		%s\n' "${BOLD}${i%%: *}: ${i#*:}${NC}"
+			done
 			# tab over the next line
 			echo -ne "\t"
 			ask "Do you want to install the optional dependencies" Y

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -178,8 +178,7 @@ function makeVirtualDeb {
 
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
 			sub_message "Optional dependencies"
-			echo -e "\t\t$name has optional dependencies that can enhance its functionalities"
-			printf '			%s\n' "${optdeps[@]}"
+			printf '		%s\n' "${optdeps[@]}"
 			ask "Do you want to install them" Y
 			if [[ $answer -eq 1 ]]; then
 				for optdep in "${optdeps[@]}"; do

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -252,6 +252,7 @@ function fancy_message() {
 		info) echo -e "[${BOLD}+${NC}] INFO: ${MESSAGE}";;
 		warn) echo -e "[${BOLD}*${NC}] WARNING: ${MESSAGE}";;
 		error) echo -e "[${BOLD}!${NC}] ERROR: ${MESSAGE}";;
+		sub) echo -e "\t[${BOLD}>${NC}] ${MESSAGE}" ;;
 		*) echo -e "[${BOLD}?${NORMAL}] UNKNOWN: ${MESSAGE}";;
 	esac
 }

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -181,7 +181,7 @@ function makeVirtualDeb {
 			printf '		%s\n' "${optdeps[@]}"
 			# tab over the next line
 			echo -ne "\t"
-			ask "Do you want to install optional dependencies" Y
+			ask "Do you want to install the optional dependencies" Y
 			if [[ $answer -eq 1 ]]; then
 				for optdep in "${optdeps[@]}"; do
 					deps+=" ${optdep%%: *}"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -179,7 +179,7 @@ function makeVirtualDeb {
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
 			sub_message "Optional dependencies"
 			for i in "${optdeps[@]}"; do
-				echo -e "\t\t${BOLD}${i%%:*}: ${i#*:}${NC}"
+				echo -e "\t\t${BOLD}${i%%:*}${NC}: ${i#*:}"
 			done
 			# tab over the next line
 			echo -ne "\t"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -142,7 +142,8 @@ function log() {
 function makeVirtualDeb {
 	# creates empty .deb package (with only the control file) for apt integration
 	# implements $(gives) variable
-	fancy_message info "Creating dummy package"
+	fancy_message info "Preparing package"
+	sub_message "Creating dummy package"
 	sudo mkdir -p "$SRCDIR/$name-pacstall/DEBIAN"
 	printf "Package: %s\n" "$name" | sudo tee "$SRCDIR/$name-pacstall/DEBIAN/control" > /dev/null
 
@@ -175,7 +176,7 @@ function makeVirtualDeb {
 		done
 
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
-			fancy_message info "$name has optional dependencies that can enhance its functionalities"
+			sub_message "$name has optional dependencies that can enhance its functionalities"
 			echo "Optional dependencies:"
 			printf '    %s\n' "${optdeps[@]}"
 			ask "Do you want to install them" Y
@@ -615,12 +616,13 @@ export -f ask fancy_message
 trap cleanup ERR
 trap - SIGINT
 
+fancy_message info "Running functions"
 bash -ceuo pipefail 'source "$pacfile";
-fancy_message info "Preparing";
+sub_message "prepare";
 echo "prepare" > /tmp/pacstall-func
-prepare; fancy_message info "Building"
+prepare; sub_message "build"
 echo "build" > /tmp/pacstall-func
-build; fancy_message info "Installing"
+build; sub_message "install"
 echo "install" > /tmp/pacstall-func
 install' || {
 	error_log 5 "$(< "/tmp/pacstall-func") $PACKAGE"
@@ -696,7 +698,8 @@ if type -t postinst > /dev/null 2>&1; then
 	}
 fi
 
-fancy_message info "Storing pacscript"
+fancy_message info "Performing post install operations"
+sub_message "Storing pacscript"
 sudo mkdir -p /var/cache/pacstall/"$PACKAGE"/"$version"
 if ! cd "$DIR" 2> /dev/null; then
 	error_log 1 "install $PACKAGE"
@@ -710,7 +713,7 @@ fi
 sudo cp -r "$PACKAGE".pacscript /var/cache/pacstall/"$PACKAGE"/"$version"
 sudo chmod o+r /var/cache/pacstall/"$PACKAGE"/"$version"/"$PACKAGE".pacscript
 
-fancy_message info "Cleaning up"
+sub_message "Cleaning up"
 cleanup
 return 0
 

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -105,7 +105,7 @@ case "$url" in
 			exit 1
 		fi
 
-		sub_message "Removing apt pin"
+		fancy_message sub "Removing apt pin"
 		sudo rm -f /etc/apt/preferences.d/"${name}-pin"
 
 		sudo rm -f "$LOGDIR/$PACKAGE"

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -77,7 +77,7 @@ case "$url" in
 		fancy_message info "Removing symlinks"
 		sudo stow --target="/" -D "$PACKAGE"
 
-		fancy_message info "Removing package"
+		fancy_message info "Removing package directory"
 		sudo rm -rf "$PACKAGE"
 		# Update PATH database
 		hash -r
@@ -104,6 +104,8 @@ case "$url" in
 			error_log 1 "remove $PACKAGE"
 			exit 1
 		fi
+
+		sub_message "Removing apt pin"
 		sudo rm -f /etc/apt/preferences.d/"${name}-pin"
 
 		sudo rm -f "$LOGDIR/$PACKAGE"

--- a/pacstall
+++ b/pacstall
@@ -127,6 +127,11 @@ function fancy_message() {
 	esac
 }
 
+function sub_message() {
+	local MESSAGE="${1}"
+	echo -e "\t[${BBlue}>${NC}]: $MESSAGE"
+}
+
 # This is the ask function. You can source this code block and then run something like:
 # ask "Do you like the color blue? " Y
 # if [[ $answer -eq 1 ]]; then

--- a/pacstall
+++ b/pacstall
@@ -123,13 +123,9 @@ function fancy_message() {
 		info) echo -e "[${BGreen}+${NC}] INFO: ${MESSAGE}" ;;
 		warn) echo >&2 -e "[${BYellow}*${NC}] WARNING: ${MESSAGE}" ;;
 		error) echo >&2 -e "[${BRed}!${NC}] ERROR: ${MESSAGE}" ;;
+		sub) echo -e "\t[${BBlue}>${NC}] ${MESSAGE}" ;;
 		*) echo >&2 -e "[${BOLD}?${NORMAL}] UNKNOWN: ${MESSAGE}" ;;
 	esac
-}
-
-function sub_message() {
-	local MESSAGE="${1}"
-	echo -e "\t[${BBlue}>${NC}] $MESSAGE"
 }
 
 # This is the ask function. You can source this code block and then run something like:

--- a/pacstall
+++ b/pacstall
@@ -114,7 +114,7 @@ export On_IWhite='\033[0;107m'  # White
 # fancy_message allows visually appealing output.
 # Source the code block and run:
 #
-# `fancy_message {info,warn,error} "What you want to say"`
+# `fancy_message {info,warn,error,sub} "What you want to say"`
 function fancy_message() {
 	local MESSAGE_TYPE="${1}"
 	local MESSAGE="${2}"

--- a/pacstall
+++ b/pacstall
@@ -129,7 +129,7 @@ function fancy_message() {
 
 function sub_message() {
 	local MESSAGE="${1}"
-	echo -e "\t[${BBlue}>${NC}]: $MESSAGE"
+	echo -e "\t[${BBlue}>${NC}] $MESSAGE"
 }
 
 # This is the ask function. You can source this code block and then run something like:


### PR DESCRIPTION
## Purpose

Currently `fancy_message` can get very hard to read very fast. This PR will split up a couple previous `fancy_message`s into a submenu styled approach.

## Screenshots
![image](https://user-images.githubusercontent.com/58742515/183452364-fc319525-e19a-4107-ab13-e2e5b27c4cec.png)
![image](https://user-images.githubusercontent.com/58742515/183452385-5208e53b-131a-44ab-b695-39fa05b329f4.png)

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.

## Credits
@wizard-28 for helping design the UI