### PR TITLE
chan(install.sh): remove `-qq` from most `apt` invocations

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -101,7 +101,10 @@ fi
 echo
 if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -7)" ]]; then
     fancy_message info "Updating"
-    apt-get update
+    case "${GITHUB_ACTIONS}" in
+        true) apt-get update -qq ;;
+        *) apt-get update ;;
+    esac
 fi
 
 fancy_message info "Installing packages"
@@ -110,10 +113,19 @@ echo -ne "Do you want to install axel (faster downloads)? [${BGreen}Y${NC}/${RED
 read -r reply <&0
 case "$reply" in
     N* | n*) ;;
-    *) apt-get install -y axel ;;
+    *)
+        case "${GITHUB_ACTIONS}" in
+            true) apt-get install axel -y -qq ;;
+            *) apt-get install axel -y ;;
+        esac
+        ;;
 esac
 
-apt-get install -y curl wget build-essential unzip git zstd iputils-ping lsb-release
+if [[ ${GITHUB_ACTIONS} == "true" ]]; then
+    apt-get install -qq -y curl wget build-essential unzip git zstd iputils-ping lsb-release
+else
+    apt-get install -y curl wget build-essential unzip git zstd iputils-ping lsb-release
+fi
 
 LOGDIR="/var/lib/pacstall/metadata"
 STGDIR="/usr/share/pacstall"

--- a/install.sh
+++ b/install.sh
@@ -101,7 +101,7 @@ fi
 echo
 if [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -7)" ]]; then
     fancy_message info "Updating"
-    apt-get -qq update
+    apt-get update
 fi
 
 fancy_message info "Installing packages"
@@ -110,10 +110,10 @@ echo -ne "Do you want to install axel (faster downloads)? [${BGreen}Y${NC}/${RED
 read -r reply <&0
 case "$reply" in
     N* | n*) ;;
-    *) apt-get install -qq -y axel ;;
+    *) apt-get install -y axel ;;
 esac
 
-apt-get install -qq -y curl wget build-essential unzip git zstd iputils-ping lsb-release
+apt-get install -y curl wget build-essential unzip git zstd iputils-ping lsb-release
 
 LOGDIR="/var/lib/pacstall/metadata"
 STGDIR="/usr/share/pacstall"


### PR DESCRIPTION
Downloading a potentially large amount of data quietly makes the install look like it hangs. There's no good reason to hide this information from the user. The warning about the CLI interface may be annoying, but it's much less of a UX issue than downloading hundreds of megabytes without any clear indication of doing so.

The very first invocation is more debatable to me, since it's more of a check than anything else. However, I also question the need to install both `curl` and `wget` during the installation - one of them is entirely sufficient.