### PR TITLE
fix(pin): use gives first

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -478,7 +478,7 @@ hash -r' | sudo tee "$STOWDIR/$name/DEBIAN/$deb_post_file" > /dev/null
         if ! [[ -d /etc/apt/preferences.d/ ]]; then
             sudo mkdir -p /etc/apt/preferences.d
         fi
-        echo "Package: ${name}
+        echo "Package: ${gives:-$name}
 Pin: version *
 Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
         return 0


### PR DESCRIPTION
## Purpose
We set an apt pin in order to prevent apt from overwriting packages when we update apt. The problem is that we currently set the pinned package to `name`, which might be different than `gives`, meaning that if `gives` is a valid apt package **and** is upgradable in the repos, the pin will not work.

## To test
Install `exa-git`, then run `sudo apt update`. Observe that apt wants to upgrade.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
