### PR TITLE
fix(install-local): ensure dirs made by sudo are readable

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -716,6 +716,7 @@ homedir="$(eval echo ~"$PACSTALL_USER")"
 export homedir
 
 sudo cp "${PACKAGE}.pacscript" /tmp
+sudo chmod a+r "/tmp/${PACKAGE}.pacscript"
 pacfile="$(readlink -f "/tmp/${PACKAGE}.pacscript")"
 export pacfile
 mapfile -t FARCH < <(dpkg --print-foreign-architectures)
@@ -776,6 +777,7 @@ fi
 
 clean_builddir
 sudo mkdir -p "$STOWDIR/$name/DEBIAN"
+sudo chmod a+rx "$STOWDIR" "$STOWDIR/$name" "$STOWDIR/$name/DEBIAN"
 
 # Run checks function
 if ! checks; then


### PR DESCRIPTION



## Purpose

I run my system with a 0007 umask, which means some of the files and directories created by pacstall with sudo aren't then readable by it when it returns back to running as a normal user.

<!--Describe the problem you are fixing or the feature you are adding.-->

## Approach

<!--How does this address the problem?-->
Simply chmod the files / directories after they are created. There doesn't seem a way to change the umask of sudo-invoked processes easily, looks like that would require modifying sudoers - that might be worth considering in future if it turns out there are many other places that need fixing up.

## Progress

<!--Make a checklist of your progress-->

This patch fixes the two locations I've found so far, but I suspect there are others. It's good enough to allow me to install the package I wanted :)

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
