### PR TITLE
feat(pacstall): add `PACSTALL_PAYLOAD` support

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -777,6 +777,12 @@ if [[ -n $patch ]]; then
     export PACPATCH="$PWD/PACSTALL_patchesdir"
 fi
 
+if [[ -n $PACSTALL_PAYLOAD ]]; then
+	file_name=${PACSTALL_PAYLOAD##*/}
+else
+	file_name=${url##*/}
+fi
+
 if [[ $name == *-git ]]; then
     # git clone quietly, with no history, and if submodules are there, download with 10 jobs
     git clone --quiet --depth=1 --jobs=10 "$url"
@@ -801,10 +807,10 @@ else
                 exit 1
             fi
             # hash the file
-            hashcheck "${url##*/}" || return 1
+            hashcheck "${file_name}" || return 1
             # unzip file
-            fancy_message info "Extracting ${url##*/}"
-            unzip -qo "${url##*/}" 1>&1 2> /dev/null
+            fancy_message info "Extracting ${file_name}"
+            unzip -qo "${file_name}" 1>&1 2> /dev/null
             # cd into it
             cd ./*/ 2> /dev/null || {
                 error_log 1 "install $PACKAGE"
@@ -819,8 +825,8 @@ else
                 cleanup
                 exit 1
             fi
-            hashcheck "${url##*/}" || return 1
-            if sudo apt install -y -f ./"${url##*/}" 2> /dev/null; then
+            hashcheck "${file_name}" || return 1
+            if sudo apt install -y -f ./"${file_name}" 2> /dev/null; then
                 log
                 if [[ -f /tmp/pacstall-pacdeps-"$name" ]]; then
                     sudo apt-mark auto "${gives:-$name}" 2> /dev/null
@@ -863,7 +869,7 @@ else
                 cleanup
                 exit 1
             fi
-            hashcheck "${url##*/}" || return 1
+            hashcheck "${file_name}" || return 1
             ;;
         *)
             if ! download "$url"; then
@@ -873,9 +879,9 @@ else
                 cleanup
                 exit 1
             fi
-            hashcheck "${url##*/}" || return 1
-            fancy_message info "Extracting ${url##*/}"
-            tar -xf "${url##*/}" 1>&1 2> /dev/null
+            hashcheck "${file_name}" || return 1
+            fancy_message info "Extracting ${file_name}"
+            tar -xf "${file_name}" 1>&1 2> /dev/null
             cd ./*/ 2> /dev/null || {
                 error_log 1 "install $PACKAGE"
                 fancy_message warn "Could not enter into the downloaded archive"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -778,9 +778,9 @@ if [[ -n $patch ]]; then
 fi
 
 if [[ -n $PACSTALL_PAYLOAD ]]; then
-	file_name=${PACSTALL_PAYLOAD##*/}
+	file_name="${PACSTALL_PAYLOAD##*/}"
 else
-	file_name=${url##*/}
+	file_name="${url##*/}"
 fi
 
 if [[ $name == *-git ]]; then

--- a/pacstall
+++ b/pacstall
@@ -321,6 +321,7 @@ function download() {
         quiet-wget)
             wget -q -- "$1" 2>&1 || return 1
             ;;
+        payload) ;;
         wget | *)
             wget -q --show-progress --progress=bar:force -- "$1" 2>&1 || return 1
             ;;
@@ -453,6 +454,22 @@ while lock $1 $2 $3 $4; do
     fi
     sleep 1
 done
+
+if [[ -n $PACSTALL_PAYLOAD ]]; then
+    export PACSTALL_DOWNLOADER="payload"
+
+    if [[ ! -f $PACSTALL_PAYLOAD ]]; then
+        fancy_message error "Payload not found"
+        exit 1
+    fi
+    mkdir -p /tmp/pacstall
+    cp "$PACSTALL_PAYLOAD" /tmp/pacstall/
+elif [[ $PACSTALL_PAYLOAD == "" ]]; then
+    fancy_message error "Payload cannot be empty"
+    exit 1
+else
+    :
+fi
 
 while [[ $1 != "--" ]]; do
     case "$1" in

--- a/pacstall
+++ b/pacstall
@@ -462,8 +462,8 @@ if [[ -n $PACSTALL_PAYLOAD ]]; then
         fancy_message error "Payload not found"
         exit 1
     fi
-    mkdir -p /tmp/pacstall
-    cp "$PACSTALL_PAYLOAD" /tmp/pacstall/
+    mkdir -p "${SRCDIR:?}"
+    cp "$PACSTALL_PAYLOAD" "${SRCDIR:?}"
 fi
 
 while [[ $1 != "--" ]]; do

--- a/pacstall
+++ b/pacstall
@@ -464,11 +464,6 @@ if [[ -n $PACSTALL_PAYLOAD ]]; then
     fi
     mkdir -p /tmp/pacstall
     cp "$PACSTALL_PAYLOAD" /tmp/pacstall/
-elif [[ -n $PACSTALL_PAYLOAD && $PACSTALL_PAYLOAD == "" ]]; then
-    fancy_message error "Payload cannot be empty"
-    exit 1
-else
-    :
 fi
 
 while [[ $1 != "--" ]]; do

--- a/pacstall
+++ b/pacstall
@@ -464,7 +464,7 @@ if [[ -n $PACSTALL_PAYLOAD ]]; then
     fi
     mkdir -p /tmp/pacstall
     cp "$PACSTALL_PAYLOAD" /tmp/pacstall/
-elif [[ $PACSTALL_PAYLOAD == "" ]]; then
+elif [[ -n $PACSTALL_PAYLOAD && $PACSTALL_PAYLOAD == "" ]]; then
     fancy_message error "Payload cannot be empty"
     exit 1
 else


### PR DESCRIPTION
## Purpose

<!--Describe the problem you are fixing or the feature you are adding.-->

Adds `PACSTALL_PAYLOAD` environment variable support, that skips downloading the `url`. This is to prevent double downloads when using pacup.

## Approach

<!--How does this address the problem?-->

Adds `PACSTALL_PAYLOAD` environment variable support that takes a file path as the value. This disables the `download` function, and makes `install-local.sh` use the `/tmp/pacstall/<file_name>` as the file name, were the payload is copied to.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
