### PR TITLE
feat(pacscript): allow long descriptions (#860

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -217,8 +217,9 @@ function is_compatible_arch() {
 
 function deblog() {
     local key="$1"
-    local content="$2"
-    echo "$key: $content" | sudo tee -a "$STOWDIR/$name/DEBIAN/control" > /dev/null
+    shift
+    local content=("$@")
+    echo "$key: ${content[*]}" | sudo tee -a "$STOWDIR/$name/DEBIAN/control" > /dev/null
 }
 
 function clean_builddir() {
@@ -433,7 +434,27 @@ function makedeb() {
     fi
 
     deblog "Maintainer" "${maintainer:-Pacstall <pacstall@pm.me>}"
-    deblog "Description" "${description}"
+
+    # Do we have a long description? (longer than 2 lines)
+    while IFS=$'\n' read -r line; do
+        if [[ -z ${line} ]]; then
+            # Description states that empty lines must contain a single period after the period.
+            local description+=(".")
+        else
+            local description_arr+=("$line")
+        fi
+    done <<< "${description}"
+    if ((${#description_arr[@]} > 1)); then
+        deblog "Description" "$(
+            echo "${description_arr[0]}"
+            for ((i = 1; i < "${#description_arr[@]}"; i++)); do
+                echo -e " ${description_arr[i]}"
+            done
+        )"
+    else
+        # shellcheck disable=SC2128
+        deblog "Description" "${description}"
+    fi
 
     for i in {removescript,postinst,preinst}; do
         case "$i" in

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -439,7 +439,7 @@ function makedeb() {
     while IFS=$'\n' read -r line; do
         if [[ -z ${line} ]]; then
             # Description states that empty lines must contain a single period after the period.
-            local description+=(".")
+            local description_arr+=(".")
         else
             local description_arr+=("$line")
         fi
@@ -452,7 +452,6 @@ function makedeb() {
             done
         )"
     else
-        # shellcheck disable=SC2128
         deblog "Description" "${description}"
     fi
 


### PR DESCRIPTION
## Purpose

Single line descriptions are very limiting, and the maintainer may wish to expand on it.

## Approach

If `description` is longer than a single line, we loop over and make an array. Then we can print out the first line normally, and for every line after, we print it with a preceding space (control file stuff). Blank lines are denoted by a single period on the line.

## Progress

- [x] Multiple lines
- [x] `.` as blank

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
