### PR TITLE
fix(deb): make deb pacdeps auto

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -794,12 +794,12 @@ else
                 exit 1
             fi
             hashcheck "${url##*/}"
-			if sudo apt install -y -f ./"${url##*/}" 2> /dev/null; then
-				log
-				if [[ -f /tmp/pacstall-pacdeps-"$name" ]]; then
-					sudo apt-mark auto "${gives:-$name}" 2> /dev/null
-				fi
-				if type -t postinst > /dev/null 2>&1; then
+            if sudo apt install -y -f ./"${url##*/}" 2> /dev/null; then
+                log
+                if [[ -f /tmp/pacstall-pacdeps-"$name" ]]; then
+                    sudo apt-mark auto "${gives:-$name}" 2> /dev/null
+                fi
+                if type -t postinst > /dev/null 2>&1; then
                     if ! postinst; then
                         error_log 5 "postinst hook"
                         fancy_message error "Could not run postinst hook successfully"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -792,9 +792,12 @@ else
                 exit 1
             fi
             hashcheck "${url##*/}"
-            if sudo apt install -y -f ./"${url##*/}" 2> /dev/null; then
-                log
-                if type -t postinst > /dev/null 2>&1; then
+			if sudo apt install -y -f ./"${url##*/}" 2> /dev/null; then
+				log
+				if [[ -f /tmp/pacstall-pacdeps-"$name" ]]; then
+					sudo apt-mark auto "${gives:-$name}" 2> /dev/null
+				fi
+				if type -t postinst > /dev/null 2>&1; then
                     if ! postinst; then
                         error_log 5 "postinst hook"
                         fancy_message error "Could not run postinst hook successfully"


### PR DESCRIPTION
## Purpose

Currently only pacdeps that are not `-deb` can be marked as auto due to the separate installation processes.

## Approach

Add a check in the deb installation.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
