### PR TITLE
refactor: quote variables & use `mapfile` wherever possible

### DIFF
--- a/misc/scripts/add-repo.sh
+++ b/misc/scripts/add-repo.sh
@@ -41,7 +41,7 @@ elif [[ $REPO == *"gitlab.com"* ]]; then
     fi
 elif [[ -d $REPO ]] > /dev/null; then
     if [[ $REPO != *"file://"* ]]; then
-        REPO="file://$(readlink -f $REPO)"
+        REPO="file://$(readlink -f "$REPO")"
     fi
 else
     fancy_message warn "The repo link must be the root to the raw files"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -690,14 +690,16 @@ if ! pacstall -L | grep -E "(^| )${name}( |$)" > /dev/null 2>&1; then
                 cleanup
                 return 1
             fi
-            sudo apt-get remove -y $replace
+            mapfile -t replaces_tmp <<< "${replace// /$'\n'}"
+            sudo apt-get remove -y "${replaces_tmp[@]}"
+            unset replaces_tmp
         fi
     fi
 fi
 
 if [[ -n ${build_depends[*]} ]]; then
     # Get all uninstalled build depends
-    build_depends=($build_depends)
+    mapfile -t build_depends <<< "${build_depends// /$'\n'}"
     for build_dep in "${build_depends[@]}"; do
         if [[ "$(dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null)" == "install ok installed" ]]; then
             build_depends_to_delete+=("${build_dep}")

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -273,9 +273,7 @@ function prompt_optdepends() {
                 # tab over the next line
                 echo -ne "\t"
                 select_options "Select optional dependencies to install" "${#suggested_optdeps[@]}"
-                while IFS= read -r line; do
-                    choices+=("$line")
-                done < /tmp/pacstall-select-options
+				read -ra choices < /tmp/pacstall-select-options
                 local choice_inc=0
                 for i in "${choices[@]}"; do
                     # have we gone over the maximum number in choices[@]?

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -225,7 +225,7 @@ function clean_builddir() {
 
 function prompt_optdepends() {
     if [[ -n $depends ]]; then
-		mapfile -t deps <<< "${depends// /$'\n'}"
+        mapfile -t deps <<< "${depends// /$'\n'}"
     fi
     if [[ ${#optdepends[@]} -ne 0 ]]; then
         for i in "${optdepends[@]}"; do
@@ -263,9 +263,11 @@ function prompt_optdepends() {
         fi
         if [[ ${#suggested_optdeps[@]} -ne 0 ]]; then
             if [[ $PACSTALL_INSTALL != 0 ]]; then
+                z=1
                 for i in "${suggested_optdeps[@]}"; do
                     # print optdepends with bold package name
-					echo -e "\t\t[${BICyan}$((i + 1))${NC}] ${BOLD}${i%%:*}${NC}:${i#*:}"
+                    echo -e "\t\t[${BICyan}$z${NC}] ${BOLD}${i%%:*}${NC}:${i#*:}"
+                    ((z++))
                 done
                 unset z
                 # tab over the next line
@@ -326,9 +328,9 @@ function prompt_optdepends() {
                     fi
                 )
             done
-			while IFS= read -r line; do
-				deps+=("$line")
-			done < /tmp/pacstall-gives
+            while IFS= read -r line; do
+                deps+=("$line")
+            done < /tmp/pacstall-gives
         fi
     fi
     if [[ -n $depends ]] || [[ -n ${deps[*]} ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -225,7 +225,7 @@ function clean_builddir() {
 
 function prompt_optdepends() {
     if [[ -n $depends ]]; then
-		mapfile -d" " deps <<< "${depends}"
+		mapfile -t deps <<< "${depends// /$'\n'}"
     fi
     if [[ ${#optdepends[@]} -ne 0 ]]; then
         for i in "${optdepends[@]}"; do
@@ -263,11 +263,9 @@ function prompt_optdepends() {
         fi
         if [[ ${#suggested_optdeps[@]} -ne 0 ]]; then
             if [[ $PACSTALL_INSTALL != 0 ]]; then
-                z=1
                 for i in "${suggested_optdeps[@]}"; do
                     # print optdepends with bold package name
-                    echo -e "\t\t[${BICyan}$z${NC}] ${BOLD}${i%%:*}${NC}:${i#*:}"
-                    ((z++))
+					echo -e "\t\t[${BICyan}$((i + 1))${NC}] ${BOLD}${i%%:*}${NC}:${i#*:}"
                 done
                 unset z
                 # tab over the next line

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -147,14 +147,14 @@ function compare_remote_version() (
     else
         local remoterepo="${_remoterepo}"
     fi
-    local remotever="$(source <(curl -s -- "$remoterepo"/packages/"$input"/"$input".pacscript) && type pkgver &> /dev/null && pkgver || echo "${full_version}")" > /dev/null
+    local remotever="$(source <(curl -s -- "$remoterepo/packages/$input/$input.pacscript") && type pkgver &> /dev/null && pkgver || echo "${full_version}")" > /dev/null
     if [[ $input == *"-git" ]]; then
-        if [[ $(pacstall -V $input) != "$remotever" ]]; then
+        if [[ $(pacstall -V "$input") != "$remotever" ]]; then
             echo "update"
         else
             echo "no"
         fi
-    elif dpkg --compare-versions "$(pacstall -V $input)" lt "$remotever" > /dev/null 2>&1; then
+    elif dpkg --compare-versions "$(pacstall -V "$input")" lt "$remotever" > /dev/null 2>&1; then
         echo "update"
     else
         echo "no"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -32,8 +32,8 @@ function cleanup() {
             sudo mv "${SRCDIR:?}"/* "/tmp/pacstall-keep/$name"
         fi
     fi
-    if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
-        sudo rm -rf /tmp/pacstall-pacdeps-"$PACKAGE"
+    if [[ -f "/tmp/pacstall-pacdeps-$PACKAGE" ]]; then
+        sudo rm -rf "/tmp/pacstall-pacdeps-$PACKAGE"
         sudo rm -rf /tmp/pacstall-pacdep
     else
         sudo rm -rf "${SRCDIR:?}"/*
@@ -53,7 +53,7 @@ function trap_ctrlc() {
     if dpkg-query -W -f='${Status}' "$name" 2> /dev/null | grep -q -E "ok installed|ok unpacked"; then
         sudo apt-get purge "${gives:-$name}" -y > /dev/null
     fi
-    sudo rm -f /etc/apt/preferences.d/"${name:-$PACKAGE}-pin"
+    sudo rm -f "/etc/apt/preferences.d/${name:-$PACKAGE}-pin"
     cleanup
     exit 1
 }

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -97,7 +97,7 @@ function log() {
             pBRANCH="${REPO##*/-/raw/}"
             branch="yes"
         else
-            pURL=$REPO
+            pURL="$REPO"
             branch="no"
         fi
     fi
@@ -273,7 +273,9 @@ function prompt_optdepends() {
                 # tab over the next line
                 echo -ne "\t"
                 select_options "Select optional dependencies to install" "${#suggested_optdeps[@]}"
-                choices=($(cat /tmp/pacstall-select-options))
+                while IFS= read -r line; do
+                    choices+=("$line")
+                done < /tmp/pacstall-select-options
                 local choice_inc=0
                 for i in "${choices[@]}"; do
                     # have we gone over the maximum number in choices[@]?
@@ -428,11 +430,11 @@ function makedeb() {
     deblog "Description" "${description}"
 
     for i in {removescript,postinst}; do
-        case $i in
+        case "$i" in
             removescript) export deb_post_file="postrm" ;;
             postinst) export deb_post_file="postinst" ;;
         esac
-        if [[ $(type -t $i) == function ]]; then
+        if [[ $(type -t "$i") == function ]]; then
             echo '#!/bin/bash
 set -e
 function ask() {

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -44,25 +44,25 @@ function get_field() {
     fi
 }
 
-echo -e "${BGreen}name${NORMAL}: $(get_field $PACKAGE Package)"
-echo -e "${BGreen}version${NORMAL}: $(get_field $PACKAGE Version)"
+echo -e "${BGreen}name${NORMAL}: $(get_field "$PACKAGE" Package)"
+echo -e "${BGreen}version${NORMAL}: $(get_field "$PACKAGE" Version)"
 if [[ -n $_install_size ]]; then
     echo -e "${BGreen}size${NORMAL}: $_install_size"
 fi
-echo -e "${BGreen}description${NORMAL}: $(get_field $PACKAGE Description)"
+echo -e "${BGreen}description${NORMAL}: $(get_field "$PACKAGE" Description)"
 echo -e "${BGreen}date installed${NORMAL}: $_date"
 
 if [[ -n $_remoterepo ]]; then
     echo -e "${BGreen}remote repo${NORMAL}: $_remoterepo"
 fi
-echo -e "${BGreen}maintainer${NORMAL}: $(get_field $PACKAGE Maintainer)"
+echo -e "${BGreen}maintainer${NORMAL}: $(get_field "$PACKAGE" Maintainer)"
 if [[ -n $_ppa ]]; then
     echo -e "${BGreen}ppa${NORMAL}: $_ppa"
 fi
 if [[ -n $_pacdeps ]]; then
     echo -e "${BGreen}pacstall dependencies${NORMAL}: ${_pacdeps[*]}"
 fi
-deps=$(get_field $PACKAGE Depends | tr -d ',')
+deps=$(get_field "$PACKAGE" Depends | tr -d ',')
 if [[ -n $deps ]]; then
     echo -e "${BGreen}dependencies${NORMAL}: ${deps}"
 fi

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -32,16 +32,16 @@ function getPath() {
     local path="${1}"
     path="${path/"file://"/}"
     path="${path/"~"/"$HOME"}"
-    path="$(readlink -f ${path})"
+    path="$(readlink -f "${path}")"
     path="${path/"$HOME"/"~"}"
-    echo $path
+    echo "${path}"
 }
 
 function specifyRepo() {
     mapfile -t SPLIT < <(echo "${1//[\/]/$'\n'}")
 
     if [[ $1 == "file://"* ]] || [[ $1 == "/"* ]] || [[ $1 == "~"* ]] || [[ $1 == "."* ]]; then
-        export URLNAME="$(getPath ${1})"
+        export URLNAME="$(getPath "${1}")"
     elif [[ $1 == *"github"* ]]; then
         export URLNAME="${SPLIT[-3]}/${SPLIT[-2]}"
     elif [[ $1 == *"gitlab"* ]]; then
@@ -62,7 +62,7 @@ function parseRepo() {
     mapfile -t SPLIT < <(echo "${REPO//[\/]/$'\n'}")
 
     if [[ $REPO == *"file://"* ]]; then
-        local REPODIR="$(getPath ${REPO})"
+        local REPODIR="$(getPath "${REPO}")"
         echo "\e]8;;$REPO\a$REPODIR\e]8;;\a"
     elif [[ $REPO == *"github"* ]]; then
         echo -e "\e]8;;https://github.com/${SPLIT[-3]}/${SPLIT[-2]}\a${SPLIT[-3]}/${SPLIT[-2]}\e]8;;\a"
@@ -76,7 +76,7 @@ function parseRepo() {
 if [[ $PACKAGE == *@* ]]; then
     REPONAME=${PACKAGE#*@}
     if [[ $REPONAME == "file://"* ]] || [[ $REPONAME == "/"* ]] || [[ $REPONAME == "~"* ]] || [[ $REPONAME == "."* ]]; then
-        REPONAME="$(getPath ${REPONAME})"
+        REPONAME="$(getPath "${REPONAME}")"
     fi
     PACKAGE=${PACKAGE%%@*}
 
@@ -119,7 +119,7 @@ while IFS= read -r URL; do
     fi
     if ! check_url "${URL}/packagelist"; then
         if [[ -z $REPOMSG ]]; then
-            fancy_message warn "Skipping repo $CYAN$(parseRepo ${URL})$NC"
+            fancy_message warn "Skipping repo $CYAN$(parseRepo "${URL}")$NC"
             fancy_message warn "You can remove or fix the URL by editing $CYAN$STGDIR/repo/pacstallrepo.txt$NC"
         fi
         continue

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -26,7 +26,7 @@ function ver_compare() {
     local first second
     first="${1#${1/[0-9]*/}}"
     second="${2#${2/[0-9]*/}}"
-    return $(dpkg --compare-versions "$first" lt "$second")
+    return "$(dpkg --compare-versions "$first" lt "$second")"
 }
 
 export UPGRADE="yes"

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -63,12 +63,13 @@ N="$(nproc)"
 
             unset _remoterepo
 
+            # shellcheck source=./misc/scripts/search.sh
             source "$STGDIR/scripts/search.sh"
 
             IDXMATCH=$(printf "%s\n" "${REPOS[@]}" | awk "\$1 ~ /^${remoterepo//\//\\/}$/ {print NR-1}")
 
             if [[ -n $IDXMATCH ]]; then
-                remotever=$(source <(curl -s -- "$remoterepo"/packages/"$i"/"$i".pacscript) && type pkgver &> /dev/null && pkgver || echo "${epoch:+$epoch:}$version") > /dev/null
+                remotever=$(source <(curl -s -- "$remoterepo/packages/$i/$i.pacscript") && type pkgver &> /dev/null && pkgver || echo "${epoch:+$epoch:}$version") > /dev/null
                 remoteurl="${REPOS[$IDXMATCH]}"
             else
                 fancy_message warn "Package ${GREEN}${i}${CYAN} is not on ${CYAN}$(parseRepo "${remoterepo}")${NC} anymore"
@@ -149,10 +150,12 @@ ${BOLD}$(cat "${up_print}")${NORMAL}\n"
         fi
         REPO="${remotes[$i]}"
         export URL="$REPO/packages/$PACKAGE/$PACKAGE.pacscript"
+        # shellcheck source=./misc/scripts/download.sh
         if ! source "$STGDIR/scripts/download.sh"; then
             fancy_message error "Failed to download the ${GREEN}${PACKAGE}${NC} pacscript"
             continue
         fi
+        # shellcheck source=./misc/scripts/install-local.sh
         source "$STGDIR/scripts/install-local.sh"
     done
 fi

--- a/pacstall
+++ b/pacstall
@@ -341,7 +341,7 @@ function select_options() {
         echo -ne "${message} [${BOLD}$(seq -s ' ' 1 "$length")${NC}] [${BIGreen}Y${NC}/${RED}n${NC}] "
     fi
     if [[ $DISABLE_PROMPTS == "no" ]]; then
-        read -r input <&0
+        read -ra input <&0
         if [[ $NON_INTERACTIVE ]]; then
             if [[ -z $input ]]; then
                 echo "Y"
@@ -358,8 +358,8 @@ function select_options() {
         echo "n" | tee /tmp/pacstall-select-options > /dev/null
     elif ! [[ $input =~ [a-zA-Z]+ ]] || [[ $input =~ ^[0-9]+$ ]]; then
         for i in "${input[@]}"; do
-            local out
-            local split_arr
+			unset split_arr
+            local out split_arr
             if [[ $i =~ [0-9]+-[0-9]+ ]] || [[ $i =~ [0-9]+..[0-9]+ ]]; then
                 case "$i" in
                     *-*)

--- a/pacstall
+++ b/pacstall
@@ -358,22 +358,25 @@ function select_options() {
         echo "n" | tee /tmp/pacstall-select-options > /dev/null
     elif ! [[ $input =~ [a-zA-Z]+ ]] || [[ $input =~ ^[0-9]+$ ]]; then
         for i in "${input[@]}"; do
+            local out
+            local split_arr
             if [[ $i =~ [0-9]+-[0-9]+ ]] || [[ $i =~ [0-9]+..[0-9]+ ]]; then
                 case "$i" in
                     *-*)
-                        split_arr=(${i//-/ })
+                        mapfile -d" " split_arr <<< "${i//-/ }"
                         ;;
                     *..*)
-                        split_arr=(${i//../ })
+                        mapfile -d" " split_arr <<< "${i//../ }"
                         ;;
                     *)
                         select_options "$message" "$length"
                         ;;
                 esac
+                # We can't use mapfile for this because it will overwrite
                 out+=($(seq -s ' ' "${split_arr[0]}" "${split_arr[1]}"))
                 continue
             else
-                out+=($i)
+                out+=("$i")
             fi
         done
         echo "${out[@]}" | tee /tmp/pacstall-select-options > /dev/null

--- a/pacstall
+++ b/pacstall
@@ -662,6 +662,7 @@ Helpful links:
             fi
 
             if [[ -n $REPO ]]; then
+				# shellcheck source=./misc/scripts/add-repo.sh
                 source "$STGDIR/scripts/add-repo.sh"
                 exit 0
             else
@@ -725,6 +726,7 @@ Helpful links:
                 exit 1
             fi
             sudo wget -q -N https://raw.githubusercontent.com/"$USERNAME"/pacstall/"$BRANCH"/misc/scripts/update.sh -P "$STGDIR/scripts" 2> /dev/null
+			# shellcheck source=./misc/scripts/update.sh
             source "$STGDIR/scripts/update.sh"
             exit 0
             ;;
@@ -761,6 +763,7 @@ Helpful links:
                     exit 1
                 }
 
+				# shellcheck source=./misc/scripts/search.sh
                 if ! source "$STGDIR/scripts/search.sh"; then
                     continue
                 fi
@@ -768,6 +771,7 @@ Helpful links:
                 specifyRepo "$REPO"
                 export URL="$REPO/packages/$PACKAGE/$PACKAGE.pacscript"
 
+				# shellcheck source=./misc/scripts/download.sh
                 if ! source "$STGDIR/scripts/download.sh"; then
                     fancy_message error "Failed to download the ${GREEN}${PACKAGE}${NC} pacscript"
                     suggested_solution "Confirm that the package exists by running '${UCyan}pacstall -S $PACKAGE${NC}'" "Check your internet connection"
@@ -791,6 +795,7 @@ Helpful links:
                 suggested_solution "Confirm that the URLs '${UGreen}https://github.com${NC}' or '${UGreen}https://gitlab.com${NC}' are accessible"
                 exit 1
             }
+			# shellcheck source=./misc/scripts/upgrade.sh
             source "$STGDIR/scripts/upgrade.sh"
             exit 0
             ;;
@@ -815,6 +820,7 @@ Helpful links:
 
         -Qi | --query-info)
             PACKAGE=$2
+			# shellcheck source=./misc/scripts/query-info.sh
             source "$STGDIR/scripts/query-info.sh"
             exit 0
             ;;

--- a/pacstall
+++ b/pacstall
@@ -363,17 +363,16 @@ function select_options() {
             if [[ $i =~ [0-9]+-[0-9]+ ]] || [[ $i =~ [0-9]+..[0-9]+ ]]; then
                 case "$i" in
                     *-*)
-                        mapfile -d" " split_arr <<< "${i//-/ }"
+                        mapfile -t -O"${#split_arr[@]}" -d" " split_arr <<< "${i//-/ }"
                         ;;
                     *..*)
-                        mapfile -d" " split_arr <<< "${i//../ }"
+                        mapfile -t -O"${#split_arr[@]}" -d" " split_arr <<< "${i//../ }"
                         ;;
                     *)
                         select_options "$message" "$length"
                         ;;
                 esac
-                # We can't use mapfile for this because it will overwrite
-                out+=($(seq -s ' ' "${split_arr[0]}" "${split_arr[1]}"))
+                mapfile -t -O"${#split_arr[@]}" split_arr < <(seq "${split_arr[0]}" "${split_arr[1]}")
                 continue
             else
                 out+=("$i")

--- a/pacstall
+++ b/pacstall
@@ -446,7 +446,7 @@ function lock() {
     elif [[ -f "/tmp/pacstall-pacdeps-$4" ]]; then
         return 1
     fi
-    pidof -o %PPID -x $0 > /dev/null && return 0 || return 1
+    pidof -o %PPID -x "$0" > /dev/null && return 0 || return 1
 }
 
 while lock $1 $2 $3 $4; do
@@ -587,7 +587,7 @@ Helpful links:
                         continue
                     fi
 
-                    specifyRepo $REPO
+                    specifyRepo "$REPO"
                     URL="$REPO/packages/$PACKAGE/$PACKAGE.pacscript"
 
                     if ! source "$STGDIR/scripts/download.sh"; then
@@ -757,7 +757,7 @@ Helpful links:
                     continue
                 fi
 
-                specifyRepo $REPO
+                specifyRepo "$REPO"
                 export URL="$REPO/packages/$PACKAGE/$PACKAGE.pacscript"
 
                 if ! source "$STGDIR/scripts/download.sh"; then

--- a/pacstall
+++ b/pacstall
@@ -376,7 +376,7 @@ function select_options() {
                         select_options "$message" "$length"
                         ;;
                 esac
-                split_arr+=($(seq -s ' ' "${split_arr[0]}" "${split_arr[1]}"))
+                out+=($(seq -s ' ' "${split_arr[0]}" "${split_arr[1]}"))
                 continue
             else
                 out+=("$i")

--- a/pacstall
+++ b/pacstall
@@ -376,7 +376,7 @@ function select_options() {
                         select_options "$message" "$length"
                         ;;
                 esac
-                out+=($(seq -s ' ' "${split_arr[0]}" "${split_arr[1]}"))
+                out+=($(seq "${split_arr[0]}" "${split_arr[1]}"))
                 continue
             else
                 out+=("$i")

--- a/pacstall
+++ b/pacstall
@@ -363,16 +363,20 @@ function select_options() {
             if [[ $i =~ [0-9]+-[0-9]+ ]] || [[ $i =~ [0-9]+..[0-9]+ ]]; then
                 case "$i" in
                     *-*)
-                        mapfile -t -O"${#split_arr[@]}" -d" " split_arr <<< "${i//-/ }"
+                        for line in ${i//-/ }; do
+                            split_arr+=("$line")
+                        done
                         ;;
                     *..*)
-                        mapfile -t -O"${#split_arr[@]}" -d" " split_arr <<< "${i//../ }"
+                        for line in ${i//../ }; do
+                            split_arr+=("$line")
+                        done
                         ;;
                     *)
                         select_options "$message" "$length"
                         ;;
                 esac
-                mapfile -t -O"${#split_arr[@]}" split_arr < <(seq "${split_arr[0]}" "${split_arr[1]}")
+                split_arr+=($(seq -s ' ' "${split_arr[0]}" "${split_arr[1]}"))
                 continue
             else
                 out+=("$i")

--- a/pacstall
+++ b/pacstall
@@ -394,6 +394,7 @@ fi
 # run sudo apt update if it's been more than a week
 [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -7)" ]] && sudo apt-get update -qq
 
+# shellcheck source=./misc/scripts/error_log.sh
 source "$STGDIR/scripts/error_log.sh"
 
 if [[ ! -t 0 ]]; then
@@ -583,6 +584,7 @@ Helpful links:
                         exit 1
                     }
 
+                    # shellcheck source=./misc/scripts/search.sh
                     if ! source "$STGDIR/scripts/search.sh"; then
                         continue
                     fi
@@ -590,6 +592,7 @@ Helpful links:
                     specifyRepo "$REPO"
                     URL="$REPO/packages/$PACKAGE/$PACKAGE.pacscript"
 
+                    # shellcheck source=./misc/scripts/download.sh
                     if ! source "$STGDIR/scripts/download.sh"; then
                         fancy_message error "Failed to download the ${GREEN}${PACKAGE}${NC} pacscript"
                         suggested_solution "Confirm that the package exists by running '${UCyan}pacstall -S $PACKAGE${NC}'" "Check your internet connection"
@@ -597,6 +600,7 @@ Helpful links:
                     fi
                     export REPO
                 fi
+                # shellcheck source=./misc/scripts/install-local.sh
                 if ! source "$STGDIR/scripts/install-local.sh"; then
                     fancy_message error "Failed to install ${GREEN}${PACKAGE}${NC}"
                     if ! [[ -f "/tmp/pacstall-pacdeps-$PACKAGE" ]]; then
@@ -623,6 +627,7 @@ Helpful links:
                 exit 1
             }
 
+            # shellcheck source=./misc/scripts/search.sh
             source "$STGDIR/scripts/search.sh"
             exit 0
             ;;
@@ -637,6 +642,7 @@ Helpful links:
             while [[ -n $2 ]]; do
                 PACKAGE=$2
                 shift
+                # shellcheck source=./misc/scripts/search.sh
                 if ! source "$STGDIR/scripts/remove.sh"; then
                     fancy_message error "Failed to remove ${GREEN}${PACKAGE}${NC}"
                 fi
@@ -753,7 +759,6 @@ Helpful links:
                 }
 
                 if ! source "$STGDIR/scripts/search.sh"; then
-                    ((i++))
                     continue
                 fi
 

--- a/pacstall
+++ b/pacstall
@@ -645,7 +645,7 @@ Helpful links:
             while [[ -n $2 ]]; do
                 PACKAGE=$2
                 shift
-                # shellcheck source=./misc/scripts/search.sh
+                # shellcheck source=./misc/scripts/remove.sh
                 if ! source "$STGDIR/scripts/remove.sh"; then
                     fancy_message error "Failed to remove ${GREEN}${PACKAGE}${NC}"
                 fi


### PR DESCRIPTION
## Purpose

Safety:tm: by using `mapfile` to convert a string at a delimiter instead of relying on bash to do it, and also by quoting variables. 

This also fixes `select_options` to allow for complex stuff like `1..3 5-10` which it should have been able to since the beginning.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
