### PR TITLE
fix(pin): include `provides[@]` in pinning

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -604,7 +604,8 @@ fi' | sudo tee "$STOWDIR/$name/DEBIAN/$deb_post_file" > /dev/null
         if ! [[ -d /etc/apt/preferences.d/ ]]; then
             sudo mkdir -p /etc/apt/preferences.d
         fi
-        echo "Package: ${gives:-$name}
+        local combined_pinning=("${provides[@]}" "${gives:-${name}}")
+        echo "Package: ${combined_pinning[*]}
 Pin: version *
 Pin-Priority: -1" | sudo tee "/etc/apt/preferences.d/${name}-pin" > /dev/null
         return 0


### PR DESCRIPTION
## Purpose

We should block the package name and everything it provides in the pin.

## Approach

Check `man 5 apt_preferences`. Basically the `Package` section allows us to specify multiple packages per pin by using a space delimited list.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.