### PR TITLE
fix: only delete stuff if not in payload mode

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -300,7 +300,9 @@ function check_url() {
 
 # use axel if available
 function download() {
-    sudo rm -f "${1##*/}"
+    if [[ $PACSTALL_DOWNLOADER != "payload" ]]; then
+        sudo rm -f "${1##*/}"
+    fi
     if [[ -z $PACSTALL_DOWNLOADER ]]; then
         if command -v axel &> /dev/null; then
             PACSTALL_DOWNLOADER=axel


### PR DESCRIPTION
## Purpose

<!--Describe the problem you are fixing or the feature you are adding.-->

Fixes payload bug, where it'd delete the file before processing it.

## Approach

<!--How does this address the problem?-->

Check if we're in payload mode, and proceed accordingly

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
