### PR TITLE
fix(build_depends): remove packages from installation by full name

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -584,8 +584,16 @@ fi
 build_depends=($build_depends)
 for build_dep in "${build_depends[@]}"; do
     if dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null | grep "^install ok installed" > /dev/null 2>&1; then
-        build_depends=("${build_depends[@]}/$build_dep")
+		build_depends_to_delete+=("${build_dep}")
     fi
+done
+
+for target in "${build_depends_to_delete[@]}"; do
+	for i in "${!build_depends[@]}"; do
+		if [[ ${build_depends[i]} == "$target" ]]; then
+			unset 'build_depends[i]'
+		fi
+	done
 done
 
 # This echo makes it ignore empty strigs

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -583,7 +583,7 @@ fi
 # Get all uninstalled build depends
 for build_dep in $build_depends; do
     if dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null | grep "^install ok installed" > /dev/null 2>&1; then
-        build_depends=${build_depends/"${build_dep}"/}
+        build_depends=${build_depends/ "${build_dep}" /}
     fi
 done
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -584,7 +584,7 @@ fi
 build_depends=($build_depends)
 for build_dep in "${build_depends[@]}"; do
     if dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null | grep "^install ok installed" > /dev/null 2>&1; then
-        build_depends=("${build_depends[@]}/$build_dep}")
+        build_depends=("${build_depends[@]}/$build_dep")
     fi
 done
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -253,7 +253,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (   
+                (
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -290,7 +290,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (   
+    (
         # create control.tar
         cd DEBIAN
         for i in *; do

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -581,17 +581,16 @@ if ! pacstall -L | grep -E "(^| )${name}( |$)" > /dev/null 2>&1; then
 fi
 
 # Get all uninstalled build depends
-for build_dep in $build_depends; do
+build_depends=($build_depends)
+for build_dep in "${build_depends[@]}"; do
     if dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null | grep "^install ok installed" > /dev/null 2>&1; then
-        build_depends=${build_depends/ "${build_dep}" /}
+		build_depends=( "${build_depends[@]}/$build_dep}" )
     fi
 done
 
-build_depends=$(echo "$build_depends" | tr -s ' ' | awk '{gsub(/^ +| +$/,"")} {print $0}')
-
 # This echo makes it ignore empty strigs
-if [[ -n $build_depends ]]; then
-    fancy_message info "${BLUE}$name${NC} requires ${CYAN}$(echo -e "$build_depends")${NC} to install"
+if [[ -n ${build_depends[*]} ]]; then
+    fancy_message info "${BLUE}$name${NC} requires ${CYAN}$(echo -e "${build_depends[*]}")${NC} to install"
     ask "Do you want to remove them after installing ${BLUE}$name${NC}" N
     if [[ $answer -eq 0 ]]; then
         NOBUILDDEP=0
@@ -599,7 +598,7 @@ if [[ -n $build_depends ]]; then
         NOBUILDDEP=1
     fi
 
-    if ! sudo apt-get install -y -qq -o=Dpkg::Use-Pty=0 $build_depends; then
+    if ! sudo apt-get install -y -qq -o=Dpkg::Use-Pty=0 ${build_depends[*]}; then
         fancy_message error "Failed to install build dependencies"
         error_log 8 "install $PACKAGE"
         fancy_message info "Cleaning up"
@@ -812,7 +811,7 @@ trap - ERR
 if [[ $NOBUILDDEP -eq 1 ]]; then
     fancy_message info "Purging build dependencies"
     # shellcheck disable=2086
-    sudo apt-get purge --auto-remove -y $build_depends
+    sudo apt-get purge --auto-remove -y ${build_depends[*]}
 fi
 
 cd "$HOME" 2> /dev/null || (

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -253,7 +253,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (
+                (   
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -290,7 +290,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (
+    (   
         # create control.tar
         cd DEBIAN
         for i in *; do
@@ -584,7 +584,7 @@ fi
 build_depends=($build_depends)
 for build_dep in "${build_depends[@]}"; do
     if dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null | grep "^install ok installed" > /dev/null 2>&1; then
-		build_depends=( "${build_depends[@]}/$build_dep}" )
+        build_depends=("${build_depends[@]}/$build_dep}")
     fi
 done
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -597,20 +597,22 @@ if [[ -n ${build_depends[*]} ]]; then
         done
     done
 
-    fancy_message info "${BLUE}$name${NC} requires ${CYAN}$(echo -e "${build_depends[*]}")${NC} to install"
-    ask "Do you want to remove them after installing ${BLUE}$name${NC}" N
-    if [[ $answer -eq 0 ]]; then
-        NOBUILDDEP=0
-    else
-        NOBUILDDEP=1
-    fi
+    if [[ ${#build_depends[@]} -ne 0 ]]; then
+        fancy_message info "${BLUE}$name${NC} requires ${CYAN}$(echo -e "${build_depends[*]}")${NC} to install"
+        ask "Do you want to remove them after installing ${BLUE}$name${NC}" N
+        if [[ $answer -eq 0 ]]; then
+            NOBUILDDEP=0
+        else
+            NOBUILDDEP=1
+        fi
 
-    if ! sudo apt-get install -y -qq -o=Dpkg::Use-Pty=0 ${build_depends[*]}; then
-        fancy_message error "Failed to install build dependencies"
-        error_log 8 "install $PACKAGE"
-        fancy_message info "Cleaning up"
-        cleanup
-        return 1
+        if ! sudo apt-get install -y -qq -o=Dpkg::Use-Pty=0 ${build_depends[*]}; then
+            fancy_message error "Failed to install build dependencies"
+            error_log 8 "install $PACKAGE"
+            fancy_message info "Cleaning up"
+            cleanup
+            return 1
+        fi
     fi
 fi
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -253,7 +253,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (
+                (   
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -290,7 +290,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (
+    (   
         # create control.tar
         cd DEBIAN
         for i in *; do
@@ -580,24 +580,23 @@ if ! pacstall -L | grep -E "(^| )${name}( |$)" > /dev/null 2>&1; then
     fi
 fi
 
-# Get all uninstalled build depends
-build_depends=($build_depends)
-for build_dep in "${build_depends[@]}"; do
-    if dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null | grep "^install ok installed" > /dev/null 2>&1; then
-		build_depends_to_delete+=("${build_dep}")
-    fi
-done
-
-for target in "${build_depends_to_delete[@]}"; do
-	for i in "${!build_depends[@]}"; do
-		if [[ ${build_depends[i]} == "$target" ]]; then
-			unset 'build_depends[i]'
-		fi
-	done
-done
-
-# This echo makes it ignore empty strigs
 if [[ -n ${build_depends[*]} ]]; then
+    # Get all uninstalled build depends
+    build_depends=($build_depends)
+    for build_dep in "${build_depends[@]}"; do
+        if dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null | grep "^install ok installed" > /dev/null 2>&1; then
+            build_depends_to_delete+=("${build_dep}")
+        fi
+    done
+
+    for target in "${build_depends_to_delete[@]}"; do
+        for i in "${!build_depends[@]}"; do
+            if [[ ${build_depends[i]} == "$target" ]]; then
+                unset 'build_depends[i]'
+            fi
+        done
+    done
+
     fancy_message info "${BLUE}$name${NC} requires ${CYAN}$(echo -e "${build_depends[*]}")${NC} to install"
     ask "Do you want to remove them after installing ${BLUE}$name${NC}" N
     if [[ $answer -eq 0 ]]; then


### PR DESCRIPTION
## Purpose

Suppose you have the build dependencies `libdbus-1-dev dbus`, however dbus is already installed. Pacstall will go through and remove packages from `build_depends` based on if they are installed or not. So, Pacstall will try to remove `dbus` from the deps, as it's already installed, however it will try to remove the first time it sees the string `dbus`, instead of the package, so the final result is `lib-1-dev dbus`. This fix internally changes `build_depends` to an array and loops through it to remove already installed elements.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
