### PR TITLE
Bugfix search.sh

### DIFF
--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -84,7 +84,7 @@ if [[ $PACKAGE == *@* ]]; then
     while IFS= read -r URL; do
         specifyRepo "$URL"
         if [[ $URLNAME == "$REPONAME" ]]; then
-            mapfile -t PACKAGELIST < <(curl -s -- "$URL"/packagelist)
+            mapfile -t PACKAGELIST < <(curl -s -- "$URL")
             IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /^${PACKAGE}$/ {print NR-1}")
             _LEN=($IDXSEARCH)
             LEN=${#_LEN[@]}


### PR DESCRIPTION
# Package installation failing due to duplicate endpoint in URL

- Fixes bug fetching package lists by removing appended `/packagelist` from curl URL. This was a quick fix implemented in the browser.

Previous URL: 'https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packagelist/packagelist'

URL after fix: 'https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packagelist'

## Purpose

Correct the URL for fetching the package list

## Approach

Eliminating duplicated endpoint

## Progress

- [x] Found the source of the incorrect URL
- [x] Corrected the URL
- [x] Package list successfully fetched

## Addendum

I apologize that I did not have the time or proper environment to perform any e2e testing but considered that negligible given the breaking nature of the bug and the simple nature of the fix.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
