### PR TITLE
rm(cget): remove never used internal function `cget`

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -81,16 +81,6 @@ function checks() {
     fi
 }
 
-function cget() {
-    URL="$1"
-    BRANCH="$2"
-    # If BRANCH was not specified, default to master
-    if [[ -n $BRANCH ]]; then
-        BRANCH=master
-    fi
-    git ls-remote "$URL" "$BRANCH" | sed "s/refs\/heads\/.*//"
-}
-
 # Logging metadata
 function log() {
     # Origin repo info parsing


### PR DESCRIPTION
## Purpose

Remove never used function. I don’t even remember why we included it, although I’m pretty sure it was supposed to be used in pkgver, but we never encouraged or even told anyone about the function.

#### Original commit
https://github.com/pacstall/pacstall/commit/00714853217ee83273d108c9136dcf57165d1ed5

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
