### PR TITLE
fix(homedir): detect any home dir, not just /home

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -449,7 +449,7 @@ function fancy_message() {
 
 function get_homedir() {
 	local PACSTALL_USER=$(logname 2> /dev/null || echo "${SUDO_USER:-${USER}}")
-	echo "/home/$PACSTALL_USER"
+	echo ~"$PACSTALL_USER"
 }
 export homedir="$(get_homedir)"
 
@@ -550,7 +550,7 @@ fi
 
 fancy_message info "Sourcing pacscript"
 DIR=$(pwd)
-homedir="/home/$PACSTALL_USER"
+homedir=~"$PACSTALL_USER"
 export homedir
 
 pacfile=$(readlink -f "$PACKAGE".pacscript)


### PR DESCRIPTION
## Purpose

Currently we set `homedir` to `/home/$USER`, but this can be an issue when users *could* in theory set their homedir to something else.

## Tests
```bash
henry@plasma:~$ echo ~root
/root
henry@plasma:~$ echo ~henry
/home/henry
henry@plasma:~$ echo ~games
/usr/games
henry@plasma:~$ echo ~irc
/run/ircd
```
vs setting the assumed homedir to `/home/$USER`.

## Drawbacks
This approach has one drawback and that is that is forces the Deb's post{rm,inst} running shell to be bash, not sh, however this isn't such a big deal considering that you have to have bash installed to run Pacstall, and most systems that a `-B` Deb is being installed on should have it as well.

## Approach

Use the `~$USER` bashism to get the canonical path to any given usernames homedir.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
