### PR TITLE
chan(*)!: `SRCDIR` -> `PACDIR`, `pkgbase` -> `srcdir`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -117,7 +117,7 @@ apt-get install -qq -y curl wget build-essential unzip git zstd iputils-ping lsb
 
 LOGDIR="/var/lib/pacstall/metadata"
 STGDIR="/usr/share/pacstall"
-SRCDIR="/tmp/pacstall"
+PACDIR="/tmp/pacstall"
 PACSTALL_USER=$(logname 2> /dev/null || echo "${SUDO_USER:-${USER}}")
 
 fancy_message info "Making directories"
@@ -125,8 +125,8 @@ mkdir -p "$STGDIR"
 mkdir -p "$STGDIR/scripts"
 mkdir -p "$STGDIR/repo"
 
-mkdir -p "$SRCDIR"
-chown "$PACSTALL_USER" -R "$SRCDIR"
+mkdir -p "$PACDIR"
+chown "$PACSTALL_USER" -R "$PACDIR"
 
 mkdir -p "$LOGDIR"
 mkdir -p "/var/log/pacstall/error_log"

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -29,21 +29,21 @@ function cleanup() {
         if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
             sudo mv /tmp/pacstall-pacdep/* "/tmp/pacstall-keep/$name"
         else
-            sudo mv "${SRCDIR:?}"/* "/tmp/pacstall-keep/$name"
+            sudo mv "${PACDIR:?}"/* "/tmp/pacstall-keep/$name"
         fi
     fi
     if [[ -f "/tmp/pacstall-pacdeps-$PACKAGE" ]]; then
         sudo rm -rf "/tmp/pacstall-pacdeps-$PACKAGE"
         sudo rm -rf /tmp/pacstall-pacdep
     else
-        sudo rm -rf "${SRCDIR:?}"/*
+        sudo rm -rf "${PACDIR:?}"/*
         # just in case we quit before $name is declared, we should be able to remove a fake directory so it doesn't exit out the script
         sudo rm -rf "${STOWDIR:-/usr/src/pacstall}/${name:-raaaaaaaandom}"
         rm -rf /tmp/pacstall-gives
     fi
     sudo rm -rf "${STOWDIR}/${name:-$PACKAGE}.deb"
     rm -f /tmp/pacstall-select-options
-    unset name repology pkgver git_pkgver epoch url source depends makedepends breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible optinstall pkgbase homepage backup pkgrel mask pac_functions repo priority noextract 2> /dev/null
+    unset name repology pkgver git_pkgver epoch url source depends makedepends breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible optinstall srcdir homepage backup pkgrel mask pac_functions repo priority noextract 2> /dev/null
     unset -f post_install post_remove pre_install prepare build package 2> /dev/null
     sudo rm -f "${pacfile}"
 }
@@ -433,7 +433,7 @@ function makedeb() {
             sudo apt-mark auto "${gives:-$name}" 2> /dev/null
         fi
         sudo rm -rf "$STOWDIR/$name"
-        sudo rm -rf "$SRCDIR/$name.deb"
+        sudo rm -rf "$PACDIR/$name.deb"
 
         if ! [[ -d /etc/apt/preferences.d/ ]]; then
             sudo mkdir -p /etc/apt/preferences.d

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -178,23 +178,23 @@ function fail_down() {
 }
 
 function gather_down() {
-    if [[ -z ${pkgbase} ]]; then
+    if [[ -z ${srcdir} ]]; then
         if [[ -n $PACSTALL_PAYLOAD ]]; then
-            export pkgbase="/tmp/pacstall-pacdep"
+            export srcdir="/tmp/pacstall-pacdep"
         else
-            export pkgbase="${SRCDIR}/${PACKAGE}~${pkgver}"
+            export srcdir="${PACDIR}/${PACKAGE}~${pkgver}"
         fi
     fi
-    mkdir -p "${pkgbase}"
-    if ! [[ ${PWD} == "${pkgbase}" ]]; then
-        find "${PWD}" -mindepth 1 -maxdepth 1 ! -wholename "${pkgbase}" \
-            ! -wholename "${SRCDIR}" \
+    mkdir -p "${srcdir}"
+    if ! [[ ${PWD} == "${srcdir}" ]]; then
+        find "${PWD}" -mindepth 1 -maxdepth 1 ! -wholename "${srcdir}" \
+            ! -wholename "${PACDIR}" \
             ! -wholename "/tmp/pacstall-pacdep" \
             ! -wholename "/tmp/pacstall-pacdeps-$PACKAGE" \
-            -exec mv {} "${pkgbase}/" \;
-        cd "${pkgbase}" || {
+            -exec mv {} "${srcdir}/" \;
+        cd "${srcdir}" || {
             error_log 1 "gather-main $PACKAGE"
-            fancy_message error "Could not enter into the main directory ${YELLOW}${pkgbase}${NC}"
+            fancy_message error "Could not enter into the main directory ${YELLOW}${srcdir}${NC}"
             clean_fail_down
         }
     fi
@@ -248,7 +248,7 @@ function git_down() {
         cd ..
         gather_down
     else
-        export pkgbase="${PWD}"
+        export srcdir="${PWD}"
     fi
 }
 
@@ -287,7 +287,7 @@ function genextr_down() {
             fancy_message warn "Could not enter into the extracted archive"
             gather_down
         }
-        export pkgbase="${PWD}"
+        export srcdir="${PWD}"
     else
         gather_down
     fi
@@ -347,7 +347,7 @@ function file_down() {
             fancy_message warn "Could not enter into the copied archive"
             gather_down
         }
-        export pkgbase="${PWD}"
+        export srcdir="${PWD}"
     else
         gather_down
     fi

--- a/misc/scripts/download.sh
+++ b/misc/scripts/download.sh
@@ -26,14 +26,14 @@
 
 if check_url "${URL}"; then
     if [[ $type == "install" ]]; then
-        mkdir -p "$SRCDIR" || {
-            if ! [[ -w $SRCDIR ]]; then
-                suggested_solution "Run '${UCyan}sudo chown -R $PACSTALL_USER:$PACSTALL_USER $SRCDIR'${NC}"
+        mkdir -p "$PACDIR" || {
+            if ! [[ -w $PACDIR ]]; then
+                suggested_solution "Run '${UCyan}sudo chown -R $PACSTALL_USER:$PACSTALL_USER $PACDIR'${NC}"
             fi
         }
-        if ! cd "$SRCDIR"; then
+        if ! cd "$PACDIR"; then
             error_log 1 "install $PACKAGE"
-            fancy_message error "Could not enter ${SRCDIR}"
+            fancy_message error "Could not enter ${PACDIR}"
             exit 1
         fi
     fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -292,15 +292,15 @@ if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
         exit 1
     fi
 else
-    mkdir -p "$SRCDIR"
-    if ! cd "$SRCDIR" 2> /dev/null; then
+    mkdir -p "$PACDIR"
+    if ! cd "$PACDIR" 2> /dev/null; then
         error_log 1 "install $PACKAGE"
-        fancy_message error "Could not enter ${SRCDIR}"
+        fancy_message error "Could not enter ${PACDIR}"
         exit 1
     fi
 fi
 
-mkdir -p "${SRCDIR}"
+mkdir -p "${PACDIR}"
 
 for i in "${!source[@]}"; do
     parse_source_entry "${source[$i]}"
@@ -340,7 +340,7 @@ for i in "${!source[@]}"; do
     unset expectedHash dest url git_branch git_tag git_commit ext_deps ext_method
 done
 
-export srcdir="$PWD"
+export pacdir="$PWD"
 sudo chown -R "$PACSTALL_USER":"$PACSTALL_USER" . 2> /dev/null
 
 export pkgdir="$STOWDIR/$name"

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -153,10 +153,10 @@ ${BOLD}$(cat "${up_print}")${NC}\n"
     upgrade=("${update_order[@]}")
 
     export local='no'
-    mkdir -p "$SRCDIR"
-    if ! cd "$SRCDIR" 2> /dev/null; then
+    mkdir -p "$PACDIR"
+    if ! cd "$PACDIR" 2> /dev/null; then
         error_log 1 "upgrade"
-        fancy_message error "Could not enter ${SRCDIR}"
+        fancy_message error "Could not enter ${PACDIR}"
         exit 1
     fi
     for to_upgrade in "${upgrade[@]}"; do

--- a/pacstall
+++ b/pacstall
@@ -28,7 +28,7 @@ export METADIR="/var/lib/pacstall/metadata"
 export LOGDIR="/var/log/pacstall/error_log"
 printf -v LOGFILE "${LOGDIR}/%(%F_%T)T.log"
 export LOGFILE
-export SRCDIR="/tmp/pacstall"
+export PACDIR="/tmp/pacstall"
 export STGDIR="/usr/share/pacstall"
 export STOWDIR="/usr/src/pacstall"
 
@@ -568,8 +568,8 @@ if [[ -n $PACSTALL_PAYLOAD && ! -f "/tmp/pacstall-pacdeps-$PACKAGE" ]]; then
         fancy_message error "Payload not found"
         exit 1
     fi
-    mkdir -p "${SRCDIR:?}"
-    cp "$PACSTALL_PAYLOAD" "${SRCDIR:?}"
+    mkdir -p "${PACDIR:?}"
+    cp "$PACSTALL_PAYLOAD" "${PACDIR:?}"
 fi
 
 while [[ $1 != "--" ]]; do
@@ -644,7 +644,7 @@ Helpful links:
 
             function trap_ctrlc() {
                 fancy_message warn "The installation of ${PACKAGE:-package} was interrupted, removing files"
-                rm -rf "${SRCDIR:?}"/* # :? makes bash error out in case SRCDIR is empty, saving us from yoinking /* directory by mistake
+                rm -rf "${PACDIR:?}"/* # :? makes bash error out in case PACDIR is empty, saving us from yoinking /* directory by mistake
                 exit 2
             }
             # Begin trapping
@@ -722,7 +722,7 @@ Helpful links:
                 if ! source "$STGDIR/scripts/install-local.sh"; then
                     fancy_message error "Failed to install ${GREEN}${PACKAGE}${NC}"
                     if ! [[ -f "/tmp/pacstall-pacdeps-$PACKAGE" ]]; then
-                        sudo rm -rf "${SRCDIR:?}"
+                        sudo rm -rf "${PACDIR:?}"
                     fi
                     exit 1
                 fi


### PR DESCRIPTION
## Purpose

`pkgbase` usage is actually for multiple packages with the same source script, not for singular packages with multiple source entries in the same script. (see: https://archlinux.org/pacman/PKGBUILD.5.html#_package_splitting) This needs `package_foo()`/`build_foo()`/`prepare_foo()` syntax and a few other things, so it will be further down the line.

what I created as `pkgbase` should actually have been `srcdir`, but this means replacing `SRCDIR` with a new name.

## Approach

`SRCDIR` -> `PACDIR`
`srcdir` -> `pacdir`
`pkgbase` -> `srcdir`
`pkgbase` to be reintroduced at a later point.

## Progress

- [x] Do it
- [x] Test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
