### PR TITLE
feat: add `incompatible` array

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -164,9 +164,8 @@ function get_incompatible_releases() {
         local distro_version_name="$(lsb_release -sc 2> /dev/null)"
         local distro_version_number="$(lsb_release -sr 2> /dev/null)"
     fi
-    local input=("$@")
-    # convert the input to lowercase
-    input=($(echo "${input[@]}" | tr '[:upper:]' '[:lower:]'))
+    # lowercase
+    local input=("${@,,}")
     for key in "${input[@]}"; do
         # check for `*:jammy`
         if [[ $key == "*:"* ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -163,6 +163,8 @@ function get_incompatible_releases() {
     fi
     local distro_version_number="$(lsb_release -sr 2> /dev/null)"
     local input=("$@")
+	# convert the input to lowercase
+	input=( $(echo "${input[@]}" | tr '[:upper:]' '[:lower:]') )
     for key in "${input[@]}"; do
         if [[ $key == "${distro_name}:${distro_version_name}" ]] || [[ $key == "${distro_name}:${distro_version_number}" ]]; then
             return 1

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -172,7 +172,7 @@ function get_incompatible_releases() {
         if [[ $key == "*:"* ]]; then
             # check for `22.04` or `jammy`
             if [[ ${key#*:} == "${distro_version_number}" ]] || [[ ${key#*:} == "${distro_version_name}" ]]; then
-                fancy_message error "This Pacscript does not work on ${BBlue}${distro_version_name}/${distro_version_number}${NC}"
+                fancy_message error "This Pacscript does not work on ${BBlue}${distro_version_name}${NC}/${BBlue}${distro_version_number}${NC}"
                 return 1
             fi
         # check for `ubuntu:*`
@@ -185,7 +185,7 @@ function get_incompatible_releases() {
         else
             # check for `ubuntu:jammy` or `ubuntu:22.04`
             if [[ $key == "${distro_name}:${distro_version_name}" ]] || [[ $key == "${distro_name}:${distro_version_number}" ]]; then
-                fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}:${distro_version_name}/${distro_name}:${distro_version_number}${NC}"
+                fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}"
                 return 1
             fi
         fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -282,7 +282,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (   
+                (
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -319,7 +319,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (   
+    (
         # create control.tar
         cd DEBIAN
         for i in *; do

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -290,7 +290,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (   
+                (
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -327,7 +327,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (   
+    (
         # create control.tar
         cd DEBIAN
         for i in *; do

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -172,17 +172,20 @@ function get_incompatible_releases() {
         if [[ $key == "*:"* ]]; then
             # check for `22.04` or `jammy`
             if [[ ${key#*:} == "${distro_version_number}" ]] || [[ ${key#*:} == "${distro_version_name}" ]]; then
+                fancy_message error "This Pacscript does not work on ${BBlue}${distro_version_name}/${distro_version_number}${NC}"
                 return 1
             fi
         # check for `ubuntu:*`
         elif [[ $key == *":*" ]]; then
             # check for `ubuntu`
             if [[ ${key%%:*} == "${distro_name}" ]]; then
+                fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}${NC}"
                 return 1
             fi
         else
             # check for `ubuntu:jammy` or `ubuntu:22.04`
             if [[ $key == "${distro_name}:${distro_version_name}" ]] || [[ $key == "${distro_name}:${distro_version_number}" ]]; then
+                fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}:${distro_version_name}/${distro_name}:${distro_version_number}${NC}"
                 return 1
             fi
         fi
@@ -287,7 +290,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (
+                (   
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -324,7 +327,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (
+    (   
         # create control.tar
         cd DEBIAN
         for i in *; do
@@ -523,9 +526,6 @@ fi
 
 if [[ -n ${incompatible[*]} ]]; then
     if ! get_incompatible_releases "${incompatible[@]}"; then
-        distro="$(lsb_release -si 2> /dev/null | tr '[:upper:]' '[:lower:]')"
-        distro_version="$(lsb_release -sc 2> /dev/null)"
-        fancy_message error "This Pacscript does not work on ${BBlue}$distro${NC}:${BBlue}$distro_version${NC}"
         cleanup
         exit 1
     fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -287,7 +287,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (   
+                (
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -324,7 +324,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (   
+    (
         # create control.tar
         cd DEBIAN
         for i in *; do

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -156,7 +156,11 @@ function compare_remote_version() (
 
 function get_incompatible_releases() {
     local distro_name="$(lsb_release -si 2> /dev/null | tr '[:upper:]' '[:lower:]')"
-    local distro_version_name="$(lsb_release -sc 2> /dev/null)"
+    if [[ "$(lsb_release -ds 2> /dev/null | tail -c 4)" == "sid" ]]; then
+        local distro_version_name="sid"
+    else
+        local distro_version_name="$(lsb_release -sc 2> /dev/null)"
+    fi
     local distro_version_number="$(lsb_release -sr 2> /dev/null)"
     local input=("$@")
     for key in "${input[@]}"; do
@@ -264,7 +268,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (
+                (   
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -301,7 +305,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (
+    (   
         # create control.tar
         cd DEBIAN
         for i in *; do

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -268,7 +268,7 @@ function prompt_optdepends() {
     if [[ -n ${deps[*]} ]]; then
         if [[ -n ${pacdeps[*]} ]]; then
             for i in "${pacdeps[@]}"; do
-                (   
+                (
                     source "$LOGDIR/$i"
                     if [[ -n $_gives ]]; then
                         echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
@@ -305,7 +305,7 @@ function createdeb() {
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    (   
+    (
         # create control.tar
         cd DEBIAN
         for i in *; do


### PR DESCRIPTION
## Purpose

Currently some scripts have methods of preventing running on certain distros using this codeblock:
```bash
if [[ "$(grep -Po 'ID=\K[^"]+' /etc/os-release)" == "debian" ]]; then
    fancy_message error "This script doesn't work on Debian"
    cleanup # Trigger pacstall cleanups
    exit 1
fi
```

This is not the best as it triggers functions that should really only be called in pacstall, it clutters the script, it doesn't take into account version differences, etc. It also prevents some CIs from sourcing this at all.

## Approach

Add a built in method with a new array called `incompatible`. Each key should look like this: `$distro:$version_name`. This will declutter a lot of scripts, and make it easier to fine tune Pacscripts. Globs also work. This will mean that a Pacscript has no running components when sourced (besides `pkgver` in some).

## Addendum

Closes #698 

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
