### PR TITLE
fix(install-local): move some `grep` commands to bash comparisons

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -583,7 +583,7 @@ if [[ -n ${build_depends[*]} ]]; then
     # Get all uninstalled build depends
     build_depends=($build_depends)
     for build_dep in "${build_depends[@]}"; do
-		if [[ "$(dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null)" == "^install ok installed" ]]; then
+		if [[ "$(dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null)" == "install ok installed" ]]; then
             build_depends_to_delete+=("${build_dep}")
         fi
     done

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -188,7 +188,7 @@ function prompt_optdepends() {
             fi
             # Add to the dependency list if already installed so it doesn't get autoremoved on upgrade
             # If the package is not installed already, add it to the list. It's much easier for a user to choose from a list of uninstalled packages than every single one regardless of it's status
-            if ! dpkg-query -W -f='${Status}' "${opt}" 2> /dev/null | grep "^install ok installed" > /dev/null 2>&1; then
+			if ! [[ "$(dpkg-query -W -f='${Status}' "${opt}" 2> /dev/null)" == "install ok installed" ]]; then
                 optdeps+=("${optdep}")
             else
                 deps+=("${opt}")
@@ -567,7 +567,7 @@ if ! pacstall -L | grep -E "(^| )${name}( |$)" > /dev/null 2>&1; then
 
     if [[ -n $replace ]]; then
         # Ask user if they want to replace the program
-        if dpkg-query -W -f='${Status}' $replace 2> /dev/null | grep -q "ok installed"; then
+		if [[ "$(dpkg-query -W -f='${Status}' "$replace" 2> /dev/null)" == "ok installed" ]]; then
             ask "This script replaces $replace. Do you want to proceed" N
             if [[ $answer -eq 0 ]]; then
                 fancy_message info "Cleaning up"
@@ -583,7 +583,7 @@ if [[ -n ${build_depends[*]} ]]; then
     # Get all uninstalled build depends
     build_depends=($build_depends)
     for build_dep in "${build_depends[@]}"; do
-        if dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null | grep "^install ok installed" > /dev/null 2>&1; then
+		if [[ "$(dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null)" == "^install ok installed" ]]; then
             build_depends_to_delete+=("${build_dep}")
         fi
     done


### PR DESCRIPTION
## Purpose

Some parts of the codebase use `grep`, but we can replace them with faster bash comparisons.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
