### PR TITLE
fix(download): download literal name

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -321,11 +321,11 @@ function download() {
             curl -L -# -o "${1##*/}" "$1" || return 1
             ;;
         quiet-wget)
-            wget -q -- "$1" 2>&1 || return 1
+            wget -q -O "${1##*/}" -- "$1" 2>&1 || return 1
             ;;
         payload) ;;
         wget | *)
-            wget -q --show-progress --progress=bar:force -- "$1" 2>&1 || return 1
+            wget -q --show-progress --progress=bar:force -O "${1##*/}" -- "$1" 2>&1 || return 1
             ;;
     esac
 }


### PR DESCRIPTION
## Purpose

If a URL has `%20` (encoded space) in it, and the download runs with `wget`, it will download but then pacstall assumes that the downloaded file still has the encoded space, messing everything up.

## Addendum

Thanks @Mythbusters123 for bringing this to my attention!

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
