### PR TITLE
fix(is_apt_package_installed): accurately check install status

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -406,7 +406,11 @@ function is_package_installed() {
 
 # Returns 0 if exists, 1 if not
 function is_apt_package_installed() {
-    dpkg -s "${1}" 2> /dev/null 1>&2
+    if [[ $(dpkg-query -W --showformat='${db:Status-Status}' "${1}") != "installed" ]]; then
+        return 1
+    else
+        return 0
+    fi
 }
 
 function is_array() {


### PR DESCRIPTION
## Purpose

Because apt is stupid and if a package is removed but not the config, it says it's installed.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.