### PR TITLE
fix(ppa): add dangling PPA warning

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -111,7 +111,7 @@ function log() {
         echo "_version=\"${epoch+$epoch:}$version"\"
         echo "_date=\"$(date)"\"
         if [[ -n $ppa ]]; then
-            echo "_ppa=\"$ppa"\"
+            echo "_ppa=(${ppa[*]})"
         fi
         if [[ $name == *-deb ]] && [[ -z $gives ]]; then
             echo "_gives=\"$(dpkg -f ./"${url##*/}" | sed -n "s/^Package: //p")"\"

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -41,7 +41,7 @@ sudo apt-get remove "${_gives:-$_name}" -y || {
 
 if [[ -n ${_ppa[*]} ]]; then
     for ppa in "${_ppa[@]}"; do
-        sudo add-apt-repository --remove ppa:"$ppa" -y
+		fancy_message warn "You may have dangling PPAs on your system. You can remove them using ${UCyan}sudo add-apt-repository --remove ppa:$ppa${NC}"
     done
 fi
 

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -41,7 +41,7 @@ sudo apt-get remove "${_gives:-$_name}" -y || {
 
 if [[ -n ${_ppa[*]} ]]; then
     for ppa in "${_ppa[@]}"; do
-		fancy_message warn "You may have dangling PPAs on your system. You can remove them using ${UCyan}sudo add-apt-repository --remove ppa:$ppa${NC}"
+        fancy_message warn "You may have dangling PPAs on your system. You can remove them using ${UCyan}sudo add-apt-repository --remove ppa:$ppa${NC}"
     done
 fi
 

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-source "$LOGDIR/$PACKAGE" 2>/dev/null || {
+source "$LOGDIR/$PACKAGE" 2> /dev/null || {
     fancy_message error "$PACKAGE is not installed"
     error_log 3 "remove $PACKAGE"
     exit 1
@@ -38,6 +38,12 @@ sudo apt-get remove "${_gives:-$_name}" -y || {
     error_log 1 "remove $PACKAGE"
     exit 1
 }
+
+if [[ -n ${_ppa[*]} ]]; then
+    for ppa in "${_ppa[@]}"; do
+        sudo add-apt-repository --remove ppa:"$ppa" -y
+    done
+fi
 
 sudo rm -f /var/log/pacstall/metadata/"$_name"
 # vim:set ft=sh ts=4 sw=4 noet:


### PR DESCRIPTION
## Purpose

PPAs linger after a package is removed that depended on a PPA.

## Approach

Remove them in `remove.sh` and convert the `_ppa` string into an array.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
