### PR TITLE
fix(logdir): split `LOGDIR` into `LOGDIR` and `METADIR`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,7 @@ esac
 
 apt-get install -qq -y curl wget build-essential unzip git iputils-ping lsb-release
 
-LOGDIR="/var/log/pacstall/metadata"
+LOGDIR="/var/lib/pacstall/metadata"
 STGDIR="/usr/share/pacstall"
 SRCDIR="/tmp/pacstall"
 PACSTALL_USER=$(logname 2> /dev/null || echo "${SUDO_USER:-${USER}}")

--- a/misc/completion/bash
+++ b/misc/completion/bash
@@ -48,12 +48,12 @@ _pacstall() {
             ;;
 
         -?(P)R?(P) | --remove)
-            COMPREPLY=($(compgen -W "$(command ls -1aA /var/log/pacstall/metadata)" -- $cur))
+            COMPREPLY=($(compgen -W "$(command ls -1aA /var/lib/pacstall/metadata)" -- $cur))
             return
             ;;
 
         -?(P)Qi?(P) | --query-info)
-            COMPREPLY=($(compgen -W "$(command ls -1aAp /var/log/pacstall/metadata)" -- $cur))
+            COMPREPLY=($(compgen -W "$(command ls -1aAp /var/lib/pacstall/metadata)" -- $cur))
             return
             ;;
 
@@ -68,7 +68,7 @@ _pacstall() {
             ;;
 
         -T | --tree)
-            COMPREPLY=($(compgen -W "$(command ls -1aAp /var/log/pacstall/metadata)" -- $cur))
+            COMPREPLY=($(compgen -W "$(command ls -1aAp /var/lib/pacstall/metadata)" -- $cur))
             return
             ;;
     esac

--- a/misc/completion/fish
+++ b/misc/completion/fish
@@ -127,7 +127,7 @@ set -l pacscript_cmds -I --install -PI -IP -KI -IK -BI -IB -KPI -KIP -PKI -PIK -
 complete -f -c pacstall -n "_seen $package_cmds" -a "(sed -e 's/\$/\/packagelist/' /usr/share/pacstall/repo/pacstallrepo | xargs -n 1 curl -s | sort -u)"
 
 # Completion for the log related flags
-complete -f -c pacstall -n "_seen $log_cmds" -a "(command ls -1aA /var/log/pacstall/metadata)"
+complete -f -c pacstall -n "_seen $log_cmds" -a "(command ls -1aA /var/lib/pacstall/metadata)"
 
 # Completion for the local pacscript flags
 complete -f -c pacstall -n "_seen $pacscript_cmds" -a "(find -maxdepth 1 -type f -name '*.pacscript' | sed 's/.pacscript//g' | sed 's/.\///g')"

