### PR TITLE
fix(upgrade): place wait to prevent overwritten variables

### DIFF
--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -48,7 +48,7 @@ N="$(nproc)"
     for i in "${list[@]}"; do
         ((n = n % N))
         ((n++ == 0)) && wait
-        {
+        (
             source "$LOGDIR/$i"
 
             # localver is the current version of the package
@@ -117,8 +117,9 @@ N="$(nproc)"
                     echo "$remoteurl" | tee -a /tmp/pacstall-up-urls > /dev/null
                 fi
             fi
-        } &
+        ) &
     done
+    wait
 )
 
 if [[ $(wc -l < /tmp/pacstall-up-list) -eq 0 ]]; then


### PR DESCRIPTION
## Purpose

Currently we run multiple upgrade checks at once, but without subshelling, and without a proper catch-all wait command, meaning that some packages will randomly not be shown for upgrading, even though they are.

## Approach

Add subshelling and proper catch-all `wait`. This will guarantee that all checks finish.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
