### PR TITLE
feat(download): `PACSTALL_DOWNLOADER` variable

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -298,14 +298,19 @@ function download() {
     if [[ -z $PACSTALL_DOWNLOADER ]]; then
         if command -v axel &> /dev/null; then
             PACSTALL_DOWNLOADER=axel
-        else
+        elif command -v wget &> /dev/null; then
             PACSTALL_DOWNLOADER=wget
+        else
+            PACSTALL_DOWNLOADER=curl
         fi
     fi
 
     case "$PACSTALL_DOWNLOADER" in
         axel)
             axel -ao "${1##*/}" "$1" || return 1
+            ;;
+        curl)
+            curl -L -# -o "${1##*/}" "$1" || return 1
             ;;
         wget | *)
             wget -q --show-progress --progress=bar:force -- "$1" 2>&1 || return 1

--- a/pacstall
+++ b/pacstall
@@ -295,11 +295,22 @@ function check_url() {
 # use axel if available
 function download() {
     sudo rm -f "${1##*/}"
-    if command -v axel > /dev/null; then
-        axel -ao "${1##*/}" "$1" || return 1
-    else
-        wget -q --show-progress --progress=bar:force -- "$1" 2>&1 || return 1
+    if [[ -z $PACSTALL_DOWNLOADER ]]; then
+        if command -v axel &> /dev/null; then
+            PACSTALL_DOWNLOADER=axel
+        else
+            PACSTALL_DOWNLOADER=wget
+        fi
     fi
+
+    case "$PACSTALL_DOWNLOADER" in
+        axel)
+            axel -ao "${1##*/}" "$1" || return 1
+            ;;
+        wget | *)
+            wget -q --show-progress --progress=bar:force -- "$1" 2>&1 || return 1
+            ;;
+    esac
 }
 
 # source this code block and run like so:


### PR DESCRIPTION
## Purpose

Some CIs have to either remove or bypass the axel binary because of explosive output when downloading. This PR introduces the `PACSTALL_DOWNLOADER` variable which will allow either `axel` or `wget` in order to forcibly set the downloader.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
