### PR TITLE
fix(upgrade): remove pre-4.0.0 git versions

### DIFF
--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -118,8 +118,7 @@ N="$(nproc)"
                     remoterepo="$alterver"
                     remoteurl="$alterurl"
                 fi
-                # If the remote version equals the local version minus the first character (0) or they both equal the same
-            elif [[ $remotever == "${localver:1}" ]] || [[ $remotever == "$localver" ]]; then
+            elif [[ $remotever == "${localver}" ]]; then
                 return
             fi
 


### PR DESCRIPTION
## Purpose

The fix was pre-4.0.0 and since we use `pkgver` as a var for the tag, we don't need this.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
