### PR TITLE
fix(install-local.sh): repair `FARCH` array

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -212,9 +212,9 @@ function get_incompatible_releases() {
 
 function is_compatible_arch() {
     local input=("${@}")
-    if array.contains input "any"; then
+    if [[ " ${input[*]} " =~ " any " ]]; then
         return 0
-    elif ! array.contains input "${CARCH}"; then
+    elif ! [[ " ${input[*]} " =~ " ${CARCH} " ]]; then
         if [[ -n ${FARCH[*]} ]]; then
             if [[ " ${FARCH[*]} " =~ " ${input[*]} " ]]; then
                 fancy_message warn "This package is for ${BBlue}${input[*]}${NC}, which is a foreign architecture"


### PR DESCRIPTION
## Purpose

The Unix philosophy is documented by [Doug McIlroy](https://en.wikipedia.org/wiki/Doug_McIlroy)[[1]](https://en.wikipedia.org/wiki/Unix_philosophy#cite_note-taoup-ch1s6-1) in the Bell System Technical Journal from 1978:[[2]](https://en.wikipedia.org/wiki/Unix_philosophy#cite_note-2)

1. Make each program do one thing well. To do a new job, build afresh rather than complicate old programs by adding new "features".
2. Expect the output of every program to become the input to another, as yet unknown, program. Don't clutter output with extraneous information. Avoid stringently columnar or binary input formats. Don't insist on interactive input.
3. Design and build software, even operating systems, to be tried early, ideally within weeks. Don't hesitate to throw away the clumsy parts and rebuild them.
4. Use tools in preference to unskilled help to lighten a programming task, even if you have to detour to build the tools and expect to throw some of them out after you've finished using them.

## Approach

It was later summarized by [Peter H. Salus](https://en.wikipedia.org/wiki/Peter_H._Salus) in A Quarter-Century of Unix (1994):[[1]](https://en.wikipedia.org/wiki/Unix_philosophy#cite_note-taoup-ch1s6-1)

1. Write programs that do one thing and do it well.
2. Write programs to work together.
3. Write programs to handle text streams, because that is a universal interface.

## Progress

- [x] Revert unnecessary re-tooling that breaks the array

## Checklist

- [x] I confirm that I have read the Unix Philosophy many times over, and understand that Pacstall is a ***package manager***, not "*Tweaks for Bash*"

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
