### PR TITLE
perf(search): use `printf -v` instead of subshells

### DIFF
--- a/misc/scripts/add-repo.sh
+++ b/misc/scripts/add-repo.sh
@@ -60,7 +60,7 @@ if ! curl --head --location -s --fail -- "$REPO/packagelist" > /dev/null; then
 fi
 REPOLIST=()
 while IFS= read -r REPOURL; do
-    REPOLIST+=("${REPOURL} ")
+    REPOLIST+=("${REPOURL}")
 done < "$STGDIR/repo/pacstallrepo"
 REPOLIST+=("$REPO")
 

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -30,11 +30,12 @@ fi
 
 function getPath() {
     local path="${1}"
+	local var="${2}"
     path="${path/"file://"/}"
     path="${path/"~"/"$HOME"}"
     path="$(readlink -f "${path}")"
     path="${path/"$HOME"/"~"}"
-    echo "${path}"
+    printf -v "${var}" "${path}"
 }
 
 function specifyRepo() {
@@ -42,7 +43,8 @@ function specifyRepo() {
     mapfile -t SPLIT < <(echo "${1//[\/]/$'\n'}")
 
     if [[ $1 == "file://"* ]] || [[ $1 == "/"* ]] || [[ $1 == "~"* ]] || [[ $1 == "."* ]]; then
-        export URLNAME="$(getPath "${1}")"
+		export URLNAME
+        getPath "${1}" URLNAME
     elif [[ $1 == *"github"* ]]; then
         export URLNAME="${SPLIT[-3]}/${SPLIT[-2]}"
     elif [[ $1 == *"gitlab"* ]]; then
@@ -59,11 +61,11 @@ function specifyRepo() {
 # terminals that support them
 function parseRepo() {
     local REPO="${1}"
-    local SPLIT
+    local SPLIT REPODIR
     mapfile -t SPLIT < <(echo "${REPO//[\/]/$'\n'}")
 
     if [[ $REPO == *"file://"* ]]; then
-        local REPODIR="$(getPath "${REPO}")"
+        getPath "${REPO}" REPODIR
         echo "\e]8;;$REPO\a$REPODIR\e]8;;\a"
     elif [[ $REPO == *"github"* ]]; then
         echo -e "\e]8;;https://github.com/${SPLIT[-3]}/${SPLIT[-2]}\a${SPLIT[-3]}/${SPLIT[-2]}\e]8;;\a"
@@ -77,7 +79,7 @@ function parseRepo() {
 if [[ $PACKAGE == *@* ]]; then
     REPONAME=${PACKAGE#*@}
     if [[ $REPONAME == "file://"* ]] || [[ $REPONAME == "/"* ]] || [[ $REPONAME == "~"* ]] || [[ $REPONAME == "."* ]]; then
-        REPONAME="$(getPath "${REPONAME}")"
+        getPath "${REPONAME}" REPONAME
     fi
     PACKAGE=${PACKAGE%%@*}
 

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -30,7 +30,7 @@ fi
 
 function getPath() {
     local path="${1}"
-	local var="${2}"
+    local var="${2}"
     path="${path/"file://"/}"
     path="${path/"~"/"$HOME"}"
     path="$(readlink -f "${path}")"
@@ -43,7 +43,7 @@ function specifyRepo() {
     mapfile -t SPLIT < <(echo "${1//[\/]/$'\n'}")
 
     if [[ $1 == "file://"* ]] || [[ $1 == "/"* ]] || [[ $1 == "~"* ]] || [[ $1 == "."* ]]; then
-		export URLNAME
+        export URLNAME
         getPath "${1}" URLNAME
     elif [[ $1 == *"github"* ]]; then
         export URLNAME="${SPLIT[-3]}/${SPLIT[-2]}"

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -35,7 +35,7 @@ function getPath() {
     path="${path/"~"/"$HOME"}"
     path="$(readlink -f "${path}")"
     path="${path/"$HOME"/"~"}"
-    printf -v "${var}" "${path}"
+    printf -v "${var}" "%s" "${path}"
 }
 
 function specifyRepo() {


### PR DESCRIPTION
## Purpose

It's faster.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
