### PR TITLE
fix(select_options): make everything more explicit

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -269,6 +269,7 @@ function prompt_optdepends() {
         if [[ ${#suggested_optdeps[@]} -ne 0 ]]; then
             if [[ $PACSTALL_INSTALL != 0 ]]; then
                 z=1
+				echo -e "\t\t[${BIRed}0${NC}] Select none"
                 for i in "${suggested_optdeps[@]}"; do
                     # print optdepends with bold package name
                     echo -e "\t\t[${BICyan}$z${NC}] ${BOLD}${i%%:*}${NC}:${i#*:}"
@@ -292,7 +293,7 @@ function prompt_optdepends() {
                     fancy_message warn "${BGreen}${skip_opt[*]}${NC} has exceeded the maximum number of optional dependencies. Skipping"
                 fi
 
-                if [[ ${choices[0]} != "n" ]]; then
+                if [[ ${choices[0]} != "n" && ${choices[0]} != "0" ]]; then
                     for i in "${choices[@]}"; do
                         ((i--))
                         local s="${suggested_optdeps[$i]}"

--- a/pacstall
+++ b/pacstall
@@ -337,9 +337,9 @@ function select_options() {
     local length="${2}"
 
     if [[ $length -ge 6 ]]; then
-        echo -ne "${message} [${BOLD}1..$length${NC}] [${BIGreen}Y${NC}/${RED}n${NC}] "
+		echo -ne "${message} [${BOLD}1-$length${NC} or ${BIGreen}Y${NC}] "
     else
-        echo -ne "${message} [${BOLD}$(seq -s ' ' 1 "$length")${NC}] [${BIGreen}Y${NC}/${RED}n${NC}] "
+		echo -ne "${message} [${BOLD}$(seq -s ' ' 1 "$length")${NC} or ${BIGreen}Y${NC}] "
     fi
     if [[ $DISABLE_PROMPTS == "no" ]]; then
         read -ra input <&0

--- a/pacstall
+++ b/pacstall
@@ -337,9 +337,9 @@ function select_options() {
     local length="${2}"
 
     if [[ $length -ge 6 ]]; then
-		echo -ne "${message} [${BOLD}1-$length${NC} or ${BIGreen}Y${NC}] "
+        echo -ne "${message} [${BOLD}1-$length${NC} or ${BIGreen}Y${NC}] "
     else
-		echo -ne "${message} [${BOLD}$(seq -s ' ' 1 "$length")${NC} or ${BIGreen}Y${NC}] "
+        echo -ne "${message} [${BOLD}$(seq -s ' ' 1 "$length")${NC} or ${BIGreen}Y${NC}] "
     fi
     if [[ $DISABLE_PROMPTS == "no" ]]; then
         read -ra input <&0


### PR DESCRIPTION
## Purpose

Right now it's kind of confusing (according to some).

## Approach

Replace `..` with `-`, remove the `fancy_message` `[Y/n]` stuff, add explicit part in optdepends print out for skipping, and add `or` text between range and `Y`

## Addendum

![Image of feature](https://user-images.githubusercontent.com/58742515/227695798-4babae87-0435-45b1-8be0-bb47876518aa.png)

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
