### PR TITLE
fix(error_log,install-local): ensure `$LOGDIR` exists before writing to it

### DIFF
--- a/misc/scripts/error_log.sh
+++ b/misc/scripts/error_log.sh
@@ -49,6 +49,10 @@ function error_log() {
     local scope="${2}"
     local time
 
+    if [[ ! -d ${LOGDIR} ]]; then
+        sudo mkdir -p "${LOGDIR}"
+    fi
+
     if [[ ! -f $LOGFILE ]]; then
         sudo touch "$LOGFILE"
         sudo find "${LOGDIR:-/var/log/pacstall/error_log/}" -type f -ctime +14 -delete

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -1095,6 +1095,9 @@ function fail_out_functions() {
 function run_function() {
     local func="$1"
     fancy_message sub "Running $func"
+    if [[ ! -d ${LOGDIR} ]]; then
+        sudo mkdir -p "${LOGDIR}"
+    fi
     # NOTE: https://stackoverflow.com/a/29163890 (shorthand for 2>&1 |)
     $func |& sudo tee "${LOGDIR}/$(printf '%(%Y-%m-%d_%T)T')-$name-$func.log" && return "${PIPESTATUS[0]}"
 }


### PR DESCRIPTION
## Purpose

Stupid bug comes up because LOGDIR isn't properly checked to be created
```bash
[~] rhino-live@rhino-live $ pacstall -PI pacstall-qa-git
[*] WARNING: Prompts are disabled
(pacstall-qa-git) Do you want to view/edit the pacscript? [y/N] N
[+] INFO: Sourcing pacscript
[+] INFO: Installing nushell-bin
[*] WARNING: Prompts are disabled
(nushell-bin) Do you want to view/edit the pacscript? [y/N] N
[+] INFO: Sourcing pacscript
[+] INFO: Retrieving packages
Initializing download: https://github.com/nushell/nushell/releases/download/0.86.0/nu-0.86.0-aarch64-unknown-linux-gnu.tar.gz
File size: 26.9117 Megabyte(s) (28218916 bytes)
Opening output file nu-0.86.0-aarch64-unknown-linux-gnu.tar.gz
Starting download

Connection 1 finished
Connection 2 finished
Connection 3 finished
Connection 0 finished
[100%] [..................................................] [  17.9MB/s] [00:00]

Downloaded 26.9117 Megabyte(s) in 1 second(s). (18327.98 KB/s)
[+] INFO: Extracting nu-0.86.0-aarch64-unknown-linux-gnu.tar.gz
[+] INFO: Running functions
    [>] Running package
tee: '/var/log/pacstall/error_log/2023-11-17_00:40:02-nushell-bin-package.log': No such file or directory
install: creating directory '/usr/src/pacstall/nushell-bin/usr'
install: creating directory '/usr/src/pacstall/nushell-bin/usr/bin'
'./nu' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu'
'./nu_plugin_inc' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_inc'
'./nu_plugin_example' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_example'
'./nu_plugin_formats' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_formats'
'./nu_plugin_custom_values' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_custom_values'
'./nu_plugin_gstat' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_gstat'
'./nu_plugin_query' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_query'
install: creating directory '/usr/src/pacstall/nushell-bin/usr/share'
install: creating directory '/usr/src/pacstall/nushell-bin/usr/share/doc'
install: creating directory '/usr/src/pacstall/nushell-bin/usr/share/doc/nushell'
'README.txt' -> '/usr/src/pacstall/nushell-bin/usr/share/doc/nushell/README.txt'
install: creating directory '/usr/src/pacstall/nushell-bin/usr/share/licenses'
install: creating directory '/usr/src/pacstall/nushell-bin/usr/share/licenses/nushell'
'LICENSE' -> '/usr/src/pacstall/nushell-bin/usr/share/licenses/nushell/LICENSE'
touch: cannot touch '/var/log/pacstall/error_log/2023-11-17_00:39:59.log': No such file or directory
find: '/var/log/pacstall/error_log': No such file or directory
tee: '/var/log/pacstall/error_log/2023-11-17_00:39:59.log': No such file or directory
    [!] ERROR: Could not package nushell-bin properly
dpkg: warning: ignoring request to remove nushell-bin which isn't installed
[+] INFO: Cleaning up
[!] ERROR: Failed to install dependency
touch: cannot touch '/var/log/pacstall/error_log/2023-11-17_00:39:57.log': No such file or directory
find: '/var/log/pacstall/error_log': No such file or directory
tee: '/var/log/pacstall/error_log/2023-11-17_00:39:57.log': No such file or directory
[!] ERROR: Failed to install pacstall-qa-git
```
## Approach

Ensure the directory is created before the file is.

## Progress

- [x] Test it works

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
