### PR TITLE
fix(compare_remote_version): add check for new pacdep

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -137,7 +137,8 @@ function log() {
 function compare_remote_version() (
     local input="${1}"
     unset -f pkgver 2> /dev/null
-    source "$LOGDIR/$input" || return 1
+	# If pacscript does not exist, assume it's not installed and trigger an "update"
+    source "$LOGDIR/$input" || { echo "update" && return 0; }
     if [[ -z ${_remoterepo} ]]; then
         return
     elif [[ ${_remoterepo} == *"github.com"* ]]; then


### PR DESCRIPTION
## Purpose

If a new pacdep is introduced into a package being upgraded, `compare_remote_version` will simply error out, instead of installing the package.

## Approach

Add check to it.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
