### PR TITLE
fix(makedeb): print gives first

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -330,7 +330,7 @@ function createdeb() {
 }
 
 function makedeb() {
-    fancy_message info "Packaging $name"
+    fancy_message info "Packaging ${gives:-$name}"
     deblog "Package" "${gives:-$name}"
 
     if [[ $version =~ ^[0-9] ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -335,7 +335,6 @@ function makedeb() {
 	else
         fancy_message info "Packaging ${BGreen}$name${NC}"
 	fi
-    fancy_message info "Packaging ${gives:-$name}"
     deblog "Package" "${gives:-$name}"
 
     if [[ $version =~ ^[0-9] ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -330,6 +330,11 @@ function createdeb() {
 }
 
 function makedeb() {
+	if [[ -n $gives ]]; then
+        fancy_message info "Packaging ${BGreen}$name${NC} as ${BBlue}$gives${NC}"
+	else
+        fancy_message info "Packaging ${BGreen}$name${NC}"
+	fi
     fancy_message info "Packaging ${gives:-$name}"
     deblog "Package" "${gives:-$name}"
 


### PR DESCRIPTION
## Purpose

When installing a package with `gives`, the `makedeb` function will print out:
```bash
[+] INFO: Packaging foo-git
```

Now becomes
```bash
[+] INFO: Packaging foo-git as foo
```

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
