### PR TITLE
perf(search): remove mapfile subshells

### DIFF
--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -33,14 +33,14 @@ function getPath() {
     local var="${2}"
     path="${path/"file://"/}"
     path="${path/"~"/"$HOME"}"
-    path="$(readlink -f "${path}")"
+    path="$(realpath "${path}")"
     path="${path/"$HOME"/"~"}"
     printf -v "${var}" "%s" "${path}"
 }
 
 function specifyRepo() {
     local SPLIT
-    mapfile -t SPLIT < <(echo "${1//[\/]/$'\n'}")
+    mapfile -t SPLIT <<< "${1//[\/]/$'\n'}"
 
     if [[ $1 == "file://"* ]] || [[ $1 == "/"* ]] || [[ $1 == "~"* ]] || [[ $1 == "."* ]]; then
         export URLNAME
@@ -64,9 +64,9 @@ function specifyRepo() {
 function parseRepo() {
     local REPO="${1}"
     local SPLIT REPODIR
-    mapfile -t SPLIT < <(echo "${REPO//[\/]/$'\n'}")
+    mapfile -t SPLIT <<< "${REPO//[\/]/$'\n'}"
 
-    if [[ $REPO == *"file://"* ]]; then
+    if [[ $REPO == "file://"* ]]; then
         getPath "${REPO}" REPODIR
         echo "\e]8;;$REPO\a$REPODIR\e]8;;\a"
     elif [[ $REPO == *"github"* ]]; then


### PR DESCRIPTION
## Purpose

We don't have a need for the subshells.

## Approach

Replace them with `<<<` variable redirection.
Also, I replaced `readlink -f` with `realpath` which seems to be faster based on my testing.
I also removed a leading glob where there shouldn't be one.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
