### PR TITLE
feat(-Qi): add queries

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -170,12 +170,12 @@ function compare_remote_version() (
     fi
     local remotever="$(source <(curl -s -- "$remoterepo/packages/$input/$input.pacscript") && type pkgver &> /dev/null && pkgver || echo "${full_version}")" > /dev/null
     if [[ $input == *"-git" ]]; then
-        if [[ $(pacstall -V "$input") != "$remotever" ]]; then
+        if [[ $(pacstall -Qi "$input" version) != "$remotever" ]]; then
             echo "update"
         else
             echo "no"
         fi
-    elif dpkg --compare-versions "$(pacstall -V "$input")" lt "$remotever" > /dev/null 2>&1; then
+    elif dpkg --compare-versions "$(pacstall -Qi "$input" version)" lt "$remotever" > /dev/null 2>&1; then
         echo "update"
     else
         echo "no"

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -51,7 +51,9 @@ if [[ -n ${_install_size} ]]; then
 fi
 description="$(get_field "$PACKAGE" Description)"
 date_installed="${_date}"
-homepage="${_homepage}"
+if [[ -n ${_homepage} ]]; then
+    homepage="${_homepage}"
+fi
 if [[ -n ${_remoterepo} ]]; then
     remote_repo="${_remoterepo}"
 fi

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -44,36 +44,70 @@ function get_field() {
     fi
 }
 
-echo -e "${BGreen}name${NC}: $(get_field "$PACKAGE" Package)"
-echo -e "${BGreen}version${NC}: $(get_field "$PACKAGE" Version)"
-if [[ -n $_install_size ]]; then
-    echo -e "${BGreen}size${NC}: $_install_size"
+name="$(get_field "$PACKAGE" Package)"
+version="$(get_field "$PACKAGE" Version)"
+if [[ -n ${_install_size} ]]; then
+    size="${_install_size}"
 fi
-echo -e "${BGreen}description${NC}: $(get_field "$PACKAGE" Description)"
-echo -e "${BGreen}date installed${NC}: $_date"
-
-if [[ -n $_homepage ]]; then
-    echo -e "${BGreen}homepage${NC}: $_homepage"
+description="$(get_field "$PACKAGE" Description)"
+date_installed="${_date}"
+homepage="${_homepage}"
+if [[ -n ${_remoterepo} ]]; then
+    remote_repo="${_remoterepo}"
 fi
-if [[ -n $_remoterepo ]]; then
-    echo -e "${BGreen}remote repo${NC}: $_remoterepo"
-fi
-echo -e "${BGreen}maintainer${NC}: $(get_field "$PACKAGE" Maintainer)"
+maintainer="$(get_field "$PACKAGE" Maintainer)"
 if [[ -n $_ppa ]]; then
-    echo -e "${BGreen}ppa${NC}: $_ppa"
+    ppa="${_ppa}"
 fi
-if [[ -n $_pacdeps ]]; then
-    echo -e "${BGreen}pacstall dependencies${NC}: ${_pacdeps[*]}"
+if [[ -n ${_pacdeps} ]]; then
+    pacstall_dependencies="${_pacdeps[*]}"
 fi
 deps=$(get_field "$PACKAGE" Depends)
 deps="${deps//,/}"
-if [[ -n $deps ]]; then
-    echo -e "${BGreen}dependencies${NC}: ${deps}"
+if [[ -n ${deps} ]]; then
+    dependencies="${deps}"
 fi
-if [[ -n $_pacstall_depends ]]; then
-    echo -e "${BGreen}install type${NC}: installed as dependency"
+if [[ -n ${_pacstall_depends} ]]; then
+    install_type="installed as dependency"
 else
-    echo -e "${BGreen}install type${NC}: explicitly installed"
+    install_type="explicitly installed"
 fi
+
+if [[ -n ${QUERY} ]]; then
+    query="${!QUERY}"
+    if [[ -z ${query} ]]; then
+        fancy_message error "Key '${QUERY}' does not exist"
+        return 1
+    else
+        echo "${query}"
+        return 0
+    fi
+fi
+
+echo -e "${BGreen}name${NC}: ${name}"
+echo -e "${BGreen}version${NC}: ${version}"
+if [[ -v size ]]; then
+    echo -e "${BGreen}size${NC}: ${size}"
+fi
+echo -e "${BGreen}description${NC}: ${description}"
+echo -e "${BGreen}date installed${NC}: ${date_installed}"
+
+if [[ -v homepage ]]; then
+    echo -e "${BGreen}homepage${NC}: ${homepage}"
+fi
+if [[ -v remote_repo ]]; then
+    echo -e "${BGreen}remote repo${NC}: ${remote_repo}"
+fi
+echo -e "${BGreen}maintainer${NC}: ${maintainer}"
+if [[ -v ppa ]]; then
+    echo -e "${BGreen}ppa${NC}: ${ppa}"
+fi
+if [[ -v pacstall_dependencies ]]; then
+    echo -e "${BGreen}pacstall dependencies${NC}: ${pacstall_dependencies}"
+fi
+if [[ -v dependencies ]]; then
+    echo -e "${BGreen}dependencies${NC}: ${dependencies}"
+fi
+echo -e "${BGreen}install type${NC}: ${install_type}"
 exit 0
 # vim:set ft=sh ts=4 sw=4 noet:

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -79,10 +79,10 @@ if [[ -n ${QUERY} ]]; then
     query="${!QUERY}"
     if [[ -z ${query} ]]; then
         fancy_message error "Key '${QUERY}' does not exist"
-        return 1
+        exit 1
     else
         echo "${query}"
-        return 0
+        exit 0
     fi
 fi
 

--- a/pacstall
+++ b/pacstall
@@ -736,21 +736,10 @@ Helpful links:
             ;;
 
         -V | --version)