--- a/misc/scripts/dep-tree.sh
+++ b/misc/scripts/dep-tree.sh
@@ -67,7 +67,7 @@ function dep_tree.load_traits() {
     out_arr="${2:?No arr given to dep_tree.load_traits}"
     unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch 2> /dev/null
     # shellcheck disable=SC1090
-    source "${LOGDIR}/${pkg}"
+    source "${METADIR}/${pkg}"
 
     if [[ -z ${_remoterepo} ]]; then
         out_arr['upgrade']=false
@@ -141,7 +141,7 @@ function dep_tree.trim_pacdeps() {
     for i in "${merged_array[@]}"; do
         unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch 2> /dev/null
         # shellcheck disable=SC1090
-        source "${LOGDIR}/${i}"
+        source "${METADIR}/${i}"
         if [[ -n ${_pacdeps[*]} ]]; then
             for z in "${_pacdeps[@]}"; do
                 if array.contains merged_array "${z}"; then

--- a/misc/scripts/error_log.sh
+++ b/misc/scripts/error_log.sh
@@ -22,8 +22,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-if [[ ! -d "/var/log/pacstall/error_log" ]]; then
-    sudo mkdir -p "/var/log/pacstall/error_log"
+if [[ ! -d ${LOGDIR} ]]; then
+    sudo mkdir -p "${LOGDIR}"
 fi
 
 # Used with permission by zakariaGatter
@@ -51,7 +51,7 @@ function error_log() {
 
     if [[ ! -f $LOGFILE ]]; then
         sudo touch "$LOGFILE"
-        sudo find /var/log/pacstall/error_log/ -type f -ctime +14 -delete
+        sudo find "${LOGDIR:-/var/log/pacstall/error_log/}" -type f -ctime +14 -delete
     fi
 
     printf -v time '%(%a %b %_d %r %Z %Y)T'

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -152,13 +152,13 @@ function log() {
         if [[ -n ${pacdeps[*]} ]]; then
             echo "_pacdeps=(${pacdeps[*]})"
         fi
-    } | sudo tee "$LOGDIR/$name" > /dev/null
+    } | sudo tee "$METADIR/$name" > /dev/null
 }
 
 function compare_remote_version() (
     local input="${1}"
     unset -f pkgver 2> /dev/null
-    source "$LOGDIR/$input" || return 1
+    source "$METADIR/$input" || return 1
     if [[ -z ${_remoterepo} ]]; then
         return
     elif [[ ${_remoterepo} == *"github.com"* ]]; then
@@ -372,7 +372,7 @@ function prompt_optdepends() {
     if [[ -n ${pacdeps[*]} ]]; then
         for i in "${pacdeps[@]}"; do
             (
-                source "$LOGDIR/$i"
+                source "$METADIR/$i"
                 if [[ -n $_gives ]]; then
                     echo "$_gives" | tee -a /tmp/pacstall-gives > /dev/null
                 else
@@ -398,10 +398,10 @@ function generate_changelog() {
 }
 
 function clean_logdir() {
-    if [[ ! -d /var/log/pacstall/error_log/ ]]; then
-        sudo mkdir -p "/var/log/pacstall/error_log"
+    if [[ ! -d ${LOGDIR} ]]; then
+        sudo mkdir -p "${LOGDIR}"
     fi
-    sudo find -H /var/log/pacstall/error_log/ -maxdepth 1 -mtime +30 -delete
+    sudo find -H "${LOGDIR:-/var/log/pacstall/error_log/}" -maxdepth 1 -mtime +30 -delete
 }
 
 function createdeb() {
@@ -576,7 +576,7 @@ fi' | sudo tee "$STOWDIR/$name/DEBIAN/$deb_post_file" > /dev/null
             } | sudo tee -a "$STOWDIR/$name/DEBIAN/$deb_post_file" > /dev/null
         fi
     done
-    echo -e "sudo rm -f $LOGDIR/$name\nsudo rm -f /etc/apt/preferences.d/$name-pin" | sudo tee -a "$STOWDIR/$name/DEBIAN/postrm" > /dev/null
+    echo -e "sudo rm -f $METADIR/$name\nsudo rm -f /etc/apt/preferences.d/$name-pin" | sudo tee -a "$STOWDIR/$name/DEBIAN/postrm" > /dev/null
     local postfile
     for postfile in {postrm,postinst,preinst}; do
         sudo chmod -x "$STOWDIR/$name/DEBIAN/${postfile}" &> /dev/null
@@ -1066,7 +1066,7 @@ function run_function() {
     local func="$1"
     fancy_message sub "Running $func"
     # NOTE: https://stackoverflow.com/a/29163890 (shorthand for 2>&1 |)
-    $func |& sudo tee "/var/log/pacstall/error_log/$(printf '%(%Y-%m-%d_%T)T')-$name-$func.log" && return "${PIPESTATUS[0]}"
+    $func |& sudo tee "${LOGDIR}/$(printf '%(%Y-%m-%d_%T)T')-$name-$func.log" && return "${PIPESTATUS[0]}"
 }
 
 function safe_run() {

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -27,12 +27,12 @@ if [[ -z $PACKAGE ]]; then
     exit 1
 fi
 
-if [[ ! -f "$LOGDIR/$PACKAGE" ]]; then
+if [[ ! -f "$METADIR/$PACKAGE" ]]; then
     fancy_message error "Package is not installed"
     exit 1
 fi
 
-source "$LOGDIR/$PACKAGE"
+source "$METADIR/$PACKAGE"
 
 function get_field() {
     # input 1: package

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-source "$LOGDIR/$PACKAGE" 2> /dev/null || {
+source "$METADIR/$PACKAGE" 2> /dev/null || {
     fancy_message error "$PACKAGE is not installed"
     exit 1
 }
@@ -43,5 +43,5 @@ if [[ -n ${_ppa[*]} ]]; then
     done
 fi
 
-sudo rm -f /var/log/pacstall/metadata/"$_name"
+sudo rm -f "${METADIR:?}/${_name}"
 # vim:set ft=sh ts=4 sw=4 noet:

--- a/misc/scripts/update.sh
+++ b/misc/scripts/update.sh
@@ -44,7 +44,7 @@ function suggested_solution() {
     fi
 }
 
-sudo mkdir -p "/var/log/pacstall/metadata"
+sudo mkdir -p "/var/lib/pacstall/metadata"
 sudo mkdir -p "/var/log/pacstall/error_log"
 sudo chown "$PACSTALL_USER" -R /var/log/pacstall/error_log
 
@@ -55,6 +55,12 @@ sudo mkdir -p /usr/share/bash-completion/completions
 
 if ! dpkg -s lsb-release > /dev/null 2>&1; then
     sudo apt-get install lsb-release -y
+fi
+
+# Pre 4.0.0 metadata dir changes
+if [[ -d "/var/log/pacstall/metadata/" ]]; then
+    sudo mv -p "/var/log/pacstall/metadata/" "/var/lib/pacstall/metadata/" \  \
+        && sudo rm -rf "/var/log/pacstall/metadata/"
 fi
 
 STGDIR="/usr/share/pacstall"

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -62,7 +62,7 @@ N="$(nproc)"
         ((n = n % N))
         ((n++ == 0)) && wait
         (
-            source "$LOGDIR/$i"
+            source "$METADIR/$i"
 
             # localver is the current version of the package
             localver="${_version}"
@@ -87,7 +87,7 @@ N="$(nproc)"
                 remoteurl="${REPOS[$IDXMATCH]}"
             else
                 fancy_message warn "Package ${GREEN}${i}${CYAN} is not on ${CYAN}$(parseRepo "${remoterepo}")${NC} anymore"
-                sudo sed -i "/_remote/d" "$LOGDIR/$i"
+                sudo sed -i "/_remote/d" "$METADIR/$i"
             fi
 
             if [[ $i != *"-git" ]]; then

--- a/pacstall
+++ b/pacstall
@@ -24,8 +24,9 @@
 
 # Configuration
 export LC_ALL=C
-export LOGDIR="/var/log/pacstall/metadata"
-printf -v LOGFILE "/var/log/pacstall/error_log/%(%F_%T)T.log"
+export METADIR="/var/lib/pacstall/metadata"
+export LOGDIR="/var/log/pacstall/error_log"
+printf -v LOGFILE "${LOGDIR}/%(%F_%T)T.log"
 export LOGFILE
 export SRCDIR="/tmp/pacstall"
 export STGDIR="/usr/share/pacstall"
@@ -797,11 +798,11 @@ Helpful links:
                 exit 1
             fi
 
-            if [[ ! -d ${LOGDIR} ]]; then
+            if [[ ! -d ${METADIR} ]]; then
                 exit 1
             fi
 
-            cd "${LOGDIR}" || exit 1
+            cd "${METADIR}" || exit 1
             shopt -s nullglob
             packages_installed=(*)
             if ((${#packages_installed[@]} == 0)); then
@@ -902,12 +903,12 @@ Helpful links:
                 fancy_message error "You failed to specify a package"
                 exit 1
             fi
-            if ! [[ -f $LOGDIR/$PACKAGE ]]; then
+            if ! [[ -f $METADIR/$PACKAGE ]]; then
                 fancy_message error "Package is not installed"
                 exit 1
             fi
 
-            source "$LOGDIR/$PACKAGE"
+            source "$METADIR/$PACKAGE"
 
             dpkg --listfiles "${_gives:-$_name}" | sed -e "s/[^-][^\/]*\//  │/g" -e "s/│\([^ ]\)/│──\1/"
             exit 0


### PR DESCRIPTION
## Purpose

Because apparently some apps clear out our metadata.

## Approach

Split `LOGDIR` into:

- `LOGDIR`: `/var/log/pacstall/error_log/`
    - For logging errors
- `METADIR`: `/var/lib/pacstall/metadata/`
    - For metadata

## Addendum

Closes #406.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
