### PR TITLE
fix(post_scripts): use raw ascii code instead of tput

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -492,7 +492,7 @@ function ask() {
 function fancy_message() {
 	local MESSAGE_TYPE="${1}"
 	local MESSAGE="${2}"
-	local BOLD=$(tput bold)
+	local BOLD="\033[1m"
 	local NC="\033[0m"
 	case ${MESSAGE_TYPE} in
 		info) echo -e "[${BOLD}+${NC}] INFO: ${MESSAGE}";;


### PR DESCRIPTION
## Purpose

It's faster, we don't have to call an external command.

## Approach

Replace `$(tput bold)` with raw ASCII code.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.