### PR TITLE
fix(upgrade): Missing export for pacdep metadata logging

### DIFF
--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -165,7 +165,7 @@ ${BOLD}$(cat "${up_print}")${NC}\n"
         if ((answer == 0)); then
             continue
         fi
-        REPO="${remotes[${PACKAGE}]}"
+        export REPO="${remotes[${PACKAGE}]}"
         export URL="$REPO/packages/$PACKAGE/$PACKAGE.pacscript"
         # shellcheck source=./misc/scripts/download.sh
         if ! source "$STGDIR/scripts/download.sh"; then


### PR DESCRIPTION
## Purpose

Fixes the issue where the metadata logging for pacdeps doesn't log `_remoterepo` properly on upgrades.

## Approach

Add the missing `$REPO` export on `upgrade.sh`;

## Addendum

There should have been opened as an issue, but it seems Elsie didn't do it smh my head

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
