### PR TITLE
fix(prompt_optdepends): prevent only adding non-installed pkgs to suggests

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -499,7 +499,15 @@ Pin: version *
 Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
         if [[ -n ${not_installed_yet_optdeps[*]} ]]; then
             fancy_message info "Installing selected optional dependencies"
+            for pkg in "${not_installed_yet_optdeps[@]}"; do
+                if [[ "$(dpkg-query -W -f='${Status}' "${pkg}" 2> /dev/null)" != "install ok installed" ]]; then
+                    local to_mark_as_auto+=("$pkg")
+                fi
+            done
             sudo -E apt-get install ${not_installed_yet_optdeps[*]} -y 2> /dev/null
+            if [[ -n $to_mark_as_auto ]]; then
+                sudo apt-mark auto "$pkg" 2> /dev/null
+            fi
         fi
         return 0
     else

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -229,10 +229,7 @@ function prompt_optdepends() {
                 local missing_optdeps+=("${opt}")
                 continue
             fi
-            # If the package is not installed already, add it to the list. It's much easier for a user to choose from a list of uninstalled packages than every single one regardless of it's status
-            if [[ "$(dpkg-query -W -f='${Status}' "${opt}" 2> /dev/null)" != "install ok installed" ]]; then
-                suggested_optdeps+=("${optdep}")
-            fi
+            suggested_optdeps+=("${optdep}")
         done
 
         if [[ ${#suggested_optdeps[@]} -ne 0 ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -222,7 +222,7 @@ function prompt_optdepends() {
 
         local suggested_optdeps=()
         for optdep in "${optdepends[@]}"; do
-            # Strip the description
+            # Strip the description, `opt` is now the canonical optdep name
             local opt=${optdep%%: *}
             # Check if package exists in the repos, and if not, go to the next program
             if [[ -z "$(apt-cache search --names-only "^$opt\$")" ]]; then
@@ -278,7 +278,7 @@ function prompt_optdepends() {
                         export not_installed_yet_optdeps+=("${s%%: *}")
                     fi
                 done
-                if [[ -n ${deps[*]} ]]; then
+                if [[ -n ${not_installed_yet_optdeps[*]} ]]; then
                     fancy_message info "Selecting packages ${BCyan}${not_installed_yet_optdeps[*]}${NC}"
                 fi
                 if pacstall -L | grep -E "(^| )${name}( |$)" > /dev/null 2>&1; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -280,7 +280,7 @@ function prompt_optdepends() {
                         local final_merged_deps=("${not_installed_yet_optdeps[@]}" "${already_installed_optdeps[@]}" "${suggested_optdeps[@]}")
                         deblog "Suggests" "$(echo "${final_merged_deps[@]//: */}" | sed 's/ /, /g')"
                         fancy_message info "Installing selected optional dependencies"
-                        sudo -E apt-get install ${not_installed_yet_optdeps[*]} -y 2> /dev/null
+                        sudo -E apt-get install "${not_installed_yet_optdeps[@]}" -y 2> /dev/null
                     fi
                     if pacstall -L | grep -E "(^| )${name}( |$)" > /dev/null 2>&1; then
                         sudo dpkg -r --force-all "${gives:-$name}" > /dev/null

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -288,16 +288,16 @@ function prompt_optdepends() {
                         sudo dpkg -r --force-all "${gives:-$name}" > /dev/null
                     fi
                 else
-					local final_merged_deps=("${not_installed_yet_optdeps[@]}" "${already_installed_optdeps[@]}" "${suggested_optdeps[@]}")
-					deblog "Suggests" "$(echo "${final_merged_deps[@]//: */}" | sed 's/ /, /g')"
-					if [[ -n ${not_installed_yet_optdeps[*]} ]]; then
-						fancy_message info "Installing selected optional dependencies"
-						sudo -E apt-get install ${not_installed_yet_optdeps[*]} -y 2> /dev/null
-					fi
-				fi
-			else # If `-B` is being used
-				for pkg in "${optdepends[@]}"; do
-					local B_suggests+=("${pkg%%: *}")
+                    local final_merged_deps=("${not_installed_yet_optdeps[@]}" "${already_installed_optdeps[@]}" "${suggested_optdeps[@]}")
+                    deblog "Suggests" "$(echo "${final_merged_deps[@]//: */}" | sed 's/ /, /g')"
+                    if [[ -n ${not_installed_yet_optdeps[*]} ]]; then
+                        fancy_message info "Installing selected optional dependencies"
+                        sudo -E apt-get install ${not_installed_yet_optdeps[*]} -y 2> /dev/null
+                    fi
+                fi
+            else # If `-B` is being used
+                for pkg in "${optdepends[@]}"; do
+                    local B_suggests+=("${pkg%%: *}")
                 done
                 deblog "Suggests" "$(echo "${B_suggests[@]//: */}" | sed 's/ /, /g')"
             fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -513,7 +513,7 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
                 fi
             done
             sudo -E apt-get install ${not_installed_yet_optdeps[*]} -y 2> /dev/null
-            if [[ -n $to_mark_as_auto ]]; then
+            if [[ -n ${to_mark_as_auto[*]} ]]; then
                 sudo apt-mark auto ${to_mark_as_auto[*]} 2> /dev/null
             fi
         fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -273,7 +273,7 @@ function prompt_optdepends() {
                     for i in "${choices[@]}"; do
                         ((i--))
                         local s="${suggested_optdeps[$i]}"
-                        export not_installed_yet_optdeps+=("${s%%: *}")
+                        local not_installed_yet_optdeps+=("${s%%: *}")
                     done
                     if [[ -n ${not_installed_yet_optdeps[*]} ]]; then
                         fancy_message info "Selecting packages ${BCyan}${not_installed_yet_optdeps[*]}${NC}"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -506,7 +506,7 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
             done
             sudo -E apt-get install ${not_installed_yet_optdeps[*]} -y 2> /dev/null
             if [[ -n $to_mark_as_auto ]]; then
-                sudo apt-mark auto "$pkg" 2> /dev/null
+                sudo apt-mark auto ${to_mark_as_auto[*]} 2> /dev/null
             fi
         fi
         return 0

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -273,16 +273,14 @@ function prompt_optdepends() {
                     for i in "${choices[@]}"; do
                         ((i--))
                         local s="${suggested_optdeps[$i]}"
-                        # does `s` actually exist in the optdeps array?
-                        if [[ -n $s ]]; then
-                            # then add it, and strip the `:`
-                            export not_installed_yet_optdeps+=("${s%%: *}")
-                        fi
+                        export not_installed_yet_optdeps+=("${s%%: *}")
                     done
                     if [[ -n ${not_installed_yet_optdeps[*]} ]]; then
                         fancy_message info "Selecting packages ${BCyan}${not_installed_yet_optdeps[*]}${NC}"
                         local final_merged_deps=("${not_installed_yet_optdeps[@]}" "${already_installed_optdeps[@]}" "${suggested_optdeps[@]}")
                         deblog "Suggests" "$(echo "${final_merged_deps[@]//: */}" | sed 's/ /, /g')"
+                        fancy_message info "Installing selected optional dependencies"
+                        sudo -E apt-get install ${not_installed_yet_optdeps[*]} -y 2> /dev/null
                     fi
                     if pacstall -L | grep -E "(^| )${name}( |$)" > /dev/null 2>&1; then
                         sudo dpkg -r --force-all "${gives:-$name}" > /dev/null
@@ -290,10 +288,6 @@ function prompt_optdepends() {
                 else
                     local final_merged_deps=("${not_installed_yet_optdeps[@]}" "${already_installed_optdeps[@]}" "${suggested_optdeps[@]}")
                     deblog "Suggests" "$(echo "${final_merged_deps[@]//: */}" | sed 's/ /, /g')"
-                    if [[ -n ${not_installed_yet_optdeps[*]} ]]; then
-                        fancy_message info "Installing selected optional dependencies"
-                        sudo -E apt-get install ${not_installed_yet_optdeps[*]} -y 2> /dev/null
-                    fi
                 fi
             else # If `-B` is being used
                 for pkg in "${optdepends[@]}"; do

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -273,19 +273,20 @@ function prompt_optdepends() {
                     ((i--))
                     local s="${suggested_optdeps[$i]}"
                     # does `s` actually exist in the optdeps array?
-                    if [[ -n $s ]]; then
-                        # then add it, and strip the `:`
-                        export not_installed_yet_optdeps+=("${s%%: *}")
-                    fi
+					if [[ -n $s ]]; then
+						# then add it, and strip the `:`
+						export not_installed_yet_optdeps+=("${s%%: *}")
+					fi
                 done
-                if [[ -n ${not_installed_yet_optdeps[*]} ]]; then
-                    fancy_message info "Selecting packages ${BCyan}${not_installed_yet_optdeps[*]}${NC}"
-                fi
+				if [[ -n ${not_installed_yet_optdeps[*]} ]]; then
+					fancy_message info "Selecting packages ${BCyan}${not_installed_yet_optdeps[*]}${NC}"
+					local final_merged_deps=("${not_installed_yet_optdeps[@]}" "${already_installed_optdeps[@]}" "${suggested_optdeps[@]}")
+					deblog "Suggests" "$(echo "${final_merged_deps[@]//: */}" | sed 's/ /, /g')"
+				fi
                 if pacstall -L | grep -E "(^| )${name}( |$)" > /dev/null 2>&1; then
                     sudo dpkg -r --force-all "${gives:-$name}" > /dev/null
                 fi
             else
-                # Add to the suggests anyway. They won't get installed but can be queried
                 local final_merged_deps=("${not_installed_yet_optdeps[@]}" "${already_installed_optdeps[@]}" "${suggested_optdeps[@]}")
                 deblog "Suggests" "$(echo "${final_merged_deps[@]//: */}" | sed 's/ /, /g')"
             fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -223,7 +223,7 @@ function prompt_optdepends() {
         local suggested_optdeps=()
         for optdep in "${optdepends[@]}"; do
             # Strip the description, `opt` is now the canonical optdep name
-            local opt=${optdep%%: *}
+            local opt="${optdep%%: *}"
             # Check if package exists in the repos, and if not, go to the next program
             if [[ -z "$(apt-cache search --names-only "^$opt\$")" ]]; then
                 local missing_optdeps+=("${opt}")


### PR DESCRIPTION
## Purpose

Move `optdepends` to `Suggests` and install them afterwards.
Change some variable names in order to make `prompt_optdepends` readable.
Remove `prompt_optdepends` entirely when using `-B` flag.
Install optdepends before package builds (now can specify buildtime optdepends)

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
