### PR TITLE
fix(install-local): remove duplicate code, use `SRCDIR`

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -762,7 +762,7 @@ else
 fi
 
 sudo mkdir -p "${SRCDIR}"
-sudo chown "$PACSTALL_USER:$PACSTALL_USER" -R "${SRCDIR}"
+sudo chown -R "$PACSTALL_USER:$PACSTALL_USER" -R "${SRCDIR}"
 
 if [[ -n $patch ]]; then
     fancy_message info "Downloading patches"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -36,10 +36,8 @@ function cleanup() {
         rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
         sudo rm -rf /tmp/pacstall-pacdep
     else
-        sudo rm -rf "${SRCDIR:?}"/*
         # just in case we quit before $name is declared, we should be able to remove a fake directory so it doesn't exit out the script
         sudo rm -rf "${STOWDIR:-/usr/src/pacstall}/${name:-raaaaaaaandom}"
-        sudo rm -rf /tmp/pacstall/*
         sudo rm -rf /tmp/pacstall-gives
     fi
     sudo rm -rf "${STOWDIR}/${name:-$PACKAGE}.deb"
@@ -763,8 +761,8 @@ else
     fi
 fi
 
-sudo mkdir -p "/tmp/pacstall"
-sudo chown "$PACSTALL_USER" -R /tmp/pacstall
+sudo mkdir -p "${SRCDIR}"
+sudo chown "$PACSTALL_USER:$PACSTALL_USER" -R "${SRCDIR}"
 
 if [[ -n $patch ]]; then
     fancy_message info "Downloading patches"


### PR DESCRIPTION
## Purpose

Parts of the codebase are duplicates, and a couple references to `/tmp/pacstall` should be `SRCDIR`.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.