### PR TITLE
fix(-L): hide no install error on non-interactive

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -808,6 +808,8 @@ Helpful links:
             if ((${#packages_installed[@]} == 0)) && [[ -t 1 ]]; then
                 fancy_message error "Nothing installed yet"
                 exit 1
+            else
+                exit 1
             fi
 
             if [[ -t 1 ]]; then

--- a/pacstall
+++ b/pacstall
@@ -805,7 +805,7 @@ Helpful links:
             cd "${METADIR}" || exit 1
             shopt -s nullglob
             packages_installed=(*)
-            if ((${#packages_installed[@]} == 0)) [[ -t 1 ]]; then
+            if ((${#packages_installed[@]} == 0)) && [[ -t 1 ]]; then
                 fancy_message error "Nothing installed yet"
                 exit 1
             fi

--- a/pacstall
+++ b/pacstall
@@ -805,7 +805,7 @@ Helpful links:
             cd "${METADIR}" || exit 1
             shopt -s nullglob
             packages_installed=(*)
-            if ((${#packages_installed[@]} == 0)); then
+            if ((${#packages_installed[@]} == 0)) [[ -t 1 ]]; then
                 fancy_message error "Nothing installed yet"
                 exit 1
             fi


### PR DESCRIPTION
## Purpose

Because we just want to exit, and not show anything to the program trying to access the package list.

## Approach

Check for `[[ -t 1 ]]`.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
