### PR TITLE
fix(upgrade): numeric argument bug

### DIFF
--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -26,7 +26,7 @@ function ver_compare() {
     local first second
     first="${1#${1/[0-9]*/}}"
     second="${2#${2/[0-9]*/}}"
-    return "$(dpkg --compare-versions "$first" lt "$second")"
+    return $(dpkg --compare-versions "$first" lt "$second")
 }
 
 export UPGRADE="yes"


### PR DESCRIPTION
## Purpose

<!--Describe the problem you are fixing or the feature you are adding.-->

Pacstall v3.9.0 errors out when upgrading any package.

![](https://rimgo.pussthecat.org/zbjHzDN.png)

## Approach

Removes quotes surrounding L29, fixing the issue.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
