### PR TITLE
feat(pacscript): add `DISTRO` variable

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -691,7 +691,7 @@ homedir="$(eval echo ~"$PACSTALL_USER")"
 export homedir
 
 sudo cp "${PACKAGE}.pacscript" /tmp
-pacfile=$(readlink -f "/tmp/${PACKAGE}.pacscript")
+pacfile="$(readlink -f "/tmp/${PACKAGE}.pacscript")"
 export pacfile
 export CARCH="$(dpkg --print-architecture)"
 export DISTRO="$(set_distro)"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -190,7 +190,7 @@ function get_incompatible_releases() {
         # check for `*:jammy`
         if [[ $key == "*:"* ]]; then
             # check for `22.04` or `jammy`
-            if [[ ${key#*:} == "${distro_version_number}" ]] || [[ ${key#*:} == "${distro_version_name}" ]]; then
+            if [[ ${key#*:} == "${distro_version_number}" || ${key#*:} == "${distro_version_name}" ]]; then
                 fancy_message error "This Pacscript does not work on ${BBlue}${distro_version_name}${NC}/${BBlue}${distro_version_number}${NC}"
                 return 1
             fi
@@ -203,12 +203,13 @@ function get_incompatible_releases() {
             fi
         else
             # check for `ubuntu:jammy` or `ubuntu:22.04`
-            if [[ $key == "${distro_name}:${distro_version_name}" ]] || [[ $key == "${distro_name}:${distro_version_number}" ]]; then
+            if [[ $key == "${distro_name}:${distro_version_name}" || $key == "${distro_name}:${distro_version_number}" ]]; then
                 fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}"
                 return 1
             fi
         fi
     done
+    export DISTRO="${distro_name}:${distro_version_name}"
 }
 
 function is_compatible_arch() {
@@ -750,7 +751,7 @@ if [[ -n $pacdeps ]]; then
                 fancy_message info "The pacstall dependency ${i} is already installed and at latest version"
 
             fi
-			# BUG: Pacstall installs pacdeps from main repo. In the RS version we should get the latest version of the pacdep from all repos and use that.
+            # BUG: Pacstall installs pacdeps from main repo. In the RS version we should get the latest version of the pacdep from all repos and use that.
         elif fancy_message info "Installing $i" && ! pacstall "$cmd" "$i"; then
             fancy_message error "Failed to install dependency"
             error_log 8 "install $PACKAGE"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -173,6 +173,18 @@ function compare_remote_version() (
     fi
 )
 
+function set_distro() {
+    local distro_name="$(lsb_release -si 2> /dev/null)"
+    distro_name="${distro_name,,}"
+    if [[ "$(lsb_release -ds 2> /dev/null | tail -c 4)" == "sid" ]]; then
+        local distro_version_name="sid"
+        local distro_version_number="sid"
+    else
+        local distro_version_name="$(lsb_release -sc 2> /dev/null)"
+    fi
+    echo "${distro_name}:${distro_version_name}"
+}
+
 function get_incompatible_releases() {
     # example for this function is "ubuntu:jammy"
     local distro_name="$(lsb_release -si 2> /dev/null)"
@@ -209,7 +221,6 @@ function get_incompatible_releases() {
             fi
         fi
     done
-    export DISTRO="${distro_name}:${distro_version_name}"
 }
 
 function is_compatible_arch() {
@@ -683,6 +694,7 @@ sudo cp "${PACKAGE}.pacscript" /tmp
 pacfile=$(readlink -f "/tmp/${PACKAGE}.pacscript")
 export pacfile
 export CARCH="$(dpkg --print-architecture)"
+export DISTRO="$(set_distro)"
 if ! source "${pacfile}"; then
     fancy_message error "Could not source pacscript"
     error_log 12 "install $PACKAGE"


### PR DESCRIPTION
## Purpose

We have `incompatible` to prevent installation on certain systems, but we don't have a way of accessing the current systems information to easily structure an install to certain systems.

## Approach

Add `$DISTRO`, which is formed as `${distro_name}:${distro_version_name}`. Mine for instance would be `ubuntu:kinetic`.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
