### PR TITLE
fix(install-local.sh): repair `compatible` array

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -185,27 +185,32 @@ function get_compatible_releases() {
     fi
     # lowercase
     local input=("${@,,}")
+    local is_compat=false
     for key in "${input[@]}"; do
         # check for `*:jammy`
         if [[ $key == "*:"* ]]; then
             # check for `22.04` or `jammy`
             if [[ ${key#*:} == "${distro_version_number}" || ${key#*:} == "${distro_version_name}" ]]; then
+                is_compat=true
                 return 0
             fi
         # check for `ubuntu:*`
         elif [[ $key == *":*" ]]; then
             # check for `ubuntu`
             if [[ ${key%%:*} == "${distro_name}" ]]; then
+                is_compat=true
                 return 0
             fi
         elif [[ $key == "${distro_name}:${distro_version_name}" || $key == "${distro_name}:${distro_version_number}" ]]; then
             # check for `ubuntu:jammy` or `ubuntu:22.04`
+            is_compat=true
             return 0
-        else
-            fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}"
-            return 1
         fi
     done
+    if [[ "${is_compat}" == "false" || "${is_compat}" != "true" ]]; then
+        fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}"
+        return 1
+    fi
 }
 
 function get_incompatible_releases() {


### PR DESCRIPTION
## Purpose

Before (true positive):
```bash
+ compatible=("ubuntu:devel")
+ get_compatible_releases ubuntu:devel
++ lsb_release -si
+ local distro_name=Ubuntu
+ distro_name=ubuntu
++ lsb_release -ds
++ tail -c 4
+ [[ xi) == \s\i\d ]]
++ lsb_release -sc
+ local distro_version_name=devel
++ lsb_release -sr
+ local distro_version_number=2023.3
+ input=('ubuntu:devel')
+ local input
+ for key in "${input[@]}"
+ [[ ubuntu:devel == \*\:* ]]
+ [[ ubuntu:devel == *\:\* ]]
+ [[ ubuntu:devel == \u\b\u\n\t\u\:\d\e\v\e\l ]]
+ return 0
```

Before (false negative):
```bash
+ compatible=("ubuntu:mantic" "ubuntu:devel")
+ get_compatible_releases ubuntu:mantic ubuntu:devel
++ lsb_release -si
+ local distro_name=Ubuntu
+ distro_name=ubuntu
++ lsb_release -ds
++ tail -c 4
+ [[ xi) == \s\i\d ]]
++ lsb_release -sc
+ local distro_version_name=devel
++ lsb_release -sr
+ local distro_version_number=2023.3
+ input=('ubuntu:mantic' 'ubuntu:devel')
+ local input
+ for key in "${input[@]}"
+ [[ ubuntu:mantic == \*\:* ]]
+ [[ ubuntu:mantic == *\:\* ]]
+ [[ ubuntu:mantic == \u\b\u\n\t\u\:\d\e\v\e\l ]]
+ [[ ubuntu:mantic == \u\b\u\n\t\u\:\2\0\2\3\.\3 ]]
+ echo 'This Pacscript does not work on ubuntu:devel/ubuntu:2023.3'
This Pacscript does not work on ubuntu:devel/ubuntu:2023.3
+ return 1
```

Before (true negative):
```bash
+ compatible=("ubuntu:mantic" "ubuntu:jammy")
+ get_compatible_releases ubuntu:mantic ubuntu:jammy
++ lsb_release -si
+ local distro_name=Ubuntu
+ distro_name=ubuntu
++ lsb_release -ds
++ tail -c 4
+ [[ xi) == \s\i\d ]]
++ lsb_release -sc
+ local distro_version_name=devel
++ lsb_release -sr
+ local distro_version_number=2023.3
+ input=('ubuntu:mantic' 'ubuntu:jammy')
+ local input
+ for key in "${input[@]}"
+ [[ ubuntu:mantic == \*\:* ]]
+ [[ ubuntu:mantic == *\:\* ]]
+ [[ ubuntu:mantic == \u\b\u\n\t\u\:\d\e\v\e\l ]]
+ [[ ubuntu:mantic == \u\b\u\n\t\u\:\2\0\2\3\.\3 ]]
+ echo 'This Pacscript does not work on ubuntu:devel/ubuntu:2023.3'
This Pacscript does not work on ubuntu:devel/ubuntu:2023.3
+ return 1
```

## Approach
Just move the `else` termination outside of the `for` loop so it can run fully.

## Progress

After (true positive):
```bash
+ compatible=("ubuntu:devel")
+ get_compatible_releases ubuntu:devel
++ lsb_release -si
+ local distro_name=Ubuntu
+ distro_name=ubuntu
++ lsb_release -ds
++ tail -c 4
+ [[ xi) == \s\i\d ]]
++ lsb_release -sc
+ local distro_version_name=devel
++ lsb_release -sr
+ local distro_version_number=2023.3
+ input=('ubuntu:devel')
+ local input
+ local is_compat=false
+ for key in "${input[@]}"
+ [[ ubuntu:devel == \*\:* ]]
+ [[ ubuntu:devel == *\:\* ]]
+ [[ ubuntu:devel == \u\b\u\n\t\u\:\d\e\v\e\l ]]
+ is_compat=true
+ return 0
```

After (true positive):
```bash
+ compatible=("ubuntu:mantic" "ubuntu:devel")
+ get_compatible_releases ubuntu:mantic ubuntu:devel
++ lsb_release -si
+ local distro_name=Ubuntu
+ distro_name=ubuntu
++ lsb_release -ds
++ tail -c 4
+ [[ xi) == \s\i\d ]]
++ lsb_release -sc
+ local distro_version_name=devel
++ lsb_release -sr
+ local distro_version_number=2023.3
+ input=('ubuntu:mantic' 'ubuntu:devel')
+ local input
+ local is_compat=false
+ for key in "${input[@]}"
+ [[ ubuntu:mantic == \*\:* ]]
+ [[ ubuntu:mantic == *\:\* ]]
+ [[ ubuntu:mantic == \u\b\u\n\t\u\:\d\e\v\e\l ]]
+ [[ ubuntu:mantic == \u\b\u\n\t\u\:\2\0\2\3\.\3 ]]
+ for key in "${input[@]}"
+ [[ ubuntu:devel == \*\:* ]]
+ [[ ubuntu:devel == *\:\* ]]
+ [[ ubuntu:devel == \u\b\u\n\t\u\:\d\e\v\e\l ]]
+ is_compat=true
+ return 0
```

After (true negative):
```bash
+ compatible=("ubuntu:mantic" "ubuntu:jammy")
+ get_compatible_releases ubuntu:mantic ubuntu:jammy
++ lsb_release -si
+ local distro_name=Ubuntu
+ distro_name=ubuntu
++ lsb_release -ds
++ tail -c 4
+ [[ xi) == \s\i\d ]]
++ lsb_release -sc
+ local distro_version_name=devel
++ lsb_release -sr
+ local distro_version_number=2023.3
+ input=('ubuntu:mantic' 'ubuntu:jammy')
+ local input
+ local is_compat=false
+ for key in "${input[@]}"
+ [[ ubuntu:mantic == \*\:* ]]
+ [[ ubuntu:mantic == *\:\* ]]
+ [[ ubuntu:mantic == \u\b\u\n\t\u\:\d\e\v\e\l ]]
+ [[ ubuntu:mantic == \u\b\u\n\t\u\:\2\0\2\3\.\3 ]]
+ for key in "${input[@]}"
+ [[ ubuntu:jammy == \*\:* ]]
+ [[ ubuntu:jammy == *\:\* ]]
+ [[ ubuntu:jammy == \u\b\u\n\t\u\:\d\e\v\e\l ]]
+ [[ ubuntu:jammy == \u\b\u\n\t\u\:\2\0\2\3\.\3 ]]
+ [[ false == \f\a\l\s\e ]]
+ echo 'This Pacscript does not work on ubuntu:devel/ubuntu:2023.3'
This Pacscript does not work on ubuntu:devel/ubuntu:2023.3
+ return 1
```

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
