### PR TITLE
feat(CI): turn docker images into locally produced matrix

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -51,7 +51,7 @@ jobs:
           chmod +x pacstall-docker-builder
           ./pacstall-docker-builder -f -a ${arch} -d ${distro} -v ${vertag}
           echo "BUILT_DOCKFILE=Dockerfile-Pacstall-${vertag}-${arch}-${distro_tag}-$(date +%Y%m%d)"  >> $GITHUB_ENV
-          echo "DOCK_LABEL=${vertag}"  >> $GITHUB_ENV
+          echo "DOCK_LABEL=${vertag}" >> $GITHUB_ENV
           echo "PLATFORM_PAIR=${distro_tag}-${arch}" >> $GITHUB_ENV
           echo "REGISTRY_IMAGE=${{ env.REGISTRY }}/${{ github.repository_owner }}/${distro_tag}" >> $GITHUB_ENV
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         OS: ["ubuntu:latest", "ubuntu:devel", "ubuntu:rolling", "debian:stable", "debian:testing", "debian:unstable"]
         platform: ["linux/amd64", "linux/arm64"]
-      fail-fast: false
+      fail-fast: true
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -99,7 +99,7 @@ jobs:
     strategy:
       matrix:
         OS: ["ubuntu:latest", "ubuntu:devel", "ubuntu:rolling", "debian:stable", "debian:testing", "debian:unstable"]
-      fail-fast: false
+      fail-fast: true
     runs-on: ubuntu-latest
     needs: [build]
     steps:

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,166 @@
+name: Publish Pacstall Docker Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      vertag:
+        description: 'Version Tag'
+        required: false
+  push:
+    branches:
+      - develop
+      - master
+    tags:
+      - '*'
+env:
+  INPUT_VERTAG: ${{ github.event.inputs.vertag }}
+  REGISTRY: ghcr.io
+
+jobs:
+
+  build:
+    strategy:
+      matrix:
+        OS: ["ubuntu:latest", "ubuntu:devel", "ubuntu:rolling", "debian:stable", "debian:testing", "debian:unstable"]
+        platform: ["linux/amd64", "linux/arm64"]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Build Dockerfile
+        run: |
+          vertag=${{ env.INPUT_VERTAG }}
+          if [[ -z ${vertag} ]]; then
+            vertag=${{ github.ref_name }}
+          fi
+          platform=${{ matrix.platform }}
+          arch=${platform#*/}
+          distro=${{ matrix.OS }}
+          distro_tag="${distro/:/-}"
+          curl -fsSL https://raw.githubusercontent.com/pacstall/docker/master/pacstall-docker-builder -o pacstall-docker-builder
+          chmod +x pacstall-docker-builder
+          ./pacstall-docker-builder -f -a ${arch} -d ${distro} -v ${vertag}
+          echo "BUILT_DOCKFILE=Dockerfile-Pacstall-${vertag}-${arch}-${distro_tag}-$(date +%Y%m%d)"  >> $GITHUB_ENV
+          echo "DOCK_LABEL=${vertag}"  >> $GITHUB_ENV
+          echo "PLATFORM_PAIR=${distro_tag}-${arch}" >> $GITHUB_ENV
+          echo "REGISTRY_IMAGE=${{ env.REGISTRY }}/${{ github.repository_owner }}/${distro_tag}" >> $GITHUB_ENV
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=raw,value=${{ env.DOCK_LABEL }}
+          flavor: latest=true
+
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./${{ env.BUILT_DOCKFILE }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    strategy:
+      matrix:
+        OS: ["ubuntu:latest", "ubuntu:devel", "ubuntu:rolling", "debian:stable", "debian:testing", "debian:unstable"]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Load envars
+        run: |
+          vertag=${{ env.INPUT_VERTAG }}
+          if [[ -z ${vertag} ]]; then
+            vertag=${{ github.ref_name }}
+          fi
+          distro=${{ matrix.OS }}
+          distro_tag="${distro/:/-}"
+          echo "DOCK_LABEL=${vertag}" >> $GITHUB_ENV
+          if [[ ${vertag} == "develop" ]]; then
+            echo "FLAVOR_LATEST=false" >> $GITHUB_ENV
+            echo "HASH_DOCK_LABEL=${vertag}-${GITHUB_SHA:0:8}" >> $GITHUB_ENV
+          elif [[ ${vertag} == "master" ]]; then
+            echo "FLAVOR_LATEST=true" >> $GITHUB_ENV
+            echo "HASH_DOCK_LABEL=${vertag}-${GITHUB_SHA:0:8}" >> $GITHUB_ENV
+          else
+            echo "FLAVOR_LATEST=true" >> $GITHUB_ENV
+          fi
+          echo "DISTRO_TAG=${distro_tag}" >> $GITHUB_ENV
+          echo "REGISTRY_IMAGE=${{ env.REGISTRY }}/${{ github.repository_owner }}/${distro_tag}" >> $GITHUB_ENV
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ env.DISTRO_TAG }}*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: v0.12.0
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=raw,value=${{ env.DOCK_LABEL }}
+            type=raw,value=${{ env.HASH_DOCK_LABEL }}
+          flavor: latest=${{ env.FLAVOR_LATEST }}
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            --annotation "index:org.opencontainers.image.description=Contains amd64/x86_64 + arm64/aarch64 pacstall:${{ env.DOCK_LABEL }} images for ${{ matrix.OS }}, from $(date +%Y%m%d)." \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        
+
       - name: Build Dockerfile
         run: |
           vertag=${{ env.INPUT_VERTAG }}
