### PR TITLE
tempfix: force set `$URL` to repair `-Up` function

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -638,6 +638,7 @@ Helpful links:
                         continue
                     fi
 
+		    # FIXME: URL is being eaten up and not supplying link on -Up function, so we are forcing it here
                     specifyRepo "$REPO"
                     URL="${REPO:-https://raw.githubusercontent.com/pacstall/pacstall-programs/master}/packages/$PACKAGE/$PACKAGE.pacscript"
 

--- a/pacstall
+++ b/pacstall
@@ -639,7 +639,7 @@ Helpful links:
                     fi
 
                     specifyRepo "$REPO"
-                    URL="$REPO/packages/$PACKAGE/$PACKAGE.pacscript"
+                    URL="${REPO:-https://raw.githubusercontent.com/pacstall/pacstall-programs/master}/packages/$PACKAGE/$PACKAGE.pacscript"
 
                     # shellcheck source=./misc/scripts/download.sh
                     if ! source "$STGDIR/scripts/download.sh"; then


### PR DESCRIPTION
## Purpose

Original issue: `rhino-core` received a dependency update for `unicorn-desktop`, but `unicorn-desktop` was added to the repository after the previous `rhino-core` update. As a result, `-Up` fails to update `rhino-core` from beta4 to beta5, and an `-I` to fetch the repo must be done to update.

## Approach

After looking into it, we found that `$URL` is getting eaten up by something, and not outputting correctly. We have found this fix to work, which subsidizes the repo into the `$URL` directly.

## Progress

- [x] Get `rhino-core` to update from `-Up` again instead of `-I`

## Addendum

Chances are we will need to revert this later, once we find where it is being eaten up, and making proper fixes. Because this is a fix vital to the user experience, it is necessary to push a fix out quickly, but it is recognized that this is not the best solution, and will have to be re-patched in the future. 

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
