### PR TITLE
feat(install-local): warn user if optdepend does not exist in repos

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -165,6 +165,11 @@ function makeVirtualDeb {
 		local optdeps=()
 		for optdep in "${optdepends[@]}"; do
 			local opt=${optdep%%: *}
+			# Check if package exists in the repos, and if not, go to the next program
+			if [[ -z "$(apt-cache search --names-only "^$opt\$")" ]]; then
+				fancy_message warn "${BLUE}$opt${NC} does not exist in apt repositories"
+				continue
+			fi
 			# Add to the dependency list if already installed so it doesn't get autoremoved on upgrade
 			# Add to the optdeps list if not to display the question
 			if ! dpkg-query -W -f='${Status}' "${opt}" 2> /dev/null | grep "^install ok installed" > /dev/null 2>&1; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -167,7 +167,7 @@ function makeVirtualDeb {
 			local opt=${optdep%%: *}
 			# Check if package exists in the repos, and if not, go to the next program
 			if [[ -z "$(apt-cache search --names-only "^$opt\$")" ]]; then
-				missing_optdeps+="\t$(fancy_message warn "${BLUE}$opt${NC} does not exist in apt repositories")"
+				missing_optdeps+=("${opt}")
 				continue
 			fi
 			# Add to the dependency list if already installed so it doesn't get autoremoved on upgrade
@@ -183,8 +183,10 @@ function makeVirtualDeb {
 
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
 			fancy_message sub "Optional dependencies"
-			if [[ -n ${missing_optdeps} ]]; then
-				printf '%s\n' "${missing_optdeps}"
+			if [[ -n ${missing_optdeps[*]} ]]; then
+				for i in "${missing_optdeps[@]}"; do
+					fancy_message warn "${BLUE}$i${NC} does not exist in apt repositories"
+				done
 			fi
 			for i in "${optdeps[@]}"; do
 				# print optdepends with bold package name

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -167,7 +167,7 @@ function makeVirtualDeb {
 			local opt=${optdep%%: *}
 			# Check if package exists in the repos, and if not, go to the next program
 			if [[ -z "$(apt-cache search --names-only "^$opt\$")" ]]; then
-				fancy_message warn "${BLUE}$opt${NC} does not exist in apt repositories"
+				missing_optdeps+="\t$(fancy_message warn "${BLUE}$opt${NC} does not exist in apt repositories")"
 				continue
 			fi
 			# Add to the dependency list if already installed so it doesn't get autoremoved on upgrade
@@ -183,7 +183,11 @@ function makeVirtualDeb {
 
 		if [[ ${#optdeps[@]} -ne 0 ]]; then
 			fancy_message sub "Optional dependencies"
+			if [[ -n ${missing_optdeps} ]]; then
+				printf '%s\n' "${missing_optdeps}"
+			fi
 			for i in "${optdeps[@]}"; do
+				# print optdepends with bold package name
 				echo -e "\t\t${BOLD}${i%%:*}${NC}:${i#*:}"
 			done
 			# tab over the next line

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -185,6 +185,7 @@ function makeVirtualDeb {
 			fancy_message sub "Optional dependencies"
 			if [[ -n ${missing_optdeps[*]} ]]; then
 				for i in "${missing_optdeps[@]}"; do
+					echo -e "\t"
 					fancy_message warn "${BLUE}$i${NC} does not exist in apt repositories"
 				done
 			fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -185,7 +185,7 @@ function makeVirtualDeb {
 			fancy_message sub "Optional dependencies"
 			if [[ -n ${missing_optdeps[*]} ]]; then
 				for i in "${missing_optdeps[@]}"; do
-					echo -e "\t"
+					echo -ne "\t"
 					fancy_message warn "${BLUE}$i${NC} does not exist in apt repositories"
 				done
 			fi


### PR DESCRIPTION
## Purpose

Currently, if an `optdepends` array contains an invalid package name, Pacstall will attempt to install it if the user confirms they want to install `optdepends`. This PR will make Pacstall check for the existence of all the `optdepends` before presenting the user with the choice to install them, and will filter out and warn the user of any incorrect packages.

## Approach

Use `apt-cache search` to confirm package existence. 

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
