### PR TITLE
fix(functions): retain CWD after run

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -875,6 +875,7 @@ $(shopt -p -o)"
     trap "fail_out_functions '$func'" ERR
 
     run_function "$func"
+    CURRENT_PATH="$PWD"
 
     trap - ERR
     eval "$restoreshopt"
@@ -889,6 +890,7 @@ done
 if [[ -n ${pac_functions[*]} ]]; then
     fancy_message info "Running functions"
     for function in "${pac_functions[@]}"; do
+        [[ -n $CURRENT_PATH ]] && cd "$CURRENT_PATH"
         safe_run "$function"
     done
 fi


### PR DESCRIPTION
## Purpose

Running `safe_run` resets the CWD after every run, meaning Pacscripts always get reset to `$SRCDIR`.

## Approach

Introduce `CURRENT_PATH` to retain the CWD.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
