### PR TITLE
feat(install-local.sh): add `compatible` array

### DIFF
--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -320,9 +320,37 @@ function lint_provides() {
     return "${ret}"
 }
 
+function lint_compatible() {
+    local ret=0 compat idx=0
+    if [[ -n ${compatible[*]} ]]; then
+        if [[ -n ${incompatible[*]} ]]; then
+            fancy_message error "'compatible' and 'incompatible' indeces cannot both be provided"
+        fi
+        for compat in "${compatible[@]}"; do
+            if [[ -z ${compat} ]]; then
+                fancy_message error "'compatible' index '${idx}' cannot be empty"
+                ret=1
+            fi
+            ((idx++))
+        done
+        idx=0
+        for compat in "${compatible[@]}"; do
+            if [[ $compat != *:* ]] || [[ $compat == "*:*" ]]; then
+                fancy_message error "'compatible' index '${idx}' is improperly formatted"
+                ret=1
+            fi
+            ((idx++))
+        done
+    fi
+    return "${ret}"
+}
+
 function lint_incompatible() {
     local ret=0 incompat idx=0
     if [[ -n ${incompatible[*]} ]]; then
+        if [[ -n ${compatible[*]} ]]; then
+            fancy_message error "'compatible' and 'incompatible' indeces cannot both be provided"
+        fi
         for incompat in "${incompatible[@]}"; do
             if [[ -z ${incompat} ]]; then
                 fancy_message error "'incompatible' index '${idx}' cannot be empty"
@@ -382,7 +410,7 @@ function lint_mask() {
 }
 
 function checks() {
-    local ret=0 check linting_checks=(lint_name lint_gives lint_pkgrel lint_epoch lint_version lint_url lint_pkgdesc lint_maintainer lint_makedepends lint_depends lint_pacdeps lint_ppa lint_optdepends lint_breaks lint_replace lint_hash lint_patch lint_provides lint_incompatible lint_arch lint_mask)
+    local ret=0 check linting_checks=(lint_name lint_gives lint_pkgrel lint_epoch lint_version lint_url lint_pkgdesc lint_maintainer lint_makedepends lint_depends lint_pacdeps lint_ppa lint_optdepends lint_breaks lint_replace lint_hash lint_patch lint_provides lint_compatible lint_incompatible lint_arch lint_mask)
     for check in "${linting_checks[@]}"; do
         "${check}" || ret=1
     done

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -320,11 +320,14 @@ function lint_provides() {
     return "${ret}"
 }
 
-function lint_compatible() {
-    local ret=0 compat idx=0
+function lint_incompatible() {
+    local ret=0 incompat compat idx=0 comp_err=0
     if [[ -n ${compatible[*]} ]]; then
         if [[ -n ${incompatible[*]} ]]; then
-            fancy_message error "'compatible' and 'incompatible' indeces cannot both be provided"
+		    if [[ ${comp_err} != 1 ]]; then
+            	fancy_message error "'compatible' and 'incompatible' indeces cannot both be provided"
+				comp_error=1
+			fi
 			ret=1
         fi
         for compat in "${compatible[@]}"; do
@@ -342,15 +345,12 @@ function lint_compatible() {
             fi
             ((idx++))
         done
-    fi
-    return "${ret}"
-}
-
-function lint_incompatible() {
-    local ret=0 incompat idx=0
-    if [[ -n ${incompatible[*]} ]]; then
+    elif [[ -n ${incompatible[*]} ]]; then
         if [[ -n ${compatible[*]} ]]; then
-            fancy_message error "'compatible' and 'incompatible' indeces cannot both be provided"
+            if [[ ${comp_err} != 1 ]]; then
+            	fancy_message error "'compatible' and 'incompatible' indeces cannot both be provided"
+				comp_error=1
+			fi
 			ret=1
         fi
         for incompat in "${incompatible[@]}"; do
@@ -412,7 +412,7 @@ function lint_mask() {
 }
 
 function checks() {
-    local ret=0 check linting_checks=(lint_name lint_gives lint_pkgrel lint_epoch lint_version lint_url lint_pkgdesc lint_maintainer lint_makedepends lint_depends lint_pacdeps lint_ppa lint_optdepends lint_breaks lint_replace lint_hash lint_patch lint_provides lint_compatible lint_incompatible lint_arch lint_mask)
+    local ret=0 check linting_checks=(lint_name lint_gives lint_pkgrel lint_epoch lint_version lint_url lint_pkgdesc lint_maintainer lint_makedepends lint_depends lint_pacdeps lint_ppa lint_optdepends lint_breaks lint_replace lint_hash lint_patch lint_provides lint_incompatible lint_arch lint_mask)
     for check in "${linting_checks[@]}"; do
         "${check}" || ret=1
     done

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -325,6 +325,7 @@ function lint_compatible() {
     if [[ -n ${compatible[*]} ]]; then
         if [[ -n ${incompatible[*]} ]]; then
             fancy_message error "'compatible' and 'incompatible' indeces cannot both be provided"
+			ret=1
         fi
         for compat in "${compatible[@]}"; do
             if [[ -z ${compat} ]]; then
@@ -350,6 +351,7 @@ function lint_incompatible() {
     if [[ -n ${incompatible[*]} ]]; then
         if [[ -n ${compatible[*]} ]]; then
             fancy_message error "'compatible' and 'incompatible' indeces cannot both be provided"
+			ret=1
         fi
         for incompat in "${incompatible[@]}"; do
             if [[ -z ${incompat} ]]; then

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -324,11 +324,11 @@ function lint_incompatible() {
     local ret=0 incompat compat idx=0 comp_err=0
     if [[ -n ${compatible[*]} ]]; then
         if [[ -n ${incompatible[*]} ]]; then
-		    if [[ ${comp_err} != 1 ]]; then
-            	fancy_message error "'compatible' and 'incompatible' indeces cannot both be provided"
-				comp_error=1
-			fi
-			ret=1
+            if [[ ${comp_err} != 1 ]]; then
+                fancy_message error "'compatible' and 'incompatible' indeces cannot both be provided"
+                comp_error=1
+            fi
+            ret=1
         fi
         for compat in "${compatible[@]}"; do
             if [[ -z ${compat} ]]; then
@@ -348,10 +348,10 @@ function lint_incompatible() {
     elif [[ -n ${incompatible[*]} ]]; then
         if [[ -n ${compatible[*]} ]]; then
             if [[ ${comp_err} != 1 ]]; then
-            	fancy_message error "'compatible' and 'incompatible' indeces cannot both be provided"
-				comp_error=1
-			fi
-			ret=1
+                fancy_message error "'compatible' and 'incompatible' indeces cannot both be provided"
+                comp_error=1
+            fi
+            ret=1
         fi
         for incompat in "${incompatible[@]}"; do
             if [[ -z ${incompat} ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -202,7 +202,8 @@ function get_compatible_releases() {
             # check for `ubuntu:jammy` or `ubuntu:22.04`
             return 0
         else
-            echo "This Pacscript does not work on ${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}"
+            fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}"
+			return 1
         fi
     done
 }

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -203,7 +203,7 @@ function get_compatible_releases() {
             return 0
         else
             fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}"
-			return 1
+            return 1
         fi
     done
 }


### PR DESCRIPTION
## Purpose

Oren (that's me) has been annoyed when creating packages that only work on a very specific distro version, having to provide a scroll's worth of listings in the `incompatible` array. 

## Approach

To solve this, a `compatible` array now exists, which is basically just the inverse of `incompatible`. `compatible` will always take precedence, because it is implied that anything not listed is `incompatible`. This adds checks to make sure compatible array is checked first, and if both of them are provided, it will give an error.

## Progress

- [x] Do the writing of it 
- [x] Make sure it doesn't break 

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
