### PR TITLE
fix(suggests): include every optdepends

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -242,7 +242,7 @@ function prompt_optdepends() {
                 fi
             else
                 # Add to the suggests anyway. They won't get installed but can be queried
-                deblog "Suggests" "$(echo "${optdeps[@]}" | awk -F': ' '{print $1}' | tr '\n' ',' | head -c -1)"
+                deblog "Suggests" "$(echo "${optdeps[@]//:*/}" | sed 's/ /, /g')"
             fi
         fi
     fi


### PR DESCRIPTION
## Purpose

A bug that only includes the first optdepend in suggests.

## Fixed image
![image](https://user-images.githubusercontent.com/58742515/195210602-24a830db-573e-4868-833c-503cdda6f02b.png)
## Previous image
![image](https://user-images.githubusercontent.com/58742515/195210635-47b0660b-8d11-463a-a822-7495be6d2316.png)

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
