### PR TITLE
feat(pacscript): change needed variables to arrays

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -229,7 +229,7 @@ function clean_builddir() {
 
 function prompt_optdepends() {
     if [[ -n $depends ]]; then
-        if is_array "${depends}"; then
+        if is_array depends; then
             deps=("${depends[@]}")
         else
             mapfile -t deps <<< "${depends// /$'\n'}"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -722,7 +722,10 @@ fi
 
 if ! is_package_installed "${name}"; then
     if [[ -n $breaks ]]; then
-        for pkg in $breaks; do
+        if ! is_array breaks; then
+            mapfile -t breaks <<< "${breaks// /$'\n'}"
+        fi
+        for pkg in "${breaks[@]}"; do
             if [[ "$(dpkg-query -W -f='${Status} ${Section}' "${pkg}" 2> /dev/null)" =~ ^(install ok installed Pacstall) ]]; then
                 # Check if anything in breaks variable is installed already
                 fancy_message error "${RED}$name${NC} breaks $pkg, which is currently installed by apt"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -228,6 +228,7 @@ function clean_builddir() {
 }
 
 function prompt_optdepends() {
+    local deps optdep
     if [[ -n $depends ]]; then
         if is_array depends; then
             deps=("${depends[@]}")

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -233,6 +233,7 @@ function prompt_optdepends() {
             deps=("${depends[@]}")
         else
             mapfile -t deps <<< "${depends// /$'\n'}"
+            fancy_message warn "Using '${BCyan}depends${NC}' as a variable instead of array is deprecated"
         fi
     fi
     if [[ ${#optdepends[@]} -ne 0 ]]; then
@@ -724,6 +725,7 @@ if ! is_package_installed "${name}"; then
     if [[ -n $breaks ]]; then
         if ! is_array breaks; then
             mapfile -t breaks <<< "${breaks// /$'\n'}"
+            fancy_message warn "Using '${BCyan}breaks${NC}' as a variable instead of array is deprecated"
         fi
         for pkg in "${breaks[@]}"; do
             if [[ "$(dpkg-query -W -f='${Status} ${Section}' "${pkg}" 2> /dev/null)" =~ ^(install ok installed Pacstall) ]]; then
@@ -767,6 +769,7 @@ if [[ -n ${build_depends[*]} ]]; then
     # Get all uninstalled build depends
     if ! is_array build_depends; then
         mapfile -t build_depends <<< "${build_depends// /$'\n'}"
+        fancy_message warn "Using '${BCyan}build_depends${NC}' as a variable instead of array is deprecated"
     fi
     for build_dep in "${build_depends[@]}"; do
         if [[ "$(dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null)" == "install ok installed" ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -762,7 +762,9 @@ fi
 
 if [[ -n ${build_depends[*]} ]]; then
     # Get all uninstalled build depends
-    mapfile -t build_depends <<< "${build_depends// /$'\n'}"
+    if ! is_array build_depends; then
+        mapfile -t build_depends <<< "${build_depends// /$'\n'}"
+    fi
     for build_dep in "${build_depends[@]}"; do
         if [[ "$(dpkg-query -W -f='${Status}' "${build_dep}" 2> /dev/null)" == "install ok installed" ]]; then
             build_depends_to_delete+=("${build_dep}")

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -229,7 +229,11 @@ function clean_builddir() {
 
 function prompt_optdepends() {
     if [[ -n $depends ]]; then
-        mapfile -t deps <<< "${depends// /$'\n'}"
+        if is_array "${depends}"; then
+            deps=("${depends[@]}")
+        else
+            mapfile -t deps <<< "${depends// /$'\n'}"
+        fi
     fi
     if [[ ${#optdepends[@]} -ne 0 ]]; then
         for i in "${optdepends[@]}"; do
@@ -270,7 +274,7 @@ function prompt_optdepends() {
         if [[ ${#suggested_optdeps[@]} -ne 0 ]]; then
             if [[ $PACSTALL_INSTALL != 0 ]]; then
                 z=1
-				echo -e "\t\t[${BIRed}0${NC}] Select none"
+                echo -e "\t\t[${BIRed}0${NC}] Select none"
                 for i in "${suggested_optdeps[@]}"; do
                     # print optdepends with bold package name
                     echo -e "\t\t[${BICyan}$z${NC}] ${BOLD}${i%%:*}${NC}:${i#*:}"

--- a/pacstall
+++ b/pacstall
@@ -404,6 +404,17 @@ function is_package_installed() {
     return 1
 }
 
+function is_array() {
+    local input raw
+    input="${1}"
+    raw="$(declare -p "${input}" 2> /dev/null)"
+    if [[ ${raw} == "declare -a ${input}"* ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 # Error out when run as root
 if [[ $EUID -eq 0 ]]; then
     fancy_message error "Pacstall can't be run as root. Please run as a normal user."


### PR DESCRIPTION
## Purpose

`depends="foo bar baz"` looks really bad and is more prone to errors than `depends=("foo" "bar" "baz")`. This changes `depends`, `build_depends` and `breaks` to arrays (most are already turned into arrays internally, so this isn't a big change internally).

## Approach

Add a check to convert the key to an array if it's not an array already, and do nothing if it's already an array. This check makes it not a breaking change, although we could add a warning if it is a variable.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
