### PR TITLE
chan(makedeb): do not show packaging status if $name and $gives are the same

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -418,7 +418,8 @@ function createdeb() {
 }
 
 function makedeb() {
-    if [[ -n $gives ]]; then
+    # It looks weird for it to say: `Packaging foo as foo`
+    if [[ -n $gives && $name != "$gives" ]]; then
         fancy_message info "Packaging ${BGreen}$name${NC} as ${BBlue}$gives${NC}"
     else
         fancy_message info "Packaging ${BGreen}$name${NC}"


### PR DESCRIPTION
## Purpose

It looks weird for this to show:
```bash
[+] INFO: Packaging goverlay as goverlay
```
when:
```bash
[+] INFO: Packaging goverlay
```
would be fine, but only when `$name` and `$gives` are the same (but then at that point, the pacscript maintainer should drop `$gives` and let `$name` implicitly be `$gives`.)

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
