### PR TITLE
fix(hashcheck): use exit instead of return

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -754,7 +754,8 @@ else
             fi
             # hash the file
             if ! hashcheck "${url##*/}"; then
-                return 1
+                cleanup
+                exit 1
             fi
             # unzip file
             fancy_message info "Extracting ${url##*/}"
@@ -774,7 +775,8 @@ else
                 exit 1
             fi
             if ! hashcheck "${url##*/}"; then
-                return 1
+                cleanup
+                exit 1
             fi
             if sudo apt install -y -f ./"${url##*/}" 2> /dev/null; then
                 log
@@ -817,7 +819,8 @@ else
                 exit 1
             fi
             if ! hashcheck "${url##*/}"; then
-                return 1
+                cleanup
+                exit 1
             fi
             ;;
         *)
@@ -830,7 +833,8 @@ else
             fi
             # I think you get it by now
             if ! hashcheck "${url##*/}"; then
-                return 1
+                cleanup
+                exit 1
             fi
             fancy_message info "Extracting ${url##*/}"
             tar -xf "${url##*/}" 1>&1 2> /dev/null

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -751,10 +751,7 @@ else
                 exit 1
             fi
             # hash the file
-            if ! hashcheck "${url##*/}"; then
-                cleanup
-                exit 1
-            fi
+            hashcheck "${url##*/}"
             # unzip file
             fancy_message info "Extracting ${url##*/}"
             unzip -qo "${url##*/}" 1>&1 2> /dev/null
@@ -772,10 +769,7 @@ else
                 cleanup
                 exit 1
             fi
-            if ! hashcheck "${url##*/}"; then
-                cleanup
-                exit 1
-            fi
+            hashcheck "${url##*/}"
             if sudo apt install -y -f ./"${url##*/}" 2> /dev/null; then
                 log
                 if type -t postinst > /dev/null 2>&1; then
@@ -816,10 +810,7 @@ else
                 cleanup
                 exit 1
             fi
-            if ! hashcheck "${url##*/}"; then
-                cleanup
-                exit 1
-            fi
+            hashcheck "${url##*/}"
             ;;
         *)
             if ! download "$url"; then
@@ -829,11 +820,7 @@ else
                 cleanup
                 exit 1
             fi
-            # I think you get it by now
-            if ! hashcheck "${url##*/}"; then
-                cleanup
-                exit 1
-            fi
+            hashcheck "${url##*/}"
             fancy_message info "Extracting ${url##*/}"
             tar -xf "${url##*/}" 1>&1 2> /dev/null
             cd ./*/ 2> /dev/null || {

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -690,11 +690,9 @@ function hashcheck() {
         # We bad
         fancy_message error "Hashes do not match"
         error_log 16 "install $PACKAGE"
-        if [[ $url != *".deb" ]]; then
-            fancy_message info "Cleaning up"
-            cleanup
-            return 1
-        fi
+        fancy_message info "Cleaning up"
+        cleanup
+        exit 1
     fi
     true
 }


### PR DESCRIPTION
## Purpose

Currently if hashcheck fails, it returns, not exits out.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
