### PR TITLE
refactor(install-local): quote everything, remove sed command

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -736,8 +736,7 @@ function hashcheck() {
 
     # Check if the input hash is the same as of the downloaded file.
     # Skip this test if the hash variable doesn't exist in the pacscript.
-    if [[ -n ${hash} ]] && [[ ${inputHash} != "${fileHash}" ]]; then
-        # We bad
+    if [[ -n "${hash}" ]] && [[ "${inputHash}" != "${fileHash}" ]]; then
         fancy_message error "Hashes do not match"
         error_log 16 "install $PACKAGE"
         fancy_message info "Cleaning up"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -203,7 +203,7 @@ function is_compatible_arch() {
     local input=("${@}")
     if [[ " ${input[*]} " =~ " all " ]]; then
         fancy_message warn "${BBlue}all${NC} is deprecated. Use ${BBlue}any${NC} instead"
-		suggested_solution "Replace ${UPurple}arch${NC} with ${UCyan}arch=(${arch[*]/all/any})${NC}"
+        suggested_solution "Replace ${UPurple}arch${NC} with ${UCyan}arch=(${arch[*]/all/any})${NC}"
         return 0
     elif [[ " ${input[*]} " =~ " any " ]]; then
         return 0
@@ -729,13 +729,14 @@ if [[ -n ${build_depends[*]} ]]; then
 fi
 
 function hashcheck() {
-    local inputHash=$hash
+    local inputHash="${hash}"
     # Get hash of file
-    local fileHash="$(sha256sum "$1" | sed 's/\s.*$//')"
+    local fileHash="$(sha256sum "${1}")"
+    fileHash="${fileHash%% *}"
 
     # Check if the input hash is the same as of the downloaded file.
     # Skip this test if the hash variable doesn't exist in the pacscript.
-    if [[ $inputHash != "$fileHash" ]] && [[ -n ${hash} ]]; then
+    if [[ -n ${hash} ]] && [[ ${inputHash} != "${fileHash}" ]]; then
         # We bad
         fancy_message error "Hashes do not match"
         error_log 16 "install $PACKAGE"


### PR DESCRIPTION
## Purpose

The function is one of the oldest and hasn't been touched in a long time. It has some quoted and some not quoted variables, and it uses a sed command that can easily be replaced.

## Approach

Quote all variables, swap out sed for native bash parameter expansion.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.