### PR TITLE
fix(clean_logdir): call it at least once

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -845,6 +845,7 @@ trap cleanup ERR
 trap - SIGINT
 
 prompt_optdepends
+clean_logdir
 
 function fail_out_functions() {
     local func="$1"


### PR DESCRIPTION
## Purpose

We don't actually call `clean_logdir` at any point.

## Approach

Call it.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
