### PR TITLE
fix(upgrade.sh): skip git packages if `0$version` equals `$remoteversion` without `0`

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -370,7 +370,7 @@ function makedeb() {
     fi
     deblog "Package" "${gives:-$name}"
 
-    if [[ $version =~ ^[0-9] ]]; then
+    if [[ $version =~ ^[0-9] ]] || [[ $name == *-git ]]; then
         deblog "Version" "${epoch+$epoch:}$version"
         export version="${epoch+$epoch:}$version"
     else

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -370,7 +370,7 @@ function makedeb() {
     fi
     deblog "Package" "${gives:-$name}"
 
-    if [[ $version =~ ^[0-9] ]] || [[ $name == *-git ]]; then
+    if [[ $version =~ ^[0-9] ]]; then
         deblog "Version" "${epoch+$epoch:}$version"
         export version="${epoch+$epoch:}$version"
     else

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -47,7 +47,7 @@ N="$(nproc)"
 (
     for i in "${list[@]}"; do
         ((n = n % N))
-            ((n++ == 0)) && wait
+        ((n++ == 0)) && wait
         {
             source "$LOGDIR/$i"
 
@@ -57,9 +57,9 @@ N="$(nproc)"
             if [[ -z ${_remoterepo} ]]; then
                 # TODO: upgrade for local pacscripts
                 return
-            elif [[ "${_remoterepo}" == *"github.com"* ]]; then
+            elif [[ ${_remoterepo} == *"github.com"* ]]; then
                 remoterepo="${_remoterepo/'github.com'/'raw.githubusercontent.com'}/${_remotebranch}"
-            elif [[ "${_remoterepo}" == *"gitlab.com"* ]]; then
+            elif [[ ${_remoterepo} == *"gitlab.com"* ]]; then
                 remoterepo="${_remoterepo}/-/raw/${_remotebranch}"
             else
                 remoterepo="${_remoterepo}"
@@ -105,7 +105,8 @@ N="$(nproc)"
                     remoterepo="$alterver"
                     remoteurl="$alterurl"
                 fi
-            elif [[ $remotever == "$localver" ]]; then
+                # If the remote version equals the local version minus the first character (0) or they both equal the same
+            elif [[ $remotever == "${localver:1}" ]] || [[ $remotever == "$localver" ]]; then
                 return
             fi
 


### PR DESCRIPTION
## Purpose

If a package does not start with a number, Pacstall will prepend a `0` to it, however that is problematic for git package sha's.

## Testing

Install `exa-git`, then upgrade it.

## Approach

Add a clause to allow first letter in git packages.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
