### PR TITLE
ref(pwd): `pwd` -> `$PWD`

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -549,7 +549,7 @@ if [[ $answer -eq 1 ]]; then
 fi
 
 fancy_message info "Sourcing pacscript"
-DIR=$(pwd)
+DIR="$PWD"
 homedir=~"$PACSTALL_USER"
 export homedir
 
@@ -744,7 +744,7 @@ if [[ -n $patch ]]; then
         wget -q "$i" -P PACSTALL_patchesdir &
     done
     wait
-    export PACPATCH=$(pwd)/PACSTALL_patchesdir
+    export PACPATCH="$PWD/PACSTALL_patchesdir"
 fi
 
 if [[ $name == *-git ]]; then

--- a/pacstall
+++ b/pacstall
@@ -729,7 +729,7 @@ Helpful links:
                     continue
                 fi
 
-                fancy_message info "${GREEN}${PACKAGE}${NC}'s pacscript is downloaded to ${GREEN}$(pwd)/$PACKAGE.pacscript${NC}"
+                fancy_message info "${GREEN}${PACKAGE}${NC}'s pacscript is downloaded to ${GREEN}${PWD}/$PACKAGE.pacscript${NC}"
             done
             exit 0
             ;;


### PR DESCRIPTION
## Purpose

It serves no purpose to call an external command when a builtin bash variable does the exact same thing.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
