### PR TITLE
fix(pacdeps): mark pacdep as auto installed

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -487,7 +487,9 @@ hash -r' | sudo tee "$STOWDIR/$name/DEBIAN/$deb_post_file" > /dev/null
             cleanup
             exit 1
         fi
-
+        if [[ -f /tmp/pacstall-pacdeps-"$name" ]]; then
+            sudo apt-mark auto "${gives:-$name}" 2> /dev/null
+        fi
         sudo rm -rf "$STOWDIR/$name"
         sudo rm -rf "$SRCDIR/$name.deb"
 

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -39,15 +39,5 @@ sudo apt-get purge "${_gives:-$_name}" -y || {
     exit 1
 }
 
-if [[ -n ${_pacdeps[*]}   ]]; then
-    for i in "${_pacdeps[@]}"; do
-        (
-            source "$LOGDIR/$i"
-            sudo apt-get purge "${_gives:-$_name}" -y
-            sudo rm -f /var/log/pacstall/metadata/"$_name"
-        )
-    done
-fi
-
 sudo rm -f /var/log/pacstall/metadata/"$_name"
 # vim:set ft=sh ts=4 sw=4 noet:


### PR DESCRIPTION
## Purpose

Currently, we remove any pacdep if the parent package is removed, however this does not take into account if other packages depend on the pacdep. This PR makes sure that apt knows that the pacdep is a dependency instead of a package that was installed and happened to satisfy the dependency.

## Approach

`apt-mark auto` it.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
