### PR TITLE
fix(-P): use noninteractive

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -425,7 +425,7 @@ hash -r' | sudo tee "$STOWDIR/$name/DEBIAN/$deb_post_file" > /dev/null
     if [[ $PACSTALL_INSTALL != 0 ]]; then
 
         # --allow-downgrades is to allow git packages to "downgrade", because the commits aren't necessarily a higher number than the last version
-        if ! sudo --preserve-env=PACSTALL_INSTALL apt-get install --reinstall "$STOWDIR/$name.deb" -y --allow-downgrades 2> /dev/null; then
+        if ! sudo --preserve-env=PACSTALL_INSTALL --preserve-env=DEBIAN_INTERACTIVE apt-get install --reinstall "$STOWDIR/$name.deb" -y --allow-downgrades 2> /dev/null; then
             echo -ne "\t"
             fancy_message error "Failed to install $name deb"
             error_log 8 "install $PACKAGE"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -425,7 +425,7 @@ hash -r' | sudo tee "$STOWDIR/$name/DEBIAN/$deb_post_file" > /dev/null
     if [[ $PACSTALL_INSTALL != 0 ]]; then
 
         # --allow-downgrades is to allow git packages to "downgrade", because the commits aren't necessarily a higher number than the last version
-        if ! sudo --preserve-env=PACSTALL_INSTALL --preserve-env=DEBIAN_INTERACTIVE apt-get install --reinstall "$STOWDIR/$name.deb" -y --allow-downgrades 2> /dev/null; then
+        if ! sudo -E apt-get install --reinstall "$STOWDIR/$name.deb" -y --allow-downgrades 2> /dev/null; then
             echo -ne "\t"
             fancy_message error "Failed to install $name deb"
             error_log 8 "install $PACKAGE"

--- a/pacstall
+++ b/pacstall
@@ -434,6 +434,7 @@ while [[ $1 != "--" ]]; do
         -P | --disable-prompts)
             fancy_message warn "Prompts are disabled"
             export DISABLE_PROMPTS=yes
+            export DEBIAN_FRONTEND=noninteractive
             ;;
 
         -B | --build-only)


### PR DESCRIPTION
## Purpose

Debconf will use prompts. `-P` guarantees no prompts. Export `DEBIAN_FRONTEND` as `noninteractive` to guarantee no prompt.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
