### PR TITLE
fix(ask_postscripts): add `DISABLE_PROMPTS` and `DEBIAN_FRONTEND` functionality

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -480,8 +480,13 @@ function ask() {
 		echo -ne "$1 [y/N] "
 	fi
 	default=${2:-}
-	read -r reply <&0
-	if [[ -z $reply ]]; then
+	if [[ -z ${DISABLE_PROMPTS} && ${DEBIAN_FRONTEND} != "noninteractive" ]]; then
+		read -r reply <&0
+		if [[ -z $reply ]]; then
+			reply=$default
+		fi
+	else
+		echo "$default"
 		reply=$default
 	fi
 	case "$reply" in


### PR DESCRIPTION
## Purpose

Because normal `ask` behaves correctly with the variables, and the same should be expected for the postscripts stripped down version.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
