### PR TITLE
fix(download): always create `SRCDIR`

### DIFF
--- a/misc/scripts/download.sh
+++ b/misc/scripts/download.sh
@@ -25,17 +25,15 @@
 # This script downloads pacscripts from the interwebs
 
 if check_url "${URL}"; then
-    if [[ $type == "install" ]]; then
-        mkdir -p "$SRCDIR" || {
-            if ! [[ -w $SRCDIR ]]; then
-                suggested_solution "Run '${UCyan}sudo chown -R $PACSTALL_USER:$PACSTALL_USER $SRCDIR'${NC}"
-            fi
-        }
-        if ! cd "$SRCDIR"; then
-            error_log 1 "install $PACKAGE"
-            fancy_message error "Could not enter ${SRCDIR}"
-            exit 1
+    mkdir -p "$SRCDIR" || {
+        if ! [[ -w $SRCDIR ]]; then
+            suggested_solution "Run '${UCyan}sudo chown -R $PACSTALL_USER:$PACSTALL_USER $SRCDIR'${NC}"
         fi
+    }
+    if ! cd "$SRCDIR"; then
+        error_log 1 "install $PACKAGE"
+        fancy_message error "Could not enter ${SRCDIR}"
+        exit 1
     fi
 
     case "$URL" in

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -46,7 +46,7 @@ function cleanup() {
     rm -f /tmp/pacstall-select-options
     unset name pkgname repology epoch url depends build_depends breaks replace gives description hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible optinstall epoch pac_functions 2> /dev/null
     unset -f pkgver postinst removescript prepare build install 2> /dev/null
-    sudo rm -rf /tmp/pacstall
+    sudo rm -rf "${SRCDIR:?}"
 }
 
 function trap_ctrlc() {


### PR DESCRIPTION
## Purpose

`SRCDIR` doesn't get remade after a package upgrades, meaning the download will fail on upgrades.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
