### PR TITLE
fix(upgrade.sh): export `CARCH` & `DISTRO`

### DIFF
--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -58,9 +58,10 @@ function calc_repo_ver() {
         fi
 }
 
-# shellcheck disable=SC2155
 export UPGRADE="yes"
+# shellcheck disable=SC2155
 export CARCH="$(dpkg --print-architecture)"
+# shellcheck disable=SC2155
 export DISTRO="$(set_distro)"
 
 fancy_message info "Checking for updates"

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -45,9 +45,9 @@ function ver_compare() {
 function calc_repo_ver() {
     local compare_repo="$1" compare_package="$2"
     unset comp_repo_ver
-    source <(curl -s -- "$compare_repo"/packages/"$compare_package"/"$compare_package".pacscript) && \
-        # shellcheck disable=SC2031
-        if [[ ${pkgname} == *-deb ]]; then
+    # shellcheck disable=SC2031
+    source <(curl -s -- "$compare_repo"/packages/"$compare_package"/"$compare_package".pacscript) \
+        && if [[ ${pkgname} == *-deb ]]; then
             comp_repo_ver="${epoch+$epoch:}${pkgver}"
         elif [[ ${pkgname} == *-git ]]; then
             parse_source_entry "${source[0]}"

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -43,9 +43,10 @@ function ver_compare() {
 }
 
 function calc_repo_ver() {
-    local compare_repo="$1"
+    local compare_repo="$1" compare_package="$2"
     unset comp_repo_ver
-    source <(curl -s -- "$compare_repo"/packages/"$i"/"$i".pacscript) \
+    source <(curl -s -- "$compare_repo"/packages/"$compare_package"/"$compare_package".pacscript) \
+        # shellcheck disable=SC2031
         && if [[ ${pkgname} == *-deb ]]; then
             comp_repo_ver="${epoch+$epoch:}${pkgver}"
         elif [[ ${pkgname} == *-git ]]; then
@@ -57,6 +58,7 @@ function calc_repo_ver() {
         fi
 }
 
+# shellcheck disable=SC2155
 export UPGRADE="yes"
 export CARCH="$(dpkg --print-architecture)"
 export DISTRO="$(set_distro)"
@@ -108,7 +110,8 @@ N="$(nproc)"
             IDXMATCH=$(printf "%s\n" "${REPOS[@]}" | awk "\$1 ~ /^${remoterepo//\//\\/}$/ {print NR-1}")
 
             if [[ -n $IDXMATCH ]]; then
-                calc_repo_ver "$remoterepo" && remotever="${comp_repo_ver}"
+                calc_repo_ver "$remoterepo" "$i" \
+                    && remotever="${comp_repo_ver}"
                 unset comp_repo_ver
                 remoteurl="${REPOS[$IDXMATCH]}"
             else
@@ -122,7 +125,8 @@ N="$(nproc)"
                     if ((IDX == IDXMATCH)); then
                         continue
                     else
-                        calc_repo_ver "${REPOS[$IDX]}" && ver="${comp_repo_ver}"
+                        calc_repo_ver "${REPOS[$IDX]}" "$i" \
+                            && ver="${comp_repo_ver}"
                         unset comp_repo_ver
                         if ! ver_compare "$alterver" "$ver"; then
                             alterver="$ver"

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -28,12 +28,33 @@ source "${STGDIR}/scripts/dep-tree.sh" || {
     return 1
 }
 
+# shellcheck source=./misc/scripts/download-local.sh
+source "${STGDIR}/scripts/download-local.sh" || {
+    fancy_message error "Could not find download-local.sh"
+    return 1
+}
+
 function ver_compare() {
     local first second
     first="${1#"${1/[0-9]*/}"}"
     second="${2#"${2/[0-9]*/}"}"
     # shellcheck disable=SC2046
     return $(dpkg --compare-versions "$first" lt "$second")
+}
+
+function calc_repo_ver() {
+    local compare_repo="$1"
+    unset comp_repo_ver
+    source <(curl -s -- "$compare_repo"/packages/"$i"/"$i".pacscript) \
+        && if [[ ${pkgname} == *-deb ]]; then
+            comp_repo_ver="${epoch+$epoch:}${pkgver}"
+        elif [[ ${pkgname} == *-git ]]; then
+            parse_source_entry "${source[0]}"
+            calc_git_pkgver
+            comp_repo_ver="${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}~git${comp_git_pkgver}"
+        else
+            comp_repo_ver="${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}"
+        fi
 }
 
 export UPGRADE="yes"
@@ -85,7 +106,8 @@ N="$(nproc)"
             IDXMATCH=$(printf "%s\n" "${REPOS[@]}" | awk "\$1 ~ /^${remoterepo//\//\\/}$/ {print NR-1}")
 
             if [[ -n $IDXMATCH ]]; then
-                remotever=$(source <(curl -s -- "$remoterepo/packages/$i/$i.pacscript") && if [[ ${pkgname} == *-deb ]]; then echo "${epoch+$epoch:}${pkgver}"; else type pkgver &> /dev/null && echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}~git$(pkgver)" || echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}"; fi) > /dev/null
+                calc_repo_ver "$remoterepo" && remotever="${comp_repo_ver}"
+                unset comp_repo_ver
                 remoteurl="${REPOS[$IDXMATCH]}"
             else
                 fancy_message warn "Package ${GREEN}${i}${CYAN} is not on ${CYAN}$(parseRepo "${remoterepo}")${NC} anymore"
@@ -98,7 +120,8 @@ N="$(nproc)"
                     if ((IDX == IDXMATCH)); then
                         continue
                     else
-                        ver=$(source <(curl -s -- "${REPOS[$IDX]}"/packages/"$i"/"$i".pacscript) && if [[ ${pkgname} == *-deb ]]; then echo "${epoch+$epoch:}${pkgver}"; else type pkgver &> /dev/null && echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}~git$(pkgver)" || echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}"; fi) > /dev/null
+                        calc_repo_ver "${REPOS[$IDX]}" && ver="${comp_repo_ver}"
+                        unset comp_repo_ver
                         if ! ver_compare "$alterver" "$ver"; then
                             alterver="$ver"
                             alterurl="$REPO"

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -45,9 +45,9 @@ function ver_compare() {
 function calc_repo_ver() {
     local compare_repo="$1" compare_package="$2"
     unset comp_repo_ver
-    source <(curl -s -- "$compare_repo"/packages/"$compare_package"/"$compare_package".pacscript) \
+    source <(curl -s -- "$compare_repo"/packages/"$compare_package"/"$compare_package".pacscript) && \
         # shellcheck disable=SC2031
-        && if [[ ${pkgname} == *-deb ]]; then
+        if [[ ${pkgname} == *-deb ]]; then
             comp_repo_ver="${epoch+$epoch:}${pkgver}"
         elif [[ ${pkgname} == *-git ]]; then
             parse_source_entry "${source[0]}"

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -58,6 +58,8 @@ function calc_repo_ver() {
 }
 
 export UPGRADE="yes"
+export CARCH="$(dpkg --print-architecture)"
+export DISTRO="$(set_distro)"
 
 fancy_message info "Checking for updates"
 


### PR DESCRIPTION
## Purpose

Pacstall isn't detecting updates on some packages that have variable checks, because it doesn't know about variables exported from `install-local.sh`. Then, even when it should know about them (`CARCH` and `DISTRO`), it drops them due to the series of subshells `upgrade.sh` puts the sourcing in. 

## Approach

Pull it out of one less subshell and let the variables be exported from `upgrade.sh`, too.

## Progress

- [x] Do it
- [x] Test it

## Addendum

See [1033](https://github.com/pacstall/pacstall/issues/1033) for more context, but we can observe:
```bash
[63:NOFUNC():1] - DEBUG: name=vscode-deb
[63:NOFUNC():2] - DEBUG: arch=("amd64" "arm64" "armhf")
[63:NOFUNC():3] - DEBUG: gives=code
[63:NOFUNC():4] - DEBUG: pkgver=1.85.0
[63:NOFUNC():5] - DEBUG: homepage=https://code.visualstudio.com/
[63:NOFUNC():6] - DEBUG: pkgdesc='lightweight but powerful source code editor'
[63:NOFUNC():7] - DEBUG: project=("project: vscode")
[63:NOFUNC():8] - DEBUG: maintainer='Diegiwg <diegiwg@gmail.com>'
[63:NOFUNC():10] - DEBUG: case "${CARCH}" in
[63:NOFUNC():23] - DEBUG: return 1
[upgrade.sh:NOFUNC():90] - DEBUG: remotever=
[upgrade.sh:NOFUNC():91] - DEBUG: remoteurl=https://raw.githubusercontent.com/pacstall/pacstall-programs/master
[upgrade.sh:NOFUNC():97] - DEBUG: [[ vscode-deb != *\-\g\i\t ]]
[upgrade.sh:NOFUNC():98] - DEBUG: alterver=0.0.0
[upgrade.sh:NOFUNC():99] - DEBUG: for IDX in "${!REPOS[@]}"
[upgrade.sh:NOFUNC():100] - DEBUG: (( IDX == IDXMATCH ))
[upgrade.sh:NOFUNC():101] - DEBUG: continue
[upgrade.sh:NOFUNC():110] - DEBUG: [[ -n '' ]]
[upgrade.sh:NOFUNC():119] - DEBUG: [[ 0.0.0 != \0\.\0\.\0 ]]
[upgrade.sh:NOFUNC():127] - DEBUG: [[ -n '' ]]
```

```bash
pacstall@docker-desktop:~$ unset CARCH
pacstall@docker-desktop:~$ calc_repo_ver https://raw.githubusercontent.com/pacstall/pacstall-programs/master vscode-deb && echo $comp_repo_ver
pacstall@docker-desktop:~$ export CARCH="$(dpkg --print-architecture)"
pacstall@docker-desktop:~$ calc_repo_ver https://raw.githubusercontent.com/pacstall/pacstall-programs/master vscode-deb && echo $comp_repo_ver
1.85.0-pacstall1
pacstall@docker-desktop:~$ 
```

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
