### PR TITLE
fix(prompt_optdepends): always show missing optdeps

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -238,7 +238,7 @@ function prompt_optdepends() {
             fi
         done
 
-        if [[ -n ${missing_optdeps[@]} ]] || [[ ${#suggested_optdeps[@]} -ne 0 ]]; then
+        if [[ -n "${missing_optdeps[@]}" ]] || [[ ${#suggested_optdeps[@]} -ne 0 ]]; then
             fancy_message sub "Optional dependencies"
         fi
         if [[ -n ${missing_optdeps[*]} ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -238,7 +238,7 @@ function prompt_optdepends() {
             fi
         done
 
-        if [[ -n "${missing_optdeps[@]}" ]] || [[ ${#suggested_optdeps[@]} -ne 0 ]]; then
+        if [[ -n "${missing_optdeps[*]}" ]] || [[ ${#suggested_optdeps[@]} -ne 0 ]]; then
             fancy_message sub "Optional dependencies"
         fi
         if [[ -n ${missing_optdeps[*]} ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -238,12 +238,14 @@ function prompt_optdepends() {
             fi
         done
 
-        if [[ ${#suggested_optdeps[@]} -ne 0 ]]; then
+        if [[ -n ${missing_optdeps[@]} ]] || [[ ${#suggested_optdeps[@]} -ne 0 ]]; then
             fancy_message sub "Optional dependencies"
-            if [[ -n ${missing_optdeps[*]} ]]; then
-                echo -ne "\t"
-                fancy_message warn "${BLUE}${missing_optdeps[*]}${NC} does not exist in apt repositories"
-            fi
+        fi
+        if [[ -n ${missing_optdeps[*]} ]]; then
+            echo -ne "\t"
+            fancy_message warn "${BLUE}${missing_optdeps[*]}${NC} does not exist in apt repositories"
+        fi
+        if [[ ${#suggested_optdeps[@]} -ne 0 ]]; then
             if [[ $PACSTALL_INSTALL != 0 ]]; then
                 z=1
                 for i in "${suggested_optdeps[@]}"; do


### PR DESCRIPTION
## Purpose

Take this code piece into consideration:
```bash
optdepends=("viu: image preview" "lshw: hardware info")
```

and that `lshw` is installed, and `viu` is not in the repos. Pacstall will not show a warning that `viu` is not in the repos because `prompt_optdepends` only delivers a prompt when anything in `optdepends` are not installed, and `lshw` is, and `viu` is added to the `missing_optdeps`, so that won't be shown either, leading to no prompt, and no shown messages.

## Approach

Run the showing of missing optdepends before the check for `suggested_optdeps`.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
