### PR TITLE
fix: localize as many vars as possible

### DIFF
--- a/misc/scripts/error_log.sh
+++ b/misc/scripts/error_log.sh
@@ -27,7 +27,7 @@ if [[ ! -d "/var/log/pacstall/error_log" ]]; then
 fi
 
 # Used with permission by zakariaGatter
-declare -A ErrMsg=([1]="Unknown cause of failure."
+declare -r -A ErrMsg=([1]="Unknown cause of failure."
     [2]="Error in configuration file."
     [3]="User specified an invalid option."
     [4]="Error in user-supplied function in pacscript."

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -128,6 +128,7 @@ while IFS= read -r URL; do
     mapfile -t PARTIALLIST < <(curl -s -- "$URL"/packagelist)
     URLLIST+=("${PARTIALLIST[@]/*/$URL}")
     PACKAGELIST+=("${PARTIALLIST[@]}")
+    unset PARTIALLIST
 done < "$STGDIR/repo/pacstallrepo.txt"
 
 REPOMSG=1

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -38,6 +38,7 @@ function getPath() {
 }
 
 function specifyRepo() {
+    local SPLIT
     mapfile -t SPLIT < <(echo "${1//[\/]/$'\n'}")
 
     if [[ $1 == "file://"* ]] || [[ $1 == "/"* ]] || [[ $1 == "~"* ]] || [[ $1 == "."* ]]; then
@@ -58,7 +59,7 @@ function specifyRepo() {
 # terminals that support them
 function parseRepo() {
     local REPO="${1}"
-
+    local SPLIT
     mapfile -t SPLIT < <(echo "${REPO//[\/]/$'\n'}")
 
     if [[ $REPO == *"file://"* ]]; then

--- a/pacstall
+++ b/pacstall
@@ -437,9 +437,9 @@ done
 set -- "${argument_list[@]}"
 
 function lock() {
-    ignore_short="-S -D -A -V -L -Qi -T -h"
-    ignore_long="--search --download --add-repo --version --query-info --tree --help"
-    ignore="$ignore_short $ignore_long"
+    local ignore_short="-S -D -A -V -L -Qi -T -h"
+    local ignore_long="--search --download --add-repo --version --query-info --tree --help"
+    local ignore="$ignore_short $ignore_long"
     if [[ $ignore =~ (^|[[:space:]])"$1"($|[[:space:]]) ]]; then
         return 1
     elif [[ $ignore =~ (^|[[:space:]])"$2"($|[[:space:]]) ]]; then

--- a/pacstall
+++ b/pacstall
@@ -269,7 +269,7 @@ function check_url() {
             return 1
         fi
     else
-        http_code="$(curl --location -o /dev/null -s --head --write-out '%{http_code}\n' -- "${1}")"
+        local http_code="$(curl --location -o /dev/null -s --head --write-out '%{http_code}\n' -- "${1}")"
         case "${http_code}" in
             000)
                 if [[ ${1} == *"packagelist" ]]; then

--- a/pacstall
+++ b/pacstall
@@ -558,6 +558,8 @@ Helpful links:
                     echo -e "$pac_body"
                     echo -e "~ Rick Pacsley ~"
                     exit 0
+                else
+                    unset pac_body pac_text
                 fi
                 if [[ ${2##*.} == "pacscript" ]]; then
                     export PACKAGE="$(basename "$2" ".pacscript")" # Removes the suffix


### PR DESCRIPTION
## Purpose

Some variables can easily be removed after use by just adding `local` to the front in functions, which might help reduce variable collision in Pacscripts.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.