### PR TITLE
fix(remove.sh): purge instead of remove

### DIFF
--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -34,7 +34,7 @@ if ! dpkg -l "${_gives:-$_name}" &> /dev/null; then
     exit 1
 fi
 
-sudo apt-get remove "${_gives:-$_name}" -y || {
+sudo apt-get purge "${_gives:-$_name}" -y || {
     error_log 1 "remove $PACKAGE"
     exit 1
 }


### PR DESCRIPTION
## Purpose

Because apt is stupid and """"removing"""" a package won't register it with apt unless it's purged 🙄.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
