### PR TITLE
fix(pacdeps): remove pacdep file after pass

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -645,6 +645,7 @@ if [[ -n $pacdeps ]]; then
             cleanup
             return 1
         fi
+        rm -f /tmp/pacstall-pacdeps-"$i"
     done
 fi
 


### PR DESCRIPTION
## Purpose

The issue is that a pacdep file isn't being deleted once it's not used.

## Approach

Remove it..

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
