### PR TITLE
fix(prompt_optdepends): add guard to max optdepend

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -227,11 +227,15 @@ function prompt_optdepends() {
             for i in "${choices[@]}"; do
                 # have we gone over the maximum number in choices[@]?
                 if [[ $i -gt ${#optdeps[@]} ]]; then
-                    fancy_message warn "${BGreen}$i${NC} has exceeded the maximum number of optional dependencies. Skipping"
+                    local skip_opt+=("$i")
                     unset 'choices[$choice_inc]'
                 fi
                 ((choice_inc++))
             done
+            if [[ -n ${skip_opt[*]} ]]; then
+                fancy_message warn "${BGreen}${skip_opt[*]}${NC} has exceeded the maximum number of optional dependencies. Skipping"
+            fi
+
             if [[ ${choices[0]} != "n" ]]; then
                 for i in "${choices[@]}"; do
                     ((i--))
@@ -259,7 +263,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (
+                (   
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -296,7 +300,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (
+    (   
         # create control.tar
         cd DEBIAN
         for i in *; do

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -263,7 +263,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (   
+                (
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -300,7 +300,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (   
+    (
         # create control.tar
         cd DEBIAN
         for i in *; do

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -223,6 +223,15 @@ function prompt_optdepends() {
             echo -ne "\t"
             select_options "Select optional dependencies to install" "${#optdeps[@]}"
             choices=($(cat /tmp/pacstall-select-options))
+			local choice_inc=0
+			for i in "${choices[@]}"; do
+				# have we gone over the maximum number in choices[@]?
+				if [[ "$i" -gt "${#optdeps[@]}" ]]; then
+					fancy_message warn "$i has exceeded the maximum number of optional dependencies. Skipping"
+					unset 'choices[$choice_inc]'
+				fi
+				(( choice_inc++ ))
+			done
             if [[ ${choices[0]} != "n" ]]; then
                 for i in "${choices[@]}"; do
                     ((i--))

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -226,7 +226,7 @@ function prompt_optdepends() {
             local choice_inc=0
             for i in "${choices[@]}"; do
                 # have we gone over the maximum number in choices[@]?
-                if [[ $i -gt ${#optdeps[@]} ]] && [[ $i != "n" ]] && [[ $i != "y" ]]; then
+                if [[ $i != "n" ]] && [[ $i != "y" ]] && [[ $i -gt ${#optdeps[@]} ]]; then
                     local skip_opt+=("$i")
                     unset 'choices[$choice_inc]'
                 fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -259,7 +259,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (   
+                (
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -296,7 +296,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (   
+    (
         # create control.tar
         cd DEBIAN
         for i in *; do

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -223,15 +223,15 @@ function prompt_optdepends() {
             echo -ne "\t"
             select_options "Select optional dependencies to install" "${#optdeps[@]}"
             choices=($(cat /tmp/pacstall-select-options))
-			local choice_inc=0
-			for i in "${choices[@]}"; do
-				# have we gone over the maximum number in choices[@]?
-				if [[ "$i" -gt "${#optdeps[@]}" ]]; then
-					fancy_message warn "$i has exceeded the maximum number of optional dependencies. Skipping"
-					unset 'choices[$choice_inc]'
-				fi
-				(( choice_inc++ ))
-			done
+            local choice_inc=0
+            for i in "${choices[@]}"; do
+                # have we gone over the maximum number in choices[@]?
+                if [[ $i -gt ${#optdeps[@]} ]]; then
+                    fancy_message warn "${BGreen}$i${NC} has exceeded the maximum number of optional dependencies. Skipping"
+                    unset 'choices[$choice_inc]'
+                fi
+                ((choice_inc++))
+            done
             if [[ ${choices[0]} != "n" ]]; then
                 for i in "${choices[@]}"; do
                     ((i--))
@@ -259,7 +259,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (
+                (   
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -296,7 +296,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (
+    (   
         # create control.tar
         cd DEBIAN
         for i in *; do
@@ -342,7 +342,7 @@ function makedeb() {
     deblog "Priority" "optional"
 
     if [[ -n ${provides[*]} ]]; then
-		deblog "Provides" "$(echo "${provides[@]}" | sed 's/ /, /g')"
+        deblog "Provides" "$(echo "${provides[@]}" | sed 's/ /, /g')"
     fi
 
     if [[ -n $replace ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -226,7 +226,7 @@ function prompt_optdepends() {
             local choice_inc=0
             for i in "${choices[@]}"; do
                 # have we gone over the maximum number in choices[@]?
-                if [[ $i -gt ${#optdeps[@]} ]]; then
+                if [[ $i -gt ${#optdeps[@]} ]] && [[ $i != "n" ]] && [[ $i != "y" ]]; then
                     local skip_opt+=("$i")
                     unset 'choices[$choice_inc]'
                 fi


### PR DESCRIPTION
## Purpose

Currently inputing invalid numbers into `prompt_optdepends` will just be skipped over entirely instead of giving a warning.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
