### PR TITLE
fix(install-local.sh): do more repair to `FARCH` array

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -252,7 +252,7 @@ function get_incompatible_releases() {
 }
 
 function is_compatible_arch() {
-    local input=("${@}") ret=1
+    local input=("${@}") ret=1 pacarch farch
     if [[ " ${input[*]} " =~ " any " ]]; then
         ret=0
     elif [[ " ${input[*]} " =~ " ${CARCH} " ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -252,23 +252,25 @@ function get_incompatible_releases() {
 }
 
 function is_compatible_arch() {
-    local input=("${@}")
+    local input=("${@}") ret=1
     if [[ " ${input[*]} " =~ " any " ]]; then
-        return 0
-    elif ! [[ " ${input[*]} " =~ " ${CARCH} " ]]; then
-        if [[ -n ${FARCH[*]} ]]; then
-            if [[ " ${FARCH[*]} " =~ " ${input[*]} " ]]; then
-                fancy_message warn "This package is for ${BBlue}${input[*]}${NC}, which is a foreign architecture"
-                return 0
-            else
-                fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
-                return 1
-            fi
-        else
-            fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
-            return 1
-        fi
+        ret=0
+    elif [[ " ${input[*]} " =~ " ${CARCH} " ]]; then
+        ret=0
+    elif [[ -n ${FARCH[*]} ]]; then
+        for pacarch in "${input[@]}"; do
+            for farch in "${FARCH[@]}"; do
+                if [[ "${pacarch}" == "${farch}" ]]; then
+                    fancy_message warn "This package is for ${BBlue}${farch}${NC}, which is a foreign architecture"
+                    ret=0
+                fi
+            done
+        done
     fi
+    if ((ret==1)); then
+        fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
+    fi
+    return "${ret}"
 }
 
 function deblog() {

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -263,8 +263,12 @@ function is_compatible_arch() {
                 if [[ "${pacarch}" == "${farch}" ]]; then
                     fancy_message warn "This package is for ${BBlue}${farch}${NC}, which is a foreign architecture"
                     ret=0
+                    break
                 fi
             done
+            if ((ret==0)); then
+                break
+            fi
         done
     fi
     if ((ret==1)); then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -271,7 +271,7 @@ function is_compatible_arch() {
             fi
         done
     fi
-    if ((ret==1)); then
+    if ((ret == 1)); then
         fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
     fi
     return "${ret}"


### PR DESCRIPTION
## Purpose
`FARCH` only worked if the given pacscript's `arch` array was singular (i.e. if more than one foreign architecture was listed, then it did not work)

## Approach
Fix the check to loop properly

## Progress

- [x] Did it
- [x] Tested

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
