### PR TITLE
fix(pacdeps): also check if `deps` no exist

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -318,22 +318,20 @@ function prompt_optdepends() {
         fi
     fi
 
-    if [[ -n ${deps[*]} ]]; then
-        if [[ -n ${pacdeps[*]} ]]; then
-            for i in "${pacdeps[@]}"; do
-                (
-                    source "$LOGDIR/$i"
-                    if [[ -n $_gives ]]; then
-                        echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
-                    else
-                        echo "$_name" | tee -a /tmp/pacstall-gives > /dev/null
-                    fi
-                )
-            done
-            while IFS= read -r line; do
-                deps+=("$line")
-            done < /tmp/pacstall-gives
-        fi
+    if [[ -n ${pacdeps[*]} ]]; then
+        for i in "${pacdeps[@]}"; do
+            (
+                source "$LOGDIR/$i"
+                if [[ -n $_gives ]]; then
+                    echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
+                else
+                    echo "$_name" | tee -a /tmp/pacstall-gives > /dev/null
+                fi
+            )
+        done
+        while IFS= read -r line; do
+            deps+=("$line")
+        done < /tmp/pacstall-gives
     fi
     if [[ -n ${deps[*]} || -n ${not_installed_yet_optdeps[*]} ]]; then
         local all_deps_to_install=("${not_installed_yet_optdeps[@]}" "${deps[@]}")


### PR DESCRIPTION
## Purpose

`deps` may not exist, such as if a package has `pacdeps` but no `depends`.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
