### PR TITLE
fix(download): convert to lowercase for ending check

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -861,7 +861,7 @@ if [[ $name == *-git ]]; then
     # Check the integrity
     git fsck --full
 else
-    case "$url" in
+    case "${url,,}" in
         *.zip)
             if ! download "$url"; then
                 error_log 1 "download $PACKAGE"
@@ -925,7 +925,7 @@ else
                 return 1
             fi
             ;;
-        *.AppImage)
+        *.appimage)
             if ! download "$url"; then
                 error_log 1 "download $PACKAGE"
                 fancy_message error "Failed to download package"


### PR DESCRIPTION
## Purpose

If a URL ends in `.appimage`, the checker will be searching for `AppImage` which won't work.

## Approach

Just for the package type checker, lowercase the entire URL to check for the ending.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
