### PR TITLE
feat(createdeb): use `xz` instead of `gzip`

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -315,11 +315,11 @@ function generate_changelog() {
 function createdeb() {
     local name="$1"
     if [[ $PACSTALL_INSTALL == "0" ]]; then
-        # We are not going to immediately install, meaning the user might want to share their deb with someone else, so create the highest compression. We want maximum compression over everything else
-        local gzip_flags="-9n"
+        # We are not going to immediately install, meaning the user might want to share their deb with someone else, so create the highest compression.
+		local xz_flags=("-9" "-T0")
     else
         # Immediate install, so we want fast build times over everything else
-        local gzip_flags="-1n"
+		local xz_flags=("-1" "-T0")
     fi
     cd "$STOWDIR/$name"
     echo "2.0" | sudo tee debian-binary > /dev/null
@@ -349,10 +349,10 @@ function createdeb() {
     sudo tar -rf "$DATA_LOCATION" "${files_for_data[@]}"
 
     fancy_message sub "Compressing"
-    sudo gzip "$gzip_flags" "$DATA_LOCATION" "$CONTROL_LOCATION"
-    sudo ar -rU "$name.deb" debian-binary control.tar.gz data.tar.gz > /dev/null 2>&1
+    sudo xz "${xz_flags[@]}" "$DATA_LOCATION" "$CONTROL_LOCATION"
+    sudo ar -rU "$name.deb" debian-binary control.tar.xz data.tar.xz > /dev/null 2>&1
     sudo mv "$name.deb" ..
-    sudo rm -f debian-binary control.tar.gz data.tar.gz
+    sudo rm -f debian-binary control.tar.xz data.tar.xz
 }
 
 function makedeb() {

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -301,7 +301,7 @@ function prompt_optdepends() {
             deps+=($(cat /tmp/pacstall-gives))
         fi
     fi
-    if [[ -n $depends ]] || [[ -n ${deps[*]}  ]]; then
+    if [[ -n $depends ]] || [[ -n ${deps[*]} ]]; then
         deblog "Depends" "$(echo "${deps[@]}" | sed 's/ /, /g')"
     fi
 }
@@ -316,10 +316,14 @@ function createdeb() {
     local name="$1"
     if [[ $PACSTALL_INSTALL == "0" ]]; then
         # We are not going to immediately install, meaning the user might want to share their deb with someone else, so create the highest compression.
-		local xz_flags=("-9" "-T0")
+        local flags=("-9" "-T0")
+        local compression="xz"
+        local command="xz"
     else
-        # Immediate install, so we want fast build times over everything else
-		local xz_flags=("-1" "-T0")
+        # Immediate install (gzip), so we want fast build times over everything else
+        local flags=("-1n")
+        local compression="gz"
+        local command="gzip"
     fi
     cd "$STOWDIR/$name"
     echo "2.0" | sudo tee debian-binary > /dev/null
@@ -349,10 +353,10 @@ function createdeb() {
     sudo tar -rf "$DATA_LOCATION" "${files_for_data[@]}"
 
     fancy_message sub "Compressing"
-    sudo xz "${xz_flags[@]}" "$DATA_LOCATION" "$CONTROL_LOCATION"
-    sudo ar -rU "$name.deb" debian-binary control.tar.xz data.tar.xz > /dev/null 2>&1
+    sudo "$command" "${flags[@]}" "$DATA_LOCATION" "$CONTROL_LOCATION"
+    sudo ar -rU "$name.deb" debian-binary control.tar."$compression" data.tar."$compression" > /dev/null 2>&1
     sudo mv "$name.deb" ..
-    sudo rm -f debian-binary control.tar.xz data.tar.xz
+    sudo rm -f debian-binary control.tar."$compression" data.tar."$compression"
 }
 
 function makedeb() {


### PR DESCRIPTION
## Purpose

`gzip` is singlethreaded, and does not compress that well. `xz` on the other hand compresses a lot more, and it multithreaded.

> **Note**
> Both Ubuntu and Debian have `xz-utils` installed by default

## Approach

Compress `{control,data}.tar` with the `xz` format instead of `gz`.

## Benchmarks

The benchmarks for `xz` were not performed with the `-e` flag, which compresses further. The results from `-e` take too long for a marginally better or sometimes worse size.

### Deb creation size

| Package | Raw size | gzip (-9n) | xz (-9 -T0) | zstd (-19 -T0) |
|---------|----------|------------|---------|--------------------|
| pacup-bin | 32MB | 12.8MB | 9.6MB | 10.2MB |
| neovim | 9.97MB |  9.9MB | 7.1MB | 7.8MB |
| discord | 73MB | 73.6MB | 53.4MB | 58.8MB |
| pacstall | 63.2KB | 24.1KB | 21.5KB | 22KB |
| hyperfine-bin | 976KB | 968KB | 730KB | 807KB |
| go-bin | 142MB | 9.9MB | 8.2MB | 9.0MB |


## Compressing the **full** Linux source tree (https://github.com/torvalds/linux)

Cloned with `git clone https://github.com/torvalds/linux`. Final cloned size was 5.4GB.

| Gzip | XZ | ZSTD |
|------|----|------|
| 4.2GB  | 3.9GB | 4.0GB |

Gzip took 4:09 to compress.
XZ took 8:33 to compress.
ZSTD took 6:44 to compress.

## Decompressing the full Linux source tree

| Gzip | XZ | ZSTD |
|------|----|------|
| 0:31 | 2:42 | 0:08 |


## Pros and Cons of using XZ

### Pros
* Consistently smaller deb sizes.
* Multithreaded compression.

### Cons
* On *old* systems (pre dpkg 1.15.6 (released 12 years ago, so it really doesn't matter). Ubuntu LTS is currently running 1.21.1, Debian stable is running 1.20.12), this won't work. Gzip has been supported since the beginning of dpkg.
* Gzip is generally faster when {un,de}compressing, so we would be losing time, however we are using the `-B` flag, so time is a nonissue.

## Conclusions
The benchmarks show that at the highest compression used, XZ is much better at compression size, whereas Gzip is quicker to compress files. The speed difference for a standard install is negligible as they both are basically not decompressing. 

## What to decide on
Either use XZ for everything, or only use it for `-B`.

## Other
When Debian stable supports ZSTD. we will switch because it's decompression speeds are *insanely* fast, with the tradeoff of being slightly larger than XZ. I had an idea about checking `incompatible` for the existence of `debian:*`, and in that case use ZSTD, but that would be unnecessarily complicated.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
