### PR TITLE
feat(pacscript): add `NCPU` variable bound to `nproc`

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -167,7 +167,7 @@ function compare_remote_version() (
 function get_incompatible_releases() {
     # example for this function is "ubuntu:jammy"
     local distro_name="$(lsb_release -si 2> /dev/null)"
-	distro_name="${distro_name,,}"
+    distro_name="${distro_name,,}"
     if [[ "$(lsb_release -ds 2> /dev/null | tail -c 4)" == "sid" ]]; then
         local distro_version_name="sid"
         local distro_version_number="sid"
@@ -604,17 +604,22 @@ Pin-Priority: -1" | sudo tee /etc/apt/preferences.d/"${name}-pin" > /dev/null
     fi
 }
 
+# NCPU is the core count
 if [[ -n $PACSTALL_BUILD_CORES ]]; then
     if [[ $PACSTALL_BUILD_CORES =~ ^[0-9]+$ ]]; then
         function nproc() {
             echo "${PACSTALL_BUILD_CORES:-1}"
         }
+        declare -rg NCPU="${PACSTALL_BUILD_CORES:-1}"
     else
         fancy_message error "${UCyan}PACSTALL_BUILD_CORES${NC} is not an integer. Falling back to 1"
         function nproc() {
             echo "1"
         }
+        declare -rg NCPU="1"
     fi
+else
+    declare -rg NCPU="$(nproc)"
 fi
 
 ask "(${BPurple}$PACKAGE${NC}) Do you want to view/edit the pacscript" N

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -510,6 +510,12 @@ function get_homedir() {
 }
 export homedir="$(get_homedir)"
 
+if [[ -n $PACSTALL_BUILD_CORES ]]; then
+	declare -gr NCPU="${PACSTALL_BUILD_CORES:-1}"
+else
+	declare -gr NCPU="$(nproc)"
+fi
+
 hash -r' | sudo tee "$STOWDIR/$name/DEBIAN/$deb_post_file" > /dev/null
             {
                 cat "${pacfile}"


### PR DESCRIPTION
## Purpose

It's not practical to run subshells to get the core count.

## Approach

Create a readonly global variable called `NCPU` (Number *of* CPUs).

## Progress

- [x] Set `$PACSTALL_BUILD_CORES`
- [x] Set to 1 if `$PACSTALL_BUILD_CORES` is improperly formatted
- [x] Set to `nproc`
- [x] Add to postscripts

## Example
```bash
name="hello"
repology=("project: ${name}")
version="2.12.1"
url="https://ftp.gnu.org/gnu/${name}/${name}-${version}.tar.gz"
build_depends=("build-essential")
depends=("libc6")
breaks=("${name}-git" "${name}-traditional")
replace=("${name}")
description="GNU implementation of the classic program that prints 'Hello, world!' when you run it"
hash="8d99142afd92576f30b0cd7cb42a8dc6809998bc5d607d88761f512e26c7db20"
maintainer="WRM-42 <y8bsbahy@anonaddy.me>"

build() {
  ./configure
  make -j"${NCPU}" # Previously $(nproc)
}

install() {
  sudo make install DESTDIR="${pkgdir}"
}
```

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
