### PR TITLE
feat(build): add `PACSTALL_BUILD_CORES` variable

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -511,7 +511,7 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
 }
 
 if [[ -n $PACSTALL_BUILD_CORES ]]; then
-    if [[ $PACSTALL_BUILD_CORES =~ '^[0-9]+$' ]]; then
+    if [[ $PACSTALL_BUILD_CORES =~ ^[0-9]+$ ]]; then
         function nproc() {
             echo "${PACSTALL_BUILD_CORES:-1}"
         }

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -511,9 +511,16 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
 }
 
 if [[ -n $PACSTALL_BUILD_CORES ]]; then
-    function nproc() {
-        echo "${PACSTALL_BUILD_CORES:-1}"
-    }
+    if [[ $PACSTALL_BUILD_CORES =~ '^[0-9]+$' ]]; then
+        function nproc() {
+            echo "${PACSTALL_BUILD_CORES:-1}"
+        }
+    else
+        fancy_message error "${UCyan}PACSTALL_BUILD_CORES${NC} is not an integer. Falling back to 1"
+        function nproc() {
+            echo "1"
+        }
+    fi
 fi
 
 ask "Do you want to view/edit the pacscript" N

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -510,6 +510,12 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
     fi
 }
 
+if [[ -n $PACSTALL_BUILD_CORES ]]; then
+    function nproc() {
+        echo "${PACSTALL_BUILD_CORES:-1}"
+    }
+fi
+
 ask "Do you want to view/edit the pacscript" N
 if [[ $answer -eq 1 ]]; then
     (


### PR DESCRIPTION
## Purpose

If the user wants to set nproc to something other than max cores.

## Approach

Create a function which overrides it.

## Addendum

Fixes #382.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
