### PR TITLE
fix(log): figure out what `gives` is based on Deb

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -64,6 +64,10 @@ function checks() {
         fancy_message error "Package does not contain name"
         exit 1
     fi
+    if [[ -z $gives && $name == *-deb ]]; then
+        fancy_message error "Deb package does not contain gives"
+        exit 1
+    fi
     if [[ -z $hash && $name != *-git ]]; then
         fancy_message warn "Package does not contain a hash"
     fi
@@ -301,7 +305,7 @@ function prompt_optdepends() {
             deps+=($(cat /tmp/pacstall-gives))
         fi
     fi
-    if [[ -n $depends ]] || [[ -n ${deps[*]}  ]]; then
+    if [[ -n $depends ]] || [[ -n ${deps[*]} ]]; then
         deblog "Depends" "$(echo "${deps[@]}" | sed 's/ /, /g')"
     fi
 }
@@ -315,7 +319,7 @@ function generate_changelog() {
 function clean_logdir() {
     local files=("$(find -H "/var/log/pacstall/error_log/" -maxdepth 1 -mtime +30)")
     if [[ -n ${files[*]} ]]; then
-		sudo rm -f "${files[@]}"
+        sudo rm -f "${files[@]}"
     fi
 }
 
@@ -864,7 +868,7 @@ function run_function() {
     local func="$1"
     fancy_message sub "Running $func"
     # NOTE: https://stackoverflow.com/a/29163890 (shorthand for 2>&1 |)
-	$func |& sudo tee "/var/log/pacstall/error_log/$(date +"%Y-%m-%d_%T")-$name-$func.log" && return "${PIPESTATUS[0]}"
+    $func |& sudo tee "/var/log/pacstall/error_log/$(date +"%Y-%m-%d_%T")-$name-$func.log" && return "${PIPESTATUS[0]}"
 }
 
 function safe_run() {

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -64,10 +64,6 @@ function checks() {
         fancy_message error "Package does not contain name"
         exit 1
     fi
-    if [[ -z $gives && $name == *-deb ]]; then
-        fancy_message error "Deb package does not contain gives"
-        exit 1
-    fi
     if [[ -z $hash && $name != *-git ]]; then
         fancy_message warn "Package does not contain a hash"
     fi
@@ -114,7 +110,9 @@ function log() {
         if [[ -n $ppa ]]; then
             echo "_ppa=\"$ppa"\"
         fi
-        if [[ -n $gives ]]; then
+        if [[ $name == *-deb ]] && [[ -z $gives ]]; then
+            echo "_gives=\"$(dpkg -f ./"${url##*/}" | sed -n "s/^Package: //p")"\"
+        elif [[ -n $gives ]]; then
             echo "_gives=\"$gives"\"
         fi
         if [[ -f /tmp/pacstall-pacdeps-"$name" ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -64,6 +64,9 @@ function checks() {
         fancy_message error "Package does not contain name"
         exit 1
     fi
+    if [[ -z $gives && $name == *-deb ]]; then
+        fancy_message warn "Deb package does not contain gives"
+    fi
     if [[ -z $hash && $name != *-git ]]; then
         fancy_message warn "Package does not contain a hash"
     fi


### PR DESCRIPTION
## Purpose

`gives` is needed on Debs to get the actual apt package name. If it does not exist, Pacstall will try to remove debs with the apt name `name`, which most definitely is not the canonical name. 

## Approach

Figure out the package name anyways and warn the user.

## Addendum

Fixes #736 

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
