### PR TITLE
fix: install pacdeps from the same origin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -49,7 +49,7 @@ function cleanup() {
     fi
     sudo rm -rf "${STOWDIR}/${name:-$PACKAGE}.deb"
     rm -f /tmp/pacstall-select-options
-    unset name repology pkgver epoch url depends makedepends breaks replace gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible optinstall epoch homepage backup pkgrel mask pac_functions 2> /dev/null
+    unset name repology pkgver epoch url depends makedepends breaks replace gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible optinstall epoch homepage backup pkgrel mask pac_functions repo 2> /dev/null
     unset -f pkgver post_install post_remove pre_install prepare build package 2> /dev/null
     sudo rm -f "${pacfile}"
 }
@@ -800,6 +800,9 @@ if [[ -n $pacdeps ]]; then
         touch "/tmp/pacstall-pacdeps-$i"
 
         [[ $KEEP ]] && cmd="-KPI" || cmd="-PI"
+        if pacstall -S "${i}@${REPO}"; then
+            repo="@${REPO}"
+        fi
         if is_package_installed "${i}"; then
             pacstall_pacdep_status="$(compare_remote_version "$i")"
             if [[ $pacstall_pacdep_status == "update" ]]; then
@@ -815,12 +818,13 @@ if [[ -n $pacdeps ]]; then
 
             fi
             # BUG: Pacstall installs pacdeps from main repo. In the RS version we should get the latest version of the pacdep from all repos and use that.
-        elif fancy_message info "Installing $i" && ! pacstall "$cmd" "$i"; then
+        elif fancy_message info "Installing $i" && ! pacstall "$cmd" "${i}${repo}"; then
             fancy_message error "Failed to install dependency"
             error_log 8 "install $PACKAGE"
             cleanup
             return 1
         fi
+        unset repo
         rm -f "/tmp/pacstall-pacdeps-$i"
     done
 fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -800,7 +800,7 @@ if [[ -n $pacdeps ]]; then
         touch "/tmp/pacstall-pacdeps-$i"
 
         [[ $KEEP ]] && cmd="-KPI" || cmd="-PI"
-        if pacstall -S "${i}@${REPO}"; then
+        if pacstall -S "${i}@${REPO}" &>/dev/null; then
             repo="@${REPO}"
         fi
         if is_package_installed "${i}"; then

--- a/pacstall
+++ b/pacstall
@@ -537,9 +537,9 @@ function lock() {
         return 1
     elif [[ $ignore =~ (^|[[:space:]])"$3"($|[[:space:]]) ]]; then
         return 1
-    elif [[ -f "/tmp/pacstall-pacdeps-$3" ]]; then
+    elif [[ -f "/tmp/pacstall-pacdeps-${3%%@*}" ]]; then
         return 1
-    elif [[ -f "/tmp/pacstall-pacdeps-$4" ]]; then
+    elif [[ -f "/tmp/pacstall-pacdeps-${4%%@*}" ]]; then
         return 1
     fi
     pidof -o %PPID -x "$0" > /dev/null && return 0 || return 1


### PR DESCRIPTION
## Purpose

Currently, pacdeps are being installed from the main repo if they exist there instead of giving preference to the same repo as the package being installed

## Approach

Check if the pacdep exists in the same repo as the package that requires it and install from it if it exists

## Addendum

Closes #680

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
