### PR TITLE
fix(deps): explicitly chosen optdepends are Depends

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -333,7 +333,7 @@ function prompt_optdepends() {
             done < /tmp/pacstall-gives
         fi
     fi
-    if [[ -n ${deps[*]} || -n "${not_installed_yet_optdeps[*]}" ]]; then
+    if [[ -n ${deps[*]} || -n ${not_installed_yet_optdeps[*]} ]]; then
         local all_deps_to_install=("${not_installed_yet_optdeps[@]}" "${deps[@]}")
         deblog "Depends" "$(echo "${all_deps_to_install[@]}" | sed 's/ /, /g')"
     fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -333,8 +333,9 @@ function prompt_optdepends() {
             done < /tmp/pacstall-gives
         fi
     fi
-    if [[ -n $depends ]] || [[ -n ${deps[*]} ]]; then
-        deblog "Depends" "$(echo "${deps[@]}" | sed 's/ /, /g')"
+    if [[ -n ${deps[*]} || -n "${not_installed_yet_optdeps[*]}" ]]; then
+        local all_deps_to_install=("${not_installed_yet_optdeps[@]}" "${deps[@]}")
+        deblog "Depends" "$(echo "${all_deps_to_install[@]}" | sed 's/ /, /g')"
     fi
 }
 


### PR DESCRIPTION
## Purpose

Explicitly chosen `optdepends` are not counted in `Depends`.

## Approach

Add them.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
