### PR TITLE
perf: remove instances of `tr` in favor of pure bash

### DIFF
--- a/misc/scripts/add-repo.sh
+++ b/misc/scripts/add-repo.sh
@@ -64,6 +64,6 @@ while IFS= read -r REPOURL; do
 done < "$STGDIR/repo/pacstallrepo.txt"
 REPOLIST+=("$REPO")
 
-echo "${REPOLIST[@]}" | tr -s ' ' '\n' | sort -u | sudo tee "$STGDIR/repo/pacstallrepo.txt" > /dev/null
+printf "%s\n" "${REPOLIST[@]}" | sort -u | sudo tee "$STGDIR/repo/pacstallrepo.txt" > /dev/null
 fancy_message info "The repo list has been updated"
 # vim:set ft=sh ts=4 sw=4 noet:

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -166,7 +166,8 @@ function compare_remote_version() (
 
 function get_incompatible_releases() {
     # example for this function is "ubuntu:jammy"
-    local distro_name="$(lsb_release -si 2> /dev/null | tr '[:upper:]' '[:lower:]')"
+    local distro_name="$(lsb_release -si 2> /dev/null)"
+	distro_name="${distro_name,,}"
     if [[ "$(lsb_release -ds 2> /dev/null | tail -c 4)" == "sid" ]]; then
         local distro_version_name="sid"
         local distro_version_number="sid"

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -65,7 +65,8 @@ fi
 if [[ -n $_pacdeps ]]; then
     echo -e "${BGreen}pacstall dependencies${NORMAL}: ${_pacdeps[*]}"
 fi
-deps=$(get_field "$PACKAGE" Depends | tr -d ',')
+deps=$(get_field "$PACKAGE" Depends)
+deps="${deps//,}"
 if [[ -n $deps ]]; then
     echo -e "${BGreen}dependencies${NORMAL}: ${deps}"
 fi


### PR DESCRIPTION
## Purpose

`tr` is an external command, and we can easily speed it up by using pure bash alternatives.

## Progress

- [x] Replace `tr` in `misc/scripts/add-repo.sh` by printing array on newlines with `printf`
- [x] Replace `tr` in `misc/scripts/install-local.sh` by lowercasing the string with `${var,,}`
- [x] Replace `tr` in `misc/scripts/query-info.sh` with `${var//,}`

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
