### PR TITLE
chore(funding): delete overriding funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-liberapay: Pacstall


### PR DESCRIPTION
Delete the overriding funding config, to follow the organization default one.