### PR TITLE
fix(cleanup): unset all variables during life of pacscript

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -44,8 +44,8 @@ function cleanup() {
     fi
     sudo rm -rf "${STOWDIR}/${name:-$PACKAGE}.deb"
     rm -f /tmp/pacstall-select-options
-    unset name version url build_depends depends breaks replace description hash optdepends ppa maintainer pacdeps patch PACPATCH NOBUILDDEP optinstall gives epoch pac_functions 2> /dev/null
-    unset -f pkgver removescript prepare build install incompatible 2> /dev/null
+    unset name pkgname repology epoch url depends build_depends breaks replace gives description hash optdepends ppa maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible optinstall epoch pac_functions 2> /dev/null
+    unset -f pkgver postinst removescript prepare build install 2> /dev/null
 }
 
 function trap_ctrlc() {


### PR DESCRIPTION
## Purpose

If some variables are not cleaned out, they can leak into others, which happened after updating steamtinkerlaunch-git, then rhino-pkg-git. The `postinst` was leaked into rhino-pkg-git when it had none, resulting in an install error.

## Approach

I went through the Pacscript 101 wiki and made sure everything was cleaned.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
