### PR TITLE
perf(prompt_optdepends): do not regen cache on every apt-cache run

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -296,7 +296,7 @@ function prompt_optdepends() {
             # Strip the description, `opt` is now the canonical optdep name
             local opt="${optdep%%: *}"
             # Check if package exists in the repos, and if not, go to the next program
-            if [[ -z "$(apt-cache search --names-only "^$opt\$")" ]]; then
+            if [[ -z "$(apt-cache search --no-generate --names-only "^$opt\$")" ]]; then
                 local missing_optdeps+=("${opt}")
                 continue
             fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -296,7 +296,7 @@ function prompt_optdepends() {
             # Strip the description, `opt` is now the canonical optdep name
             local opt="${optdep%%: *}"
             # Check if package exists in the repos, and if not, go to the next program
-            if [[ -z "$(apt-cache search --no-generate --names-only "^$opt\$")" ]]; then
+            if [[ -z "$(apt-cache search --no-generate --names-only "^$opt\$" &> /dev/null || apt-cache search --names-only "^$opt\$")" ]]; then
                 local missing_optdeps+=("${opt}")
                 continue
             fi


### PR DESCRIPTION
## Purpose

It's slow and at the beginning of every pacstall run, it checks if the cache is reasonably in date (7 days), so regenerating the cache for checking `optdepends` is really slow and not useful.

## Approach

Add `--no-generate` to `apt-cache`.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
