### PR TITLE
fix(install-local.sh): use `curl -sO` instead of `wget -q` for downloading patches

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -970,7 +970,10 @@ if [[ -n $patch ]]; then
     for i in "${patch[@]}"; do
         curl -sO "$i"
     done
-    popd > /dev/null || return 1
+    popd > /dev/null || {
+        fancy_message error "Could not enter into patches directory"
+        return 1
+    }
     export PACPATCH="$PWD/PACSTALL_patchesdir"
 fi
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -961,13 +961,13 @@ mkdir -p "${SRCDIR}"
 if [[ -n $patch ]]; then
     fancy_message info "Downloading patches"
     mkdir -p PACSTALL_patchesdir
-	# NOTE: not using --output-dir,
-	# since Buster/Focal include a version of curl w/o that option.
-	pushd PACSTALL_patchesdir > /dev/null || return 1
+    # NOTE: not using --output-dir,
+    # since Buster/Focal include a version of curl w/o that option.
+    pushd PACSTALL_patchesdir > /dev/null || return 1
     for i in "${patch[@]}"; do
         curl -sO "$i"
     done
-	popd > /dev/null || return 1
+    popd > /dev/null || return 1
     export PACPATCH="$PWD/PACSTALL_patchesdir"
 fi
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -963,7 +963,10 @@ if [[ -n $patch ]]; then
     mkdir -p PACSTALL_patchesdir
     # NOTE: not using --output-dir,
     # since Buster/Focal include a version of curl w/o that option.
-    pushd PACSTALL_patchesdir > /dev/null || return 1
+    pushd PACSTALL_patchesdir > /dev/null || {
+        fancy_message error "Could not enter into patches directory"
+        return 1
+    }
     for i in "${patch[@]}"; do
         curl -sO "$i"
     done

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -963,11 +963,11 @@ if [[ -n $patch ]]; then
     mkdir -p PACSTALL_patchesdir
 	# NOTE: not using --output-dir,
 	# since Buster/Focal include a version of curl w/o that option.
-	cd PACSTALL_patchesdir
+	pushd PACSTALL_patchesdir > /dev/null || return 1
     for i in "${patch[@]}"; do
         curl -sO "$i"
     done
-	cd ..
+	popd > /dev/null || return 1
     export PACPATCH="$PWD/PACSTALL_patchesdir"
 fi
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -961,9 +961,13 @@ mkdir -p "${SRCDIR}"
 if [[ -n $patch ]]; then
     fancy_message info "Downloading patches"
     mkdir -p PACSTALL_patchesdir
+	# NOTE: not using --output-dir,
+	# since Buster/Focal include a version of curl w/o that option.
+	cd PACSTALL_patchesdir
     for i in "${patch[@]}"; do
-        curl -sO "$i" --output-dir PACSTALL_patchesdir
+        curl -sO "$i"
     done
+	cd ..
     export PACPATCH="$PWD/PACSTALL_patchesdir"
 fi
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -962,7 +962,7 @@ if [[ -n $patch ]]; then
     fancy_message info "Downloading patches"
     mkdir -p PACSTALL_patchesdir
     for i in "${patch[@]}"; do
-        wget -q "$i" -P PACSTALL_patchesdir
+        curl -sO "$i" --output-dir PACSTALL_patchesdir
     done
     export PACPATCH="$PWD/PACSTALL_patchesdir"
 fi


### PR DESCRIPTION
## Purpose

<!--Describe the problem you are fixing or the feature you are adding.-->

When downloading patches, `wget -q` includes URL parameters in the resulting filename. This causes e.g. patches from the AUR to have `?h=${pkgname}` appended to their filenames, which is ugly.

## Approach

<!--How does this address the problem?-->

The `-O` flag for `curl` tells it to use the remote file name, so it ignores URL parameters, solving the problem. Otherwise the functionality is identical.

## Addendum

One potential issue is that the `--output-dir` flag was introduced in `curl` 7.73.0, and the Debian 10 non-backports repo (and by extension, Ubuntu 20.04) uses an older version. An easy solution is to `cd` into PACSTALL_patchesdir, download the patches and `cd` back. But I'd like to discuss which approach is best.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
