### PR TITLE
feat(-L): add fancy listing

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -126,6 +126,9 @@ function log() {
         echo "_version=\"${full_version}"\"
         echo "_install_size=\"${install_size}"\"
         echo "_date=\"$(date)"\"
+        if [[ -n $maintainer ]]; then
+            echo "_maintainer=\"${maintainer}"\"
+        fi
         if [[ -n $ppa ]]; then
             echo "_ppa=(${ppa[*]})"
         fi

--- a/pacstall
+++ b/pacstall
@@ -845,7 +845,7 @@ Helpful links:
                     fi
                 done
             else
-                echo "${packages_installed[*]}"
+				printf '%s\n' "${packages_installed[@]}"
             fi
             exit 0
             ;;

--- a/pacstall
+++ b/pacstall
@@ -430,6 +430,10 @@ function is_function() {
     fi
 }
 
+function size_of_deb() {
+    dpkg-query '--showformat=${Installed-Size}\n' --show "${1:?}" | numfmt --to=iec
+}
+
 # Error out when run as root
 if ((EUID == 0)); then
     fancy_message error "Pacstall can't be run as root. Please run as a normal user."
@@ -812,9 +816,36 @@ Helpful links:
                 exit 1
             fi
 
-            if ! /bin/ls -1aA "$LOGDIR"; then
+            cd "${LOGDIR}" || exit 1
+            shopt -s nullglob
+            packages_installed=(*)
+            if ((${#packages_installed[@]} == 0)); then
                 fancy_message error "Nothing installed yet"
                 exit 1
+            fi
+
+            if [[ -t 1 ]]; then
+                for pkg in "${packages_installed[@]}"; do
+                    unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _maintainer 2> /dev/null
+                    source ./"${pkg}"
+                    echo -e "${BYellow}~${NC} ${BGreen}${_name}${BPurple}@${BCyan}${_version}${NC}"
+                    if [[ -n ${_gives} ]]; then
+                        echo -e "   ${BBlue}gives${NC}        : ${BOLD}${_gives}${NC}"
+                    fi
+                    echo -e "   ${BBlue}maintainer${NC}   : ${BOLD}${_maintainer:-$(dpkg-query '--showformat=${Maintainer}\n' --show "${_gives:-$_name}")}${NC}"
+                    if [[ ${_name} == *-deb ]]; then
+                        echo -e "   ${BBlue}size${NC}         : ${BOLD}$(size_of_deb "${_gives:-$name}")${NC}"
+                    else
+                        echo -e "   ${BBlue}size${NC}         : ${BOLD}${_install_size:-unknown}${NC}"
+                    fi
+                    echo -e "   ${BBlue}repository${NC}   : ${BOLD}${_remoterepo:-local}${NC}"
+                    echo -e "   ${BBlue}install date${NC} : ${BOLD}${_date:-unknown}${NC}"
+                    if [[ ${pkg} != "${packages_installed[-1]}" ]]; then
+                        echo
+                    fi
+                done
+            else
+                echo "${packages_installed[*]}"
             fi
             exit 0
             ;;


### PR DESCRIPTION
## Purpose

Currently `-L` looks so barren. This basically merges the looks of `-Qi` with the functionality of `-L`.

## Approach

We check if the terminal is a terminal or is being piped. We display the old `-L` output when it's being piped as it just displays package names, but if it's an interactive terminal, we show the new style in all it's glory.

## Addendum

##### Interactive
![image](https://github.com/pacstall/pacstall/assets/58742515/f23371ec-5fa0-4c1a-aad2-f95f6a441ef5)

##### Piped
![image](https://github.com/pacstall/pacstall/assets/58742515/e5e62767-c0f8-40df-8702-1f4ee6c9bbfc)

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
