### PR TITLE
fix(PACSTALL_EDITOR): fall back to EDITOR if not found

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -252,7 +252,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (
+                (   
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -289,7 +289,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (
+    (   
         # create control.tar
         cd DEBIAN
         for i in *; do
@@ -319,11 +319,11 @@ function createdeb() {
 }
 
 function makedeb() {
-	if [[ -n $gives ]]; then
+    if [[ -n $gives ]]; then
         fancy_message info "Packaging ${BGreen}$name${NC} as ${BBlue}$gives${NC}"
-	else
+    else
         fancy_message info "Packaging ${BGreen}$name${NC}"
-	fi
+    fi
     deblog "Package" "${gives:-$name}"
 
     if [[ $version =~ ^[0-9] ]]; then
@@ -461,7 +461,10 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
 ask "Do you want to view/edit the pacscript" N
 if [[ $answer -eq 1 ]]; then
     if [[ -n $PACSTALL_EDITOR ]]; then
-        $PACSTALL_EDITOR "$PACKAGE".pacscript
+        $PACSTALL_EDITOR "$PACKAGE".pacscript || {
+            fancy_message warn "'$PACSTALL_EDITOR' not found, falling back to '$EDITOR'"
+            $EDITOR "$PACKAGE".pacscript
+        }
     elif [[ -n $EDITOR ]]; then
         $EDITOR "$PACKAGE".pacscript
     elif [[ -n $VISUAL ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -252,7 +252,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (   
+                (
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -289,7 +289,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (   
+    (
         # create control.tar
         cd DEBIAN
         for i in *; do

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -252,7 +252,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (
+                (   
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -289,7 +289,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (
+    (   
         # create control.tar
         cd DEBIAN
         for i in *; do
@@ -460,18 +460,23 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
 
 ask "Do you want to view/edit the pacscript" N
 if [[ $answer -eq 1 ]]; then
-    if [[ -n $PACSTALL_EDITOR ]]; then
-        $PACSTALL_EDITOR "$PACKAGE".pacscript || {
-            fancy_message warn "'$PACSTALL_EDITOR' not found, falling back to '$EDITOR'"
+    (
+        if [[ -n $PACSTALL_EDITOR ]]; then
+            $PACSTALL_EDITOR "$PACKAGE".pacscript || {
+                fancy_message warn "'$PACSTALL_EDITOR' not found, falling back to '$EDITOR'"
+                $EDITOR "$PACKAGE".pacscript
+            }
+        elif [[ -n $EDITOR ]]; then
             $EDITOR "$PACKAGE".pacscript
-        }
-    elif [[ -n $EDITOR ]]; then
-        $EDITOR "$PACKAGE".pacscript
-    elif [[ -n $VISUAL ]]; then
-        $VISUAL "$PACKAGE".pacscript
-    else
+        elif [[ -n $VISUAL ]]; then
+            $VISUAL "$PACKAGE".pacscript
+        else
+            sensible-editor "$PACKAGE".pacscript
+        fi
+    ) || {
+        fancy_message warn "Editor not found, falling back to 'sensible-editor'"
         sensible-editor "$PACKAGE".pacscript
-    fi
+    }
 fi
 
 fancy_message info "Sourcing pacscript"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -462,10 +462,7 @@ ask "Do you want to view/edit the pacscript" N
 if [[ $answer -eq 1 ]]; then
     (
         if [[ -n $PACSTALL_EDITOR ]]; then
-            $PACSTALL_EDITOR "$PACKAGE".pacscript || {
-                fancy_message warn "'$PACSTALL_EDITOR' not found, falling back to '$EDITOR'"
-                $EDITOR "$PACKAGE".pacscript
-            }
+            $PACSTALL_EDITOR "$PACKAGE".pacscript
         elif [[ -n $EDITOR ]]; then
             $EDITOR "$PACKAGE".pacscript
         elif [[ -n $VISUAL ]]; then


### PR DESCRIPTION
## Purpose

If `PACSTALL_EDITOR`s command is not found, pacstall will pass through. This will make it fall back to `EDITOR`.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
