### PR TITLE
fix(trap_ctrlc): `$2` is not the global one, it is the argument

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -575,7 +575,7 @@ Helpful links:
             fi
 
             function trap_ctrlc() {
-                fancy_message warn "The installation of $2 was interrupted, removing files"
+                fancy_message warn "The installation of ${PACKAGE:-package} was interrupted, removing files"
                 rm -rf "${SRCDIR:?}"/* # :? makes bash error out in case SRCDIR is empty, saving us from yoinking /* directory by mistake
                 exit 2
             }


### PR DESCRIPTION
## Purpose

`$2` is an argument to `trap_ctrlc`, not the global pacstall `$2`.

## Approach

Use `$PACKAGE`, or fall back to the string `package` if `$PACKAGE` was not defined when killed.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
