### PR TITLE
fix(select_options): only allow ranges from smallest to greatest

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -367,11 +367,13 @@ function select_options() {
                         for line in ${i//-/ }; do
                             split_arr+=("$line")
                         done
+                        if ((${split_arr[0]} > ${split_arr[-1]})); then select_options "$message" "$length"; fi
                         ;;
                     *..*)
                         for line in ${i//../ }; do
                             split_arr+=("$line")
                         done
+                        if ((${split_arr[0]} > ${split_arr[-1]})); then select_options "$message" "$length"; fi
                         ;;
                     *)
                         select_options "$message" "$length"


### PR DESCRIPTION
## Purpose

`5..1` doesn't make sense as a range, and it messes with `seq`.

## Approach

Check if `range[0] > range[-1]` and fail if so.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
