### PR TITLE
fix(install-local.sh): chown pacscript

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -707,6 +707,7 @@ homedir="$(eval echo ~"$PACSTALL_USER")"
 export homedir
 
 sudo cp "${PACKAGE}.pacscript" /tmp
+sudo chown "$PACSTALL_USER":"$PACSTALL_USER" "/tmp/${PACKAGE}.pacscript"
 pacfile="$(readlink -f "/tmp/${PACKAGE}.pacscript")"
 export pacfile
 mapfile -t FARCH < <(dpkg --print-foreign-architectures)


### PR DESCRIPTION
## Purpose

I often use virtual machines to test out pacscripts, for that I use a Shared Folder between the host and the guest.
When I get into that directory in the guest, the files belong to root:vboxsf.
When I do a local pacstall install, I get a permission error.
![image](https://github.com/pacstall/pacstall/assets/10415894/47498da8-acf9-4845-9bf5-af81c0edfe8c)


## Approach

After copying the pacscript to /tmp, make sure it belongs to the pacstall user


## Checklist

- [X] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