-            PACKAGE="$2"
-            if [[ -z $PACKAGE ]]; then
-                version_number="3.15.0"
-                version_name="Rhythm"
-                echo -e "${version_number} \033[1m\x1b[38;2;${pac_version[red]};${pac_version[green]};${pac_version[blue]}m${version_name}${NC}"
-                exit 0
-            else
-                # If pacstall -V was called with an argument, it's a package, so get the package version (useful for scripting)
-                if source "$LOGDIR/$PACKAGE" 2> /dev/null && dpkg-query --showformat='${Version}\n' --show "${_gives:-$_name}"; then
-                    exit 0
-                else
-                    fancy_message error "${GREEN}${PACKAGE}${NC} is not installed"
-                    exit 1
-                fi
-            fi
+            version_number="3.15.0"
+            version_name="Rhythm"
+            echo -e "${version_number} \033[1m\x1b[38;2;${pac_version[red]};${pac_version[green]};${pac_version[blue]}m${version_name}${NC}"
+            exit 0
             ;;
 
         -U | --update)
@@ -930,6 +919,7 @@ Helpful links:
 
         -Qi | --query-info)
             PACKAGE=$2
+            QUERY=$3
             # shellcheck source=./misc/scripts/query-info.sh
             source "$STGDIR/scripts/query-info.sh"
             exit 0


### PR DESCRIPTION
## Purpose

Currently we have one way to get information about an installed package in a parsable way, and that's `-Qi`. We also have `-V pkg` for getting the version but that's never been publicly used and not meant for people to actually use. This PR adds an extra argument to `-Qi` that will print out the corresponding key:
```bash
elsie ~ % ››› pacstall -Qi goverlay
name: goverlay
version: 0.9.1
size: 30K
description: Graphical UI to help manage Linux overlays
date installed: Sat May 13 18:33:06 CDT 2023
maintainer: Elsie19 <hwengerstickel@pm.me>
dependencies: mangohud libqt5pas-dev
install type: explicitly installed
elsie ~/Elsie19 % ››› pacstall -Qi goverlay install_type
explicitly installed
elsie ~/Elsie19 % ››› pacstall -Qi goverlay version
0.9.1
elsie ~/Elsie19 % ››› pacstall -Qi goverlay fake_key
[!] ERROR: Key 'fake_key' does not exist
```

## Other
This removes `-V arg` functionality entirely, and the corresponding calls to it in pacstall have been replaced.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
