### PR TITLE
fix(full_version): use old style for debs

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -136,6 +136,8 @@ function compare_remote_version() (
     local remotever="$(
         source <(curl -s -- "$remoterepo/packages/$input/$input.pacscript") && if is_function pkgver; then
             echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}~git$(pkgver)"
+        elif [[ ${name} == *-deb ]]; then
+            echo "${epoch+$epoch:}${pkgver}"
         else
             echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}"
         fi
@@ -709,6 +711,8 @@ fi
 
 if is_function pkgver; then
     full_version="${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}~git$(pkgver)"
+elif [[ ${name} == *-deb ]]; then
+    full_version="${epoch+$epoch:}${pkgver}"
 else
     full_version="${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}"
 fi

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -85,7 +85,7 @@ N="$(nproc)"
             IDXMATCH=$(printf "%s\n" "${REPOS[@]}" | awk "\$1 ~ /^${remoterepo//\//\\/}$/ {print NR-1}")
 
             if [[ -n $IDXMATCH ]]; then
-                remotever=$(source <(curl -s -- "$remoterepo/packages/$i/$i.pacscript") && type pkgver &> /dev/null && echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}~git$(pkgver)" || echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}") > /dev/null
+                remotever=$(source <(curl -s -- "$remoterepo/packages/$i/$i.pacscript") && if [[ ${name} == *-deb ]]; then echo "${epoch+$epoch:}${pkgver}"; else type pkgver &> /dev/null && echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}~git$(pkgver)" || echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}"; fi) > /dev/null
                 remoteurl="${REPOS[$IDXMATCH]}"
             else
                 fancy_message warn "Package ${GREEN}${i}${CYAN} is not on ${CYAN}$(parseRepo "${remoterepo}")${NC} anymore"
@@ -98,7 +98,7 @@ N="$(nproc)"
                     if ((IDX == IDXMATCH)); then
                         continue
                     else
-                        ver=$(source <(curl -s -- "${REPOS[$IDX]}"/packages/"$i"/"$i".pacscript) && type pkgver &> /dev/null && echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}~git$(pkgver)" || echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}") > /dev/null
+                        ver=$(source <(curl -s -- "${REPOS[$IDX]}"/packages/"$i"/"$i".pacscript) && if [[ ${name} == *-deb ]]; then echo "${epoch+$epoch:}${pkgver}"; else type pkgver &> /dev/null && echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}~git$(pkgver)" || echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}"; fi) > /dev/null
                         if ! ver_compare "$alterver" "$ver"; then
                             alterver="$ver"
                             alterurl="$REPO"


### PR DESCRIPTION
## Purpose

It fudges up the version, like [spotify-client-deb](https://github.com/pacstall/pacstall-programs/blob/f46dd0a27d56267acd8499a078004c95c7303d2a/packages/spotify-client-deb/spotify-client-deb.pacscript) is `1.2.13.661.ga588f749-pacstall1` when it should be logged as `1.2.13.661.ga588f749`.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
