### PR TITLE
fix(createdeb): allow top level files

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -410,9 +410,13 @@ function createdeb() {
     popd > /dev/null || return 1
     sudo tar -cf "$PWD/data.tar" -T /dev/null
     local DATA_LOCATION="$PWD/data.tar"
-    # collect every top level dir except for DEBIAN
+    # collect every top level file/dir except for deb stuff
     for i in *; do
-        if [[ -d $i && $i != "DEBIAN" ]]; then
+		if [[ -d $i || -f $i
+			&& $i != "DEBIAN"
+			&& $i != "data.tar"
+			&& $i != "control.tar"
+			&& $i != "debian-binary" ]]; then
             local files_for_data+=("$i")
         fi
     done


### PR DESCRIPTION
## Purpose

We only allowed top-level directories in debs, and we would simply ignore files. Even though people should not be putting files in `/`, it should be there for them to use regardless.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
