### PR TITLE
feat(install-local): show pretty index of optdepends

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -192,7 +192,7 @@ function makeVirtualDeb {
 			z=1
 			for i in "${optdeps[@]}"; do
 				# print optdepends with bold package name
-				echo -e "\t\t[${BIBlue}$z${NC}] ${BOLD}${i%%:*}${NC}:${i#*:}"
+				echo -e "\t\t[${BICyan}$z${NC}] ${BOLD}${i%%:*}${NC}:${i#*:}"
 				(( z++ ))
 			done
 			unset z

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -189,10 +189,13 @@ function makeVirtualDeb {
 					fancy_message warn "${BLUE}$i${NC} does not exist in apt repositories"
 				done
 			fi
+			z=0
 			for i in "${optdeps[@]}"; do
 				# print optdepends with bold package name
-				echo -e "\t\t${BOLD}${i%%:*}${NC}:${i#*:}"
+				echo -e "\t\t[${BIBlue}$z${NC}] ${BOLD}${i%%:*}${NC}:${i#*:}"
+				(( z++ ))
 			done
+			unset z
 			# tab over the next line
 			echo -ne "\t"
 			ask "Do you want to install the optional dependencies" Y

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -189,7 +189,7 @@ function makeVirtualDeb {
 					fancy_message warn "${BLUE}$i${NC} does not exist in apt repositories"
 				done
 			fi
-			z=0
+			z=1
 			for i in "${optdeps[@]}"; do
 				# print optdepends with bold package name
 				echo -e "\t\t[${BIBlue}$z${NC}] ${BOLD}${i%%:*}${NC}:${i#*:}"


### PR DESCRIPTION
## Purpose

Showing the index of each optdepend looks very visually appealing and can make it easier to differentiate between lines (maybe it's my dyslexia, who knows). 

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.

## Screenshots
![image](https://user-images.githubusercontent.com/58742515/184133717-44b5feb1-72e8-4102-882d-07e750378268.png)
![image](https://user-images.githubusercontent.com/58742515/184133762-be1c88dd-39b6-484f-b505-8dce5c3813fa.png)