### PR TITLE
fix(pacdeps): pacdeps are implicit deps to parent package

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -316,20 +316,18 @@ function prompt_optdepends() {
         fi
     fi
 
-    if [[ -n ${deps[*]} ]]; then
-        if [[ -n ${pacdeps[*]} ]]; then
-            for i in "${pacdeps[@]}"; do
-                (
-                    source "$LOGDIR/$i"
-                    if [[ -n $_gives ]]; then
-                        echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
-                    else
-                        echo "$_name" | tee -a /tmp/pacstall-gives > /dev/null
-                    fi
-                )
-            done
-            deps+=($(cat /tmp/pacstall-gives))
-        fi
+    if [[ -n ${pacdeps[*]} ]]; then
+        for i in "${pacdeps[@]}"; do
+            (
+                source "$LOGDIR/$i"
+                if [[ -n ${_gives} ]]; then
+                    echo "${_gives}" | tee -a /tmp/pacstall-gives > /dev/null
+                else
+                    echo "${_name}" | tee -a /tmp/pacstall-gives > /dev/null
+                fi
+            )
+        done
+        deps+=($(< /tmp/pacstall-gives))
     fi
     if [[ -n $depends ]] || [[ -n ${deps[*]} ]]; then
         deblog "Depends" "$(echo "${deps[@]}" | sed 's/ /, /g')"


### PR DESCRIPTION
## Purpose

Previously we'd check if deps exist first, then if pacdeps exist, then make them implicit deps, but we don't want that. We want to check if pacdeps exist, then add them to the deps list.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
