### PR TITLE
feat(optdepends): add array selection

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -59,7 +59,12 @@ function select_options() {
 	rm -f /tmp/pacstall-select-options
 	local message="${1}"
 	local length="${2}"
-	echo -ne "${message} [${BOLD}$( seq -s ' ' 1 "$length" )${NC}] [${BIGreen}Y${NC}/${RED}n${NC}] "
+
+	if [[ $length -ge 6 ]]; then
+		echo -ne "${message} [${BOLD}1..$length${NC}] [${BIGreen}Y${NC}/${RED}n${NC}] "
+	else
+		echo -ne "${message} [${BOLD}$( seq -s ' ' 1 "$length" )${NC}] [${BIGreen}Y${NC}/${RED}n${NC}] "
+	fi
 	if [[ -z $DISABLE_PROMPTS ]]; then
 		read -r input <&0
 		if [[ $NON_INTERACTIVE ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -679,7 +679,7 @@ export srcdir="$PWD"
 sudo chown -R "$PACSTALL_USER":"$PACSTALL_USER" . 2> /dev/null
 
 export pkgdir="/usr/src/pacstall/$name"
-export -f ask fancy_message
+export -f ask fancy_message select_options
 
 # Trap so that we can clean up (hopefully without messing up anything)
 trap cleanup ERR

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -59,7 +59,7 @@ function select_options() {
 	rm -f /tmp/pacstall-select-options
 	local message="${1}"
 	local length="${2}"
-	echo -ne "${message} [$( seq -s ' ' 1 "$length" )] [${BIGreen}Y${NC}/${RED}n${NC}] "
+	echo -ne "${message} [${BOLD}$( seq -s ' ' 1 "$length" )${NC}] [${BIGreen}Y${NC}/${RED}n${NC}] "
 	if [[ -z $DISABLE_PROMPTS ]]; then
 		read -r input <&0
 		if [[ $NON_INTERACTIVE ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -77,7 +77,16 @@ function select_options() {
 	elif [[ $input =~ ^[Nn]$ ]]; then
 		echo "n" | tee /tmp/pacstall-select-options >/dev/null
 	elif ! [[ $input =~ [a-zA-Z]+ ]] || [[ $input =~ ^[0-9]+$ ]]; then
-		echo "$input" | tee /tmp/pacstall-select-options >/dev/null
+		for i in "${input[@]}"; do
+			if [[ $i =~ [0-9]+-[0-9]+ ]]; then
+				split_arr=(${i//-/ })
+				out+=( $(seq -s ' ' "${split_arr[0]}" "${split_arr[1]}") )
+				continue
+			else
+				out+=($i)
+			fi
+		done
+		echo "${out[@]}" | tee /tmp/pacstall-select-options >/dev/null
 	else
 		select_options "$message" "$length"
 	fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -55,6 +55,9 @@ function trap_ctrlc() {
 	exit 1
 }
 
+# source this code block and run like so:
+# 	$ select_options "My message I want to send" "${#array[@]}"
+# This will then output the options given by the user to /tmp/pacstall-select-options, which you can then turn into another array
 function select_options() {
 	rm -f /tmp/pacstall-select-options
 	local message="${1}"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -55,50 +55,6 @@ function trap_ctrlc() {
 	exit 1
 }
 
-# source this code block and run like so:
-# 	$ select_options "My message I want to send" "${#array[@]}"
-# This will then output the options given by the user to /tmp/pacstall-select-options, which you can then turn into another array
-function select_options() {
-	rm -f /tmp/pacstall-select-options
-	local message="${1}"
-	local length="${2}"
-
-	if [[ $length -ge 6 ]]; then
-		echo -ne "${message} [${BOLD}1..$length${NC}] [${BIGreen}Y${NC}/${RED}n${NC}] "
-	else
-		echo -ne "${message} [${BOLD}$( seq -s ' ' 1 "$length" )${NC}] [${BIGreen}Y${NC}/${RED}n${NC}] "
-	fi
-	if [[ -z $DISABLE_PROMPTS ]]; then
-		read -r input <&0
-		if [[ $NON_INTERACTIVE ]]; then
-			if [[ -z $input ]]; then
-				echo "Y"
-			fi
-			echo "$input"
-		fi
-	else
-		echo "Y"
-		input="Y"
-	fi
-	if [[ -z $input ]] || [[ $input =~ ^[Yy]$ ]]; then
-		seq -s ' ' 1 "$length" | tee /tmp/pacstall-select-options >/dev/null
-	elif [[ $input =~ ^[Nn]$ ]]; then
-		echo "n" | tee /tmp/pacstall-select-options >/dev/null
-	elif ! [[ $input =~ [a-zA-Z]+ ]] || [[ $input =~ ^[0-9]+$ ]]; then
-		for i in "${input[@]}"; do
-			if [[ $i =~ [0-9]+-[0-9]+ ]]; then
-				split_arr=(${i//-/ })
-				out+=( $(seq -s ' ' "${split_arr[0]}" "${split_arr[1]}") )
-				continue
-			else
-				out+=($i)
-			fi
-		done
-		echo "${out[@]}" | tee /tmp/pacstall-select-options >/dev/null
-	else
-		select_options "$message" "$length"
-	fi
-}
 
 # run checks to verify script works
 function checks() {

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -233,7 +233,9 @@ function makeVirtualDeb {
 				for i in "${choices[@]}"; do
 					(( i-- ))
 					s="${optdeps[$i]}"
-					deps+=" ${s%%: *}"
+					if [[ -n $s ]]; then
+						deps+=" ${s%%: *}"
+					fi
 				done
 				if pacstall -L | grep -E "(^| )${name}( |$)" > /dev/null 2>&1; then
 					sudo dpkg -r --force-all "$name" > /dev/null

--- a/pacstall
+++ b/pacstall
@@ -194,6 +194,7 @@ function ask() {
 		esac
 	done
 }
+
 function check_url() {
 	if [[ ${1} == "file://"* ]]; then
 		if [[ -f ${1/"file://"/} ]]; then
@@ -269,8 +270,18 @@ function select_options() {
 		echo "n" | tee /tmp/pacstall-select-options >/dev/null
 	elif ! [[ $input =~ [a-zA-Z]+ ]] || [[ $input =~ ^[0-9]+$ ]]; then
 		for i in "${input[@]}"; do
-			if [[ $i =~ [0-9]+-[0-9]+ ]]; then
-				split_arr=(${i//-/ })
+			if [[ $i =~ [0-9]+-[0-9]+ ]] || [[ $i =~ [0-9]+..[0-9]+ ]]; then
+				case "$i" in
+					-)
+						split_arr=(${i//-/ })
+						;;
+					*..*)
+						split_arr=(${i//../ })
+						;;
+					*)
+						select_options "$message" "$length"
+						;;
+				esac
 				out+=( $(seq -s ' ' "${split_arr[0]}" "${split_arr[1]}") )
 				continue
 			else

--- a/pacstall
+++ b/pacstall
@@ -238,6 +238,51 @@ function download() {
 	fi
 }
 
+# source this code block and run like so:
+# 	$ select_options "My message I want to send" "${#array[@]}"
+# This will then output the options given by the user to /tmp/pacstall-select-options, which you can then turn into another array
+function select_options() {
+	rm -f /tmp/pacstall-select-options
+	local message="${1}"
+	local length="${2}"
+
+	if [[ $length -ge 6 ]]; then
+		echo -ne "${message} [${BOLD}1..$length${NC}] [${BIGreen}Y${NC}/${RED}n${NC}] "
+	else
+		echo -ne "${message} [${BOLD}$( seq -s ' ' 1 "$length" )${NC}] [${BIGreen}Y${NC}/${RED}n${NC}] "
+	fi
+	if [[ -z $DISABLE_PROMPTS ]]; then
+		read -r input <&0
+		if [[ $NON_INTERACTIVE ]]; then
+			if [[ -z $input ]]; then
+				echo "Y"
+			fi
+			echo "$input"
+		fi
+	else
+		echo "Y"
+		input="Y"
+	fi
+	if [[ -z $input ]] || [[ $input =~ ^[Yy]$ ]]; then
+		seq -s ' ' 1 "$length" | tee /tmp/pacstall-select-options >/dev/null
+	elif [[ $input =~ ^[Nn]$ ]]; then
+		echo "n" | tee /tmp/pacstall-select-options >/dev/null
+	elif ! [[ $input =~ [a-zA-Z]+ ]] || [[ $input =~ ^[0-9]+$ ]]; then
+		for i in "${input[@]}"; do
+			if [[ $i =~ [0-9]+-[0-9]+ ]]; then
+				split_arr=(${i//-/ })
+				out+=( $(seq -s ' ' "${split_arr[0]}" "${split_arr[1]}") )
+				continue
+			else
+				out+=($i)
+			fi
+		done
+		echo "${out[@]}" | tee /tmp/pacstall-select-options >/dev/null
+	else
+		select_options "$message" "$length"
+	fi
+}
+
 # Error out when run as root
 if [[ $EUID -eq 0 ]]; then
 	fancy_message error "Pacstall can't be run as root. Please run as a normal user."

--- a/pacstall
+++ b/pacstall
@@ -272,7 +272,7 @@ function select_options() {
 		for i in "${input[@]}"; do
 			if [[ $i =~ [0-9]+-[0-9]+ ]] || [[ $i =~ [0-9]+..[0-9]+ ]]; then
 				case "$i" in
-					-)
+					*-*)
 						split_arr=(${i//-/ })
 						;;
 					*..*)


### PR DESCRIPTION
## Purpose

Currently, `optdepends` can either be entirely selected or entirely deselected, leaving the user with no choice of what optional dependencies they want to install.

## Approach

Create a prompt that will ask the user which `optdepends` they want to install, or choosing ranges (`2-5`), while also keeping `Y` and `N` options as to select everything or nothing.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.

## Screenshots
##### Using `-P`
![image](https://user-images.githubusercontent.com/58742515/184552354-ada4ca67-afc7-41c0-97d1-995569b81cbb.png)
##### Selecting deps
![image](https://user-images.githubusercontent.com/58742515/184552379-36ccccb0-ca30-4171-a73d-3a87ecd7a981.png)
##### None
![image](https://user-images.githubusercontent.com/58742515/184552413-6b3a619e-819e-44fa-87e7-dff2465c1bbc.png)
##### Input as non-numbers
![image](https://user-images.githubusercontent.com/58742515/184552484-eea92786-870e-4167-8e99-13bd4a7257b6.png)
##### Ranges
![image](https://user-images.githubusercontent.com/58742515/185001173-19d31906-3656-4f18-9523-a4286153cb9a.png)