### PR TITLE
refactor(*): use `printf` instead of `date`

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -363,7 +363,7 @@ function prompt_optdepends() {
 function generate_changelog() {
     echo -e "${name} (${full_version}) $(lsb_release -sc); urgency=medium\n"
     echo -e "  * Version now at ${full_version}.\n"
-    echo -e " -- $maintainer  $(date +"%a, %d %b %Y %T %z")"
+    echo -e " -- $maintainer  $(printf '%(%a, %d %b %Y %T %z)T')"
 }
 
 function clean_logdir() {
@@ -1011,7 +1011,7 @@ function run_function() {
     local func="$1"
     fancy_message sub "Running $func"
     # NOTE: https://stackoverflow.com/a/29163890 (shorthand for 2>&1 |)
-    $func |& sudo tee "/var/log/pacstall/error_log/$(date +"%Y-%m-%d_%T")-$name-$func.log" && return "${PIPESTATUS[0]}"
+    $func |& sudo tee "/var/log/pacstall/error_log/$(printf '%(%Y-%m-%d_%T)T')-$name-$func.log" && return "${PIPESTATUS[0]}"
 }
 
 function safe_run() {

--- a/pacstall
+++ b/pacstall
@@ -25,7 +25,7 @@
 # Configuration
 export LC_ALL=C
 export LOGDIR="/var/log/pacstall/metadata"
-LOGFILE="/var/log/pacstall/error_log/$(date +"%F_%T.log")"
+LOGFILE="/var/log/pacstall/error_log/$(printf '%(%F_%T)T.log')"
 export LOGFILE
 export SRCDIR="/tmp/pacstall"
 export STGDIR="/usr/share/pacstall"

--- a/pacstall
+++ b/pacstall
@@ -25,7 +25,7 @@
 # Configuration
 export LC_ALL=C
 export LOGDIR="/var/log/pacstall/metadata"
-LOGFILE="/var/log/pacstall/error_log/$(printf '%(%F_%T)T.log')"
+printf -v LOGFILE "/var/log/pacstall/error_log/%(%F_%T)T.log"
 export LOGFILE
 export SRCDIR="/tmp/pacstall"
 export STGDIR="/usr/share/pacstall"


### PR DESCRIPTION
## Purpose

Because we can and it's builtin rather than not.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
