### PR TITLE
refactor(*): remove `NORMAL` variable

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,6 @@
 
 # Colors
 BOLD=$(tput bold)
-NORMAL=$(tput sgr0)
 NC="\033[0m"
 
 RED='\033[0;31m'
@@ -40,7 +39,7 @@ function fancy_message() {
     # 0 - info
     # 1 - warning
     # 2 - error
-    if [[ -z ${1} ]] || [[ -z ${2} ]]; then
+    if [[ -z ${1} || -z ${2} ]]; then
         return
     fi
 
@@ -51,7 +50,7 @@ function fancy_message() {
         info) echo -e "[${BGreen}+${NC}] INFO: ${MESSAGE}" ;;
         warn) echo >&2 -e "[${BYellow}*${NC}] WARNING: ${MESSAGE}" ;;
         error) echo >&2 -e "[${BRed}!${NC}] ERROR: ${MESSAGE}" ;;
-        *) echo >&2 -e "[${BOLD}?${NORMAL}] UNKNOWN: ${MESSAGE}" ;;
+        *) echo >&2 -e "[${BOLD}?${NC}] UNKNOWN: ${MESSAGE}" ;;
     esac
 }
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -500,7 +500,7 @@ function fancy_message() {
 		warn) echo -e "[${BOLD}*${NC}] WARNING: ${MESSAGE}";;
 		error) echo -e "[${BOLD}!${NC}] ERROR: ${MESSAGE}";;
 		sub) echo -e "\t[${BOLD}>${NC}] ${MESSAGE}" ;;
-		*) echo -e "[${BOLD}?${NORMAL}] UNKNOWN: ${MESSAGE}";;
+		*) echo -e "[${BOLD}?${NC}] UNKNOWN: ${MESSAGE}";;
 	esac
 }
 

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -44,36 +44,36 @@ function get_field() {
     fi
 }
 
-echo -e "${BGreen}name${NORMAL}: $(get_field "$PACKAGE" Package)"
-echo -e "${BGreen}version${NORMAL}: $(get_field "$PACKAGE" Version)"
+echo -e "${BGreen}name${NC}: $(get_field "$PACKAGE" Package)"
+echo -e "${BGreen}version${NC}: $(get_field "$PACKAGE" Version)"
 if [[ -n $_install_size ]]; then
-    echo -e "${BGreen}size${NORMAL}: $_install_size"
+    echo -e "${BGreen}size${NC}: $_install_size"
 fi
-echo -e "${BGreen}description${NORMAL}: $(get_field "$PACKAGE" Description)"
-echo -e "${BGreen}date installed${NORMAL}: $_date"
+echo -e "${BGreen}description${NC}: $(get_field "$PACKAGE" Description)"
+echo -e "${BGreen}date installed${NC}: $_date"
 
 if [[ -n $_homepage ]]; then
-    echo -e "${BGreen}homepage${NORMAL}: $_homepage"
+    echo -e "${BGreen}homepage${NC}: $_homepage"
 fi
 if [[ -n $_remoterepo ]]; then
-    echo -e "${BGreen}remote repo${NORMAL}: $_remoterepo"
+    echo -e "${BGreen}remote repo${NC}: $_remoterepo"
 fi
-echo -e "${BGreen}maintainer${NORMAL}: $(get_field "$PACKAGE" Maintainer)"
+echo -e "${BGreen}maintainer${NC}: $(get_field "$PACKAGE" Maintainer)"
 if [[ -n $_ppa ]]; then
-    echo -e "${BGreen}ppa${NORMAL}: $_ppa"
+    echo -e "${BGreen}ppa${NC}: $_ppa"
 fi
 if [[ -n $_pacdeps ]]; then
-    echo -e "${BGreen}pacstall dependencies${NORMAL}: ${_pacdeps[*]}"
+    echo -e "${BGreen}pacstall dependencies${NC}: ${_pacdeps[*]}"
 fi
 deps=$(get_field "$PACKAGE" Depends)
 deps="${deps//,}"
 if [[ -n $deps ]]; then
-    echo -e "${BGreen}dependencies${NORMAL}: ${deps}"
+    echo -e "${BGreen}dependencies${NC}: ${deps}"
 fi
 if [[ -n $_pacstall_depends ]]; then
-    echo -e "${BGreen}install type${NORMAL}: installed as dependency"
+    echo -e "${BGreen}install type${NC}: installed as dependency"
 else
-    echo -e "${BGreen}install type${NORMAL}: explicitly installed"
+    echo -e "${BGreen}install type${NC}: explicitly installed"
 fi
 exit 0
 # vim:set ft=sh ts=4 sw=4 noet:

--- a/misc/scripts/update.sh
+++ b/misc/scripts/update.sh
@@ -26,8 +26,6 @@
 # Color variables are ok, while "$USERNAME" and "$BRANCH" are needed
 BOLD=$(tput bold)
 export BOLD
