### PR TITLE
fix(PACSTALL_PAYLOAD): do not delete file if payload is active

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -300,7 +300,11 @@ function check_url() {
 
 # use axel if available
 function download() {
-    sudo rm -f "${1##*/}"
+    if [[ -n ${PACSTALL_PAYLOAD} ]]; then
+        return
+    else
+        sudo rm -f "${1##*/}"
+    fi
     if [[ -z $PACSTALL_DOWNLOADER ]]; then
         if command -v axel &> /dev/null; then
             PACSTALL_DOWNLOADER=axel


### PR DESCRIPTION
## Purpose

We don't want to nuke the file if it exists as `PACSTALL_PAYLOAD`.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
