### PR TITLE
fix(log): use `declare` to avoid possible string splitting

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -150,7 +150,9 @@ function log() {
             fi
         fi
         if [[ -n ${pacdeps[*]} ]]; then
-            echo "_pacdeps=(${pacdeps[*]})"
+            _pacdeps=("${pacdeps[@]}")
+            declare -p _pacdeps
+            unset _pacdeps
         fi
     } | sudo tee "$LOGDIR/$name" > /dev/null
 }


### PR DESCRIPTION
## Purpose

If for some reason a developer makes a really bad pacscript, and keys in `pacdeps` are not one word, it can lead to incorrect logging.

## Approach

We can use `declare -p` to print out how bash views the array, which is almost guaranteed to be safe from splitting, and can be sourced.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
