### PR TITLE
Add code for python list command & list package version

### DIFF
--- a/pacstall/cmds/list.py
+++ b/pacstall/cmds/list.py
@@ -4,6 +4,28 @@
 #  / ____/ /_/ / /__(__  ) /_/ /_/ / / /
 # /_/    \__,_/\___/____/\__/\__,_/_/_/
 #
+# Copyright (C) 2020-2021
+#
+# This file is part of Pacstall
+#
+# Pacstall is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3 of the License
+#
+# Pacstall is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
+
+#     ____                  __        ____
+#    / __ \____ ___________/ /_____ _/ / /
+#   / /_/ / __ `/ ___/ ___/ __/ __ `/ / /
+#  / ____/ /_/ / /__(__  ) /_/ /_/ / / /
+# /_/    \__,_/\___/____/\__/\__,_/_/_/
+#
 # Copyright (C) 2020-2022
 #
 # This file is part of Pacstall


### PR DESCRIPTION
## Purpose

This adds the `list` function to the Python Rewrite (#340).  It essentially works the same way as the list function in the script by listing the files in the metadata directory.

## Approach

It also adds version information to the list.  It opens the metadata files to parse the version information.  Other information from the metadata files could be added as need.

## Progress

This is complete, but could be modified if there is something that needs to be added.


## Addendum

Note the `list()` function overwrites the built-in Python `list` function.  This is not a good practice.  I'm not really familiar enough with `typer` to know how to correct this.   Perhaps a comment in the code could draw attention to this for someone to fix it later.

Here's the comparison of pacstall (shell) and Python pacstall output on my computer:

pacstall (shell)
```
❯ pacstall --list
bat
brave-browser-deb
brave-keyring-deb
micro
nodejs-lts-deb
starship-bin
```

pacstall (Python)  Note: I don't have this installed so I had to modify how I executed this:
```
❯ python3 -m pacstall list 
bat, 0.19.0
brave-browser-deb, 1.41.96
brave-keyring-deb, 1.13-1
micro, 2.0.10
nodejs-lts-deb, 16.15.0
starship-bin, 1.9.1
```

## Checklist

- [ x ] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