-NORMAL=$(tput sgr0)
-export NORMAL
 export NC='\033[0m'
 export UCyan='\033[4;36m'
 export BPurple='\033[1;35m'
@@ -149,12 +147,12 @@ fi
 
 if [[ ${new_username} == "pacstall" ]]; then
     echo -e "Useful links:"
-    echo -e "\t${BYellow}Website${NC}: ${BOLD}https://pacstall.dev${NORMAL}"
-    echo -e "\t${BPurple}Packages${NC}: ${BOLD}https://pacstall.dev/packages${NORMAL}"
-    echo -e "\t${BCyan}GitHub${NC}: ${BOLD}https://github.com/pacstall${NORMAL}"
-    echo -e "\t${BRed}Report Bugs${NC}: ${BOLD}https://github.com/${new_username}/pacstall/issues${NORMAL}"
-    echo -e "\t${BBlue}Discord${NC}: ${BOLD}https://discord.gg/yzrjXJV6K8${NORMAL}"
-    echo -e "\t${BGreen}Matrix${NC}: ${BOLD}https://matrix.to/#/#pacstall:matrix.org${NORMAL}"
+    echo -e "\t${BYellow}Website${NC}: ${BOLD}https://pacstall.dev${NC}"
+    echo -e "\t${BPurple}Packages${NC}: ${BOLD}https://pacstall.dev/packages${NC}"
+    echo -e "\t${BCyan}GitHub${NC}: ${BOLD}https://github.com/pacstall${NC}"
+    echo -e "\t${BRed}Report Bugs${NC}: ${BOLD}https://github.com/${new_username}/pacstall/issues${NC}"
+    echo -e "\t${BBlue}Discord${NC}: ${BOLD}https://discord.gg/yzrjXJV6K8${NC}"
+    echo -e "\t${BGreen}Matrix${NC}: ${BOLD}https://matrix.to/#/#pacstall:matrix.org${NC}"
 fi
 exit 0
 

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -124,7 +124,7 @@ if (($(wc -l < "${up_list}") == 0)); then
 else
     fancy_message info "Packages can be upgraded"
     echo -e "Upgradable: $(wc -l < "${up_print}")
-${BOLD}$(cat "${up_print}")${NORMAL}\n"
+${BOLD}$(cat "${up_print}")${NC}\n"
 
     upgrade=()
     while IFS= read -r line; do

--- a/pacstall
+++ b/pacstall
@@ -39,8 +39,6 @@ export PACSTALL_INSTALL=1
 # Colors
 BOLD=$(tput bold)
 export BOLD
-NORMAL=$(tput sgr0)
-export NORMAL
 export NC='\033[0m'
 # Courtesy of https://stackoverflow.com/a/28938235/13449010
 
@@ -168,7 +166,7 @@ function fancy_message() {
         warn) echo >&2 -e "[${BYellow}*${NC}] ${BOLD}WARNING${NC}: ${MESSAGE}" ;;
         error) echo >&2 -e "[${BRed}!${NC}] ${BOLD}ERROR${NC}: ${MESSAGE}" ;;
         sub) echo -e "\t[${BBlue}>${NC}] ${MESSAGE}" ;;
-        *) echo >&2 -e "[${BOLD}?${NORMAL}] ${BOLD}UNKNOWN${NC}: ${MESSAGE}" ;;
+        *) echo >&2 -e "[${BOLD}?${NC}] ${BOLD}UNKNOWN${NC}: ${MESSAGE}" ;;
     esac
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -24,7 +24,6 @@
 
 # Colors
 BOLD=$(tput bold)
-NORMAL=$(tput sgr0)
 NC="\033[0m"
 
 RED='\033[0;31m'
@@ -44,7 +43,7 @@ function fancy_message() {
     # 0 - info
     # 1 - warning
     # 2 - error
-    if [[ -z ${1} ]] || [[ -z ${2} ]]; then
+    if [[ -z ${1} || -z ${2} ]]; then
         return
     fi
 
@@ -55,7 +54,7 @@ function fancy_message() {
         info) echo -e "[${BGreen}+${NC}] INFO: ${MESSAGE}" ;;
         warn) echo >&2 -e "[${BYellow}*${NC}] WARNING: ${MESSAGE}" ;;
         error) echo >&2 -e "[${BRed}!${NC}] ERROR: ${MESSAGE}" ;;
-        *) echo >&2 -e "[${BOLD}?${NORMAL}] UNKNOWN: ${MESSAGE}" ;;
+        *) echo >&2 -e "[${BOLD}?${NC}] UNKNOWN: ${MESSAGE}" ;;
     esac
 }
 


### PR DESCRIPTION
## Purpose

It's fragmented between `NORMAL` and `NC`, and `NC` is faster because it's a raw ascii code.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
