### PR TITLE
refactor(date): replace subshell calls to `date` with `printf`

### DIFF
--- a/misc/scripts/error_log.sh
+++ b/misc/scripts/error_log.sh
@@ -47,12 +47,15 @@ declare -r -A ErrMsg=([1]="Unknown cause of failure."
 function error_log() {
     local code="${1}"
     local scope="${2}"
+    local time
 
     if [[ ! -f $LOGFILE ]]; then
         sudo touch "$LOGFILE"
         sudo find /var/log/pacstall/error_log/ -type f -ctime +14 -delete
     fi
-    printf '[ %(%a %b %_d %r %Z %Y)T | %s ] Error %s - %s\n' "${scope}" "${code}" "${ErrMsg[$code]}" | sudo tee -a "$LOGFILE" > /dev/null
+
+    printf -v time '%(%a %b %_d %r %Z %Y)T'
+    echo -e "[ ${time} | ${scope} ] Error ${code} - ${ErrMsg[${code}]}" | sudo tee -a "$LOGFILE" > /dev/null
     return 0
 }
 

--- a/misc/scripts/error_log.sh
+++ b/misc/scripts/error_log.sh
@@ -52,7 +52,7 @@ function error_log() {
         sudo touch "$LOGFILE"
         sudo find /var/log/pacstall/error_log/ -type f -ctime +14 -delete
     fi
-    echo -e "[ $(date) | $scope ] Error $code - ${ErrMsg[$code]}" | sudo tee -a "$LOGFILE" > /dev/null
+    printf '[ %(%a %b %_d %r %Z %Y)T | %s ] Error %s - %s\n' "${scope}" "${code}" "${ErrMsg[$code]}" | sudo tee -a "$LOGFILE" > /dev/null
     return 0
 }
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -125,7 +125,7 @@ function log() {
         echo "_name=\"$name"\"
         echo "_version=\"${full_version}"\"
         echo "_install_size=\"${install_size}"\"
-        echo "_date=\"$(date)"\"
+        printf '_date=\"%(%a %b %_d %r %Z %Y)T\"\n'
         if [[ -n $maintainer ]]; then
             echo "_maintainer=\"${maintainer}"\"
         fi


### PR DESCRIPTION
## Purpose

`$(date)` is way slower than `printf '%()T'`, which is a builtin.

## Approach

Replace them with equivalent calls.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
