### PR TITLE
fix(query-info): add back size

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -470,7 +470,7 @@ hash -r' | sudo tee "$STOWDIR/$name/DEBIAN/$deb_post_file" > /dev/null
     done
 
     deblog "Installed-Size" "$(sudo du -s --apparent-size --exclude=DEBIAN -- "$STOWDIR/$name" | cut -d' ' -f1)"
-    export install_size="$(sudo du -s --apparent-size --exclude=DEBIAN -- "$STOWDIR/$name" | cut -d' ' -f1)"
+    export install_size="$(sudo du -s --apparent-size --exclude=DEBIAN -- "$STOWDIR/$name" | awk '{ print $1 }' | numfmt --to=iec)"
 
     generate_changelog | sudo tee -a "$STOWDIR/$name/DEBIAN/changelog" > /dev/null
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -109,6 +109,7 @@ function log() {
             echo "_pkgname=\"$pkgname"\"
         fi
         echo "_version=\"${epoch+$epoch:}$version"\"
+        echo "_install_size=\"${install_size}"\"
         echo "_date=\"$(date)"\"
         if [[ -n $ppa ]]; then
             echo "_ppa=(${ppa[*]})"
@@ -238,7 +239,7 @@ function prompt_optdepends() {
             fi
         done
 
-        if [[ -n "${missing_optdeps[*]}" ]] || [[ ${#suggested_optdeps[@]} -ne 0 ]]; then
+        if [[ -n ${missing_optdeps[*]} ]] || [[ ${#suggested_optdeps[@]} -ne 0 ]]; then
             fancy_message sub "Optional dependencies"
         fi
         if [[ -n ${missing_optdeps[*]} ]]; then
@@ -469,6 +470,7 @@ hash -r' | sudo tee "$STOWDIR/$name/DEBIAN/$deb_post_file" > /dev/null
     done
 
     deblog "Installed-Size" "$(sudo du -s --apparent-size --exclude=DEBIAN -- "$STOWDIR/$name" | cut -d' ' -f1)"
+    export install_size="$(sudo du -s --apparent-size --exclude=DEBIAN -- "$STOWDIR/$name" | cut -d' ' -f1)"
 
     generate_changelog | sudo tee -a "$STOWDIR/$name/DEBIAN/changelog" > /dev/null
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -469,7 +469,7 @@ hash -r' | sudo tee "$STOWDIR/$name/DEBIAN/$deb_post_file" > /dev/null
         sudo chmod 755 "$STOWDIR/$name/DEBIAN/$i" 1> /dev/null 2>&1
     done
 
-    deblog "Installed-Size" "$(sudo du -s --apparent-size --exclude=DEBIAN -- "$STOWDIR/$name" | cut -d' ' -f1)"
+    deblog "Installed-Size" "$(sudo du -s --apparent-size --exclude=DEBIAN -- "$STOWDIR/$name" | awk '{ print $1 }')"
     export install_size="$(sudo du -s --apparent-size --exclude=DEBIAN -- "$STOWDIR/$name" | awk '{ print $1 }' | numfmt --to=iec)"
 
     generate_changelog | sudo tee -a "$STOWDIR/$name/DEBIAN/changelog" > /dev/null

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -47,7 +47,7 @@ function get_field() {
 echo -e "${BGreen}name${NORMAL}: $(get_field $PACKAGE Package)"
 echo -e "${BGreen}version${NORMAL}: $(get_field $PACKAGE Version)"
 if [[ -n $_install_size ]]; then
-    echo -e "${BGreen}size${NORMAL}: $(get_field $PACKAGE Installed-Size)"
+    echo -e "${BGreen}size${NORMAL}: $_install_size"
 fi
 echo -e "${BGreen}description${NORMAL}: $(get_field $PACKAGE Description)"
 echo -e "${BGreen}date installed${NORMAL}: $_date"

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -47,7 +47,7 @@ function get_field() {
 echo -e "${BGreen}name${NORMAL}: $(get_field $PACKAGE Package)"
 echo -e "${BGreen}version${NORMAL}: $(get_field $PACKAGE Version)"
 if [[ -n $_install_size ]]; then
-    echo -e "${BGreen}size${NORMAL}: $(get_field $PACKAGE Installed-Size | cut -d' ' -f 2 | numfmt --to=iec)"
+    echo -e "${BGreen}size${NORMAL}: $(get_field $PACKAGE Installed-Size)"
 fi
 echo -e "${BGreen}description${NORMAL}: $(get_field $PACKAGE Description)"
 echo -e "${BGreen}date installed${NORMAL}: $_date"

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -46,7 +46,7 @@ function get_field() {
 
 echo -e "${BGreen}name${NORMAL}: $(get_field $PACKAGE Package)"
 echo -e "${BGreen}version${NORMAL}: $(get_field $PACKAGE Version)"
-if [[ -n ${size} ]]; then
+if [[ -n $_install_size ]]; then
     echo -e "${BGreen}size${NORMAL}: $(get_field $PACKAGE Installed-Size | cut -d' ' -f 2 | numfmt --to=iec)"
 fi
 echo -e "${BGreen}description${NORMAL}: $(get_field $PACKAGE Description)"


### PR DESCRIPTION
## Purpose

Somewhere along the road, `$size` stopped working in `query-info.sh`. Another bug this fixes is the `Installed-Size` field including the path of `/usr/src/pacstall/$name`.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
