### PR TITLE
fix(compare_remote_version): unset `pkgver` before checks

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -136,6 +136,7 @@ function log() {
 
 function compare_remote_version() (
     local input="${1}"
+    unset -f pkgver 2> /dev/null
     source "$LOGDIR/$input" || return 1
     if [[ -z ${_remoterepo} ]]; then
         return


### PR DESCRIPTION
## Purpose

`pkgver` leaks into `compare_remote_version()`, causing potentially broken information.

## Approach

Unset `pkgver` before running.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
