### PR TITLE
fix(install.sh): install `curl`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -86,7 +86,7 @@ if ! command -v apt &> /dev/null; then
     fancy_message error "apt could not be found"
     exit 1
 fi
-apt-get install -y -qq sudo wget iputils-ping
+apt-get install -y -qq sudo wget curl iputils-ping
 
 echo -e "|------------------------|"
 echo -e "|---${GREEN}Pacstall Installer${NC}---|"


### PR DESCRIPTION
## Purpose

The installer does not install curl, meaning that if it’s not installed when the user runs the installer, it will fail

## Approach

Install it.

## Addendum

Fixes #693.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