@@ -159,7 +159,7 @@ jobs:
           docker buildx imagetools create \
             --annotation "index:org.opencontainers.image.description=Contains amd64/x86_64 + arm64/aarch64 pacstall:${{ env.DOCK_LABEL }} images for ${{ matrix.OS }}, from $(date +%Y%m%d)." \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |


### PR DESCRIPTION
## Purpose

need both multi-arch (amd64+arm64) and multi-distro (ubuntu+debian) images. 

## Approach

Example workflow:
<img width="603" alt="Screenshot 2024-02-22 at 1 39 04 PM" src="https://github.com/pacstall/pacstall/assets/104327997/f58deb1c-c199-4737-a808-233f05f69024">

https://github.com/oklopfer/pacstall/actions/runs/8008403762


<img width="653" alt="Screenshot 2024-02-22 at 1 46 32 PM" src="https://github.com/pacstall/pacstall/assets/104327997/a1b01df2-6ca1-4fb2-88a0-ca2792d6128e">

(yes they are the same commit, but on different branches; shows that develop does not mark latest)

<img width="646" alt="Screenshot 2024-02-22 at 1 57 15 PM" src="https://github.com/pacstall/pacstall/assets/104327997/2e1a0a0c-ecbb-4fac-ad10-babf5e155354">

(with version tag)

naming scheme:
`ghcr.io/pacstall/{ubuntu,debian}-{distro_release}:{ref}`

refs are:
- `master`, `master-{hash_shortform}`
- `develop`, `master-{hash_shortform}`
- `version_tag` (like `4.3.2`)
- `latest` (either `master` or `version_tag`, never `develop`)

architecture is automatic to host device

## Progress

- [x] fork my https://github.com/rhino-linux/docker program into https://github.com/pacstall/docker for storage of the dockerfile construction script (packages currently built over there, but to trigger builds on push, we move workflow here)
- [x] create a super dynamic workflow file that can run independent of the docker repository, as it can just curl in the above mentioned script
- [x] have it publish automatically on pushes to master + develop, and on tag creation
- [x] have backup: 
 <img width="355" alt="Screenshot 2024-02-22 at 1 33 04 PM" src="https://github.com/pacstall/pacstall/assets/104327997/61078050-4895-450e-a24f-a19080e6ae88">
 
- [x] can select branch to re-publish for master + develop, and can type in the box for version tags
- [x] yes, it does actually hard switch to the pacstall version
- [x] figure out how to name master + develop docker tags `${branch}-${git_hash}` instead of `${branch}-${YYYYMMDD}`

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
