### PR TITLE
feat(install-local): show package name at beginning and end

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -550,7 +550,7 @@ if [[ -n $PACSTALL_BUILD_CORES ]]; then
     fi
 fi
 
-ask "Do you want to view/edit the pacscript" N
+ask "(${BPurple}$PACKAGE${NC}) Do you want to view/edit the pacscript" N
 if [[ $answer -eq 1 ]]; then
     (
         if [[ -n $PACSTALL_EDITOR ]]; then
@@ -984,6 +984,7 @@ sudo chmod o+r "/var/cache/pacstall/$PACKAGE/${epoch+$epoch:}$version/$PACKAGE.p
 fancy_message sub "Cleaning up"
 cleanup
 
+fancy_message info "Done installing ${BPurple}$PACKAGE${NC}"
 return 0
 
 # vim:set ft=sh ts=4 sw=4 noet:


### PR DESCRIPTION
## Purpose

During installs with multiple packages, it can be hard to see what package is currently being installed.

## Approach

Show the package name before and after it installs.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.