### PR TITLE
fix(pacstall): add `FARCH` array

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -241,9 +241,12 @@ function is_compatible_arch() {
     elif [[ " ${input[*]} " =~ " any " ]]; then
         return 0
     elif [[ -n "${FARCH[*]}" ]]; then
-        if [[ " ${input[*]} " =~ " ${FARCH[*]} " ]]; then
+        if [[ " ${FARCH[*]} " =~ " ${input[*]} " ]]; then
             fancy_message warn "This package is for ${BBlue}${input[*]}${NC}, which is a foreign architecture"
             return 0
+        else
+            fancy_message warn "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
+            return 1
         fi
     elif ! [[ " ${input[*]} " =~ " ${CARCH} " ]]; then
         fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -245,7 +245,7 @@ function is_compatible_arch() {
         	if [[ " ${FARCH[*]} " =~ " ${input[*]} " ]]; then
             	fancy_message warn "This package is for ${BBlue}${input[*]}${NC}, which is a foreign architecture"
             	return 0
-			else 
+			else
            		fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
         		return 1
 			fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -240,6 +240,11 @@ function is_compatible_arch() {
         return 0
     elif [[ " ${input[*]} " =~ " any " ]]; then
         return 0
+    elif [[ -n "${FARCH[*]}" ]]; then
+        if [[ " ${input[*]} " =~ " ${FARCH[*]} " ]]; then
+            fancy_message warn "This package is for a ${BBlue}foreign architecture${NC}"
+            return 0
+        fi
     elif ! [[ " ${input[*]} " =~ " ${CARCH} " ]]; then
         fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
         return 1
@@ -704,6 +709,8 @@ export homedir
 sudo cp "${PACKAGE}.pacscript" /tmp
 pacfile="$(readlink -f "/tmp/${PACKAGE}.pacscript")"
 export pacfile
+mapfile -t FARCH < <(dpkg --print-foreign-architectures)
+export FARCH
 export CARCH="$(dpkg --print-architecture)"
 export DISTRO="$(set_distro)"
 if ! source "${pacfile}"; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -240,17 +240,19 @@ function is_compatible_arch() {
         return 0
     elif [[ " ${input[*]} " =~ " any " ]]; then
         return 0
-    elif [[ -n "${FARCH[*]}" ]]; then
-        if [[ " ${FARCH[*]} " =~ " ${input[*]} " ]]; then
-            fancy_message warn "This package is for ${BBlue}${input[*]}${NC}, which is a foreign architecture"
-            return 0
-        else
-            fancy_message warn "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
-            return 1
-        fi
     elif ! [[ " ${input[*]} " =~ " ${CARCH} " ]]; then
-        fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
-        return 1
+		if [[ -n "${FARCH[*]}" ]]; then
+        	if [[ " ${FARCH[*]} " =~ " ${input[*]} " ]]; then
+            	fancy_message warn "This package is for ${BBlue}${input[*]}${NC}, which is a foreign architecture"
+            	return 0
+			else 
+           		fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
+        		return 1
+			fi
+   		else
+        	fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
+        	return 1
+		fi
     fi
 }
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -242,7 +242,7 @@ function is_compatible_arch() {
         return 0
     elif [[ -n "${FARCH[*]}" ]]; then
         if [[ " ${input[*]} " =~ " ${FARCH[*]} " ]]; then
-            fancy_message warn "This package is for a ${BBlue}foreign architecture${NC}"
+            fancy_message warn "This package is for ${BBlue}${input[*]}${NC}, which is a foreign architecture"
             return 0
         fi
     elif ! [[ " ${input[*]} " =~ " ${CARCH} " ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -241,18 +241,18 @@ function is_compatible_arch() {
     elif [[ " ${input[*]} " =~ " any " ]]; then
         return 0
     elif ! [[ " ${input[*]} " =~ " ${CARCH} " ]]; then
-		if [[ -n "${FARCH[*]}" ]]; then
-        	if [[ " ${FARCH[*]} " =~ " ${input[*]} " ]]; then
-            	fancy_message warn "This package is for ${BBlue}${input[*]}${NC}, which is a foreign architecture"
-            	return 0
-			else
-           		fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
-        		return 1
-			fi
-   		else
-        	fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
-        	return 1
-		fi
+        if [[ -n ${FARCH[*]} ]]; then
+            if [[ " ${FARCH[*]} " =~ " ${input[*]} " ]]; then
+                fancy_message warn "This package is for ${BBlue}${input[*]}${NC}, which is a foreign architecture"
+                return 0
+            else
+                fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
+                return 1
+            fi
+        else
+            fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
+            return 1
+        fi
     fi
 }
 


### PR DESCRIPTION
## Purpose

the is_compatible_arch check doesn't currently work for foreign architectures - i.e. if dpkg adds arm64 to an amd64 machine, CARCH won't do, so we need a solution.

## Approach

Make a FARCH variable array, test if it exists, and test if our input arch matches one of the FARCH outputs

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
