### PR TITLE
fix: relation with pacdeps

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -134,6 +134,9 @@ function log() {
 			echo "_remotebranch=\"$pBRANCH"\"
 		fi
 	fi
+	if [[ -n "${pacdeps[*]}" ]]; then
+		echo "_pacdeps=(${pacdeps[@]})"
+	fi
 	} | sudo tee "$LOGDIR/$name" > /dev/null
 }
 

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -28,6 +28,16 @@ source "$LOGDIR/$PACKAGE" || {
 	exit 1
 }
 
+if [[ -n "${_pacdeps[*]}" ]]; then
+	for i in "${_pacdeps[@]}"; do
+		pacstall -R "$i" || {
+				fancy_message error "Failed to remove $PACKAGE"
+				error_log 3 "remove $PACKAGE"
+				exit 1
+		}
+	done
+fi
+
 if ! dpkg -l "${_gives:-$_name}" &>/dev/null; then
 	fancy_message error "$PACKAGE is not installed"
 	error_log 3 "remove $PACKAGE"


### PR DESCRIPTION
## Purpose

Currently `pacdeps` has no relation to their parent packages. This PR will give at least *some* form of relationship, allowing the removal of pacdeps with their parent packages. I will make a PR later that will put pacdeps into `Depends` of the parent package, but for now, this will work.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
