### PR TITLE
perf(search): use native find replace

### DIFF
--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -38,7 +38,7 @@ function getPath() {
 }
 
 function specifyRepo() {
-    mapfile -t SPLIT < <(echo "$1" | tr "/" "\n")
+    mapfile -t SPLIT < <(echo "${1//[\/]/$'\n'}")
 
     if [[ $1 == "file://"* ]] || [[ $1 == "/"* ]] || [[ $1 == "~"* ]] || [[ $1 == "."* ]]; then
         export URLNAME="$(getPath ${1})"
@@ -59,7 +59,7 @@ function specifyRepo() {
 function parseRepo() {
     local REPO="${1}"
 
-    mapfile -t SPLIT < <(echo "$REPO" | tr "/" "\n")
+    mapfile -t SPLIT < <(echo "${REPO//[\/]/$'\n'}")
 
     if [[ $REPO == *"file://"* ]]; then
         local REPODIR="$(getPath ${REPO})"


### PR DESCRIPTION
## Purpose

It's one less external tool used.

## Approach

Replace `tr` in `search.sh` with a native bash variable substitution.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
