### PR TITLE
fix(select_options): ranges cannot go from num to num

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -367,13 +367,13 @@ function select_options() {
                         for line in ${i//-/ }; do
                             split_arr+=("$line")
                         done
-                        if ((${split_arr[0]} > ${split_arr[-1]})); then select_options "$message" "$length"; fi
+                        if ((${split_arr[0]} > ${split_arr[-1]} || ${split_arr[0]} == ${split_arr[-1]})); then select_options "$message" "$length"; fi
                         ;;
                     *..*)
                         for line in ${i//../ }; do
                             split_arr+=("$line")
                         done
-                        if ((${split_arr[0]} > ${split_arr[-1]})); then select_options "$message" "$length"; fi
+                        if ((${split_arr[0]} > ${split_arr[-1]} || ${split_arr[0]} == ${split_arr[-1]})); then select_options "$message" "$length"; fi
                         ;;
                     *)
                         select_options "$message" "$length"


### PR DESCRIPTION
## Purpose

Disallow `1..1`, `5..5`, etc.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
