### PR TITLE
feat(download): add `quiet-wget` for silent download (#786

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -312,7 +312,7 @@ function download() {
         curl)
             curl -L -# -o "${1##*/}" "$1" || return 1
             ;;
-        null-wget)
+        quiet-wget)
             wget -q -- "$1" 2>&1 || return 1
             ;;
         wget | *)

--- a/pacstall
+++ b/pacstall
@@ -312,6 +312,9 @@ function download() {
         curl)
             curl -L -# -o "${1##*/}" "$1" || return 1
             ;;
+        null-wget)
+            wget -q -- "$1" 2>&1 || return 1
+            ;;
         wget | *)
             wget -q --show-progress --progress=bar:force -- "$1" 2>&1 || return 1
             ;;


### PR DESCRIPTION
## Purpose

Rhino's logs reach 500MB because of the download progress bars...

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
