### PR TITLE
chan!(*): `hash` -> `*sums`

### DIFF
--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -401,7 +401,6 @@ function lint_hash() {
             fi
         done
     fi
-    echo "${test_hash[*]}"
     return "${ret}"
 }
 

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -174,8 +174,8 @@ function lint_source() {
             if [[ -n ${!source_arch} ]]; then
                 test_source=()
                 if [[ -n ${source[0]} ]]; then
-                  # shellcheck disable=SC2206
-                  test_source+=(${source[*]})
+                    # shellcheck disable=SC2206
+                    test_source+=(${source[*]})
                 fi
                 # shellcheck disable=SC2206
                 test_source+=(${!source_arch})
@@ -188,7 +188,7 @@ function lint_source() {
             fi
         done
         if [[ -n ${source[1]} ]]; then
-           lint_source_deb_test "${source[@]}"
+            lint_source_deb_test "${source[@]}"
         fi
     fi
     return "${ret}"
@@ -337,7 +337,7 @@ function lint_hash() {
     for test_hashsum_type in "${test_hashsums[@]}"; do
         test_hashsum_style="${test_hashsum_type}sums[*]"
         if [[ -n ${!test_hashsum_style} ]]; then
-            if [[ -z ${test_hash} ]]; then 
+            if [[ -z ${test_hash} ]]; then
                 # shellcheck disable=SC2206
                 test_hash=(${!test_hashsum_style})
                 test_hashsum_method="${test_hashsum_type}"
@@ -350,7 +350,7 @@ function lint_hash() {
         fi
     done
     for test_hashsum_type in "${test_hashsums[@]}"; do
-        if ((ret==1)); then
+        if ((ret == 1)); then
             break
         fi
         test_hashsum_style="${test_hashsum_type}sums[*]"
@@ -394,7 +394,7 @@ function lint_hash() {
             if [[ ${test_hash[i]} == "SKIP" ]]; then
                 ret=0
 
-            elif ((${#test_hash[i]} != ${test_hashsum_value})) || [[ ! ${test_hash[i]} =~ ^[a-fA-F0-9]+$ ]]; then
+            elif ((${#test_hash[i]} != test_hashsum_value)) || [[ ! ${test_hash[i]} =~ ^[a-fA-F0-9]+$ ]]; then
                 fancy_message error "'hash' is improperly formatted"
                 ret=1
                 break

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -357,7 +357,7 @@ function lint_hash() {
         for harch in "${known_archs_hash[@]}"; do
             test_hash_arch="${test_hashsum_type}sums_${harch}[*]"
             if [[ -n ${!test_hash_arch} ]]; then
-                if [[ -z ${!test_hashsum_style} && -z ${test_hash} ]]; then
+                if [[ -z ${!test_hashsum_style} && -z ${test_hash[*]} ]]; then
                     if [[ -z ${test_hashsum_method} ]]; then
                         # shellcheck disable=SC2206
                         test_hash=(${!test_hash_arch})

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -337,7 +337,7 @@ function lint_hash() {
     for test_hashsum_type in "${test_hashsums[@]}"; do
         test_hashsum_style="${test_hashsum_type}sums[*]"
         if [[ -n ${!test_hashsum_style} ]]; then
-            if [[ -z ${test_hash} ]]; then
+            if [[ -z ${test_hash[*]} ]]; then
                 # shellcheck disable=SC2206
                 test_hash=(${!test_hashsum_style})
                 test_hashsum_method="${test_hashsum_type}"
@@ -383,12 +383,12 @@ function lint_hash() {
     # shellcheck disable=SC2128
     if [[ -n ${test_hash} ]]; then
         case ${test_hashsum_method} in
-            ${test_hashsums[0]} | ${test_hashsums[1]}) test_hashsum_value=128 ;;
-            ${test_hashsums[2]}) test_hashsum_value=96 ;;
-            ${test_hashsums[3]}) test_hashsum_value=64 ;;
-            ${test_hashsums[4]}) test_hashsum_value=56 ;;
-            ${test_hashsums[5]}) test_hashsum_value=40 ;;
-            ${test_hashsums[6]}) test_hashsum_value=32 ;;
+            "${test_hashsums[0]}" | "${test_hashsums[1]}") test_hashsum_value=128 ;;
+            "${test_hashsums[2]}") test_hashsum_value=96 ;;
+            "${test_hashsums[3]}") test_hashsum_value=64 ;;
+            "${test_hashsums[4]}") test_hashsum_value=56 ;;
+            "${test_hashsums[5]}") test_hashsum_value=40 ;;
+            "${test_hashsums[6]}") test_hashsum_value=32 ;;
         esac
         for i in ${!test_hash[*]}; do
             if [[ ${test_hash[i]} == "SKIP" ]]; then

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -331,34 +331,77 @@ function lint_replaces() {
 }
 
 function lint_hash() {
-    local ret=0 test_hash known_archs_hash=()
-    mapfile -t known_archs_hash < <(dpkg-architecture --list-known)
-    for i in "${!known_archs_hash[@]}"; do
-        # shellcheck disable=SC2004
-        known_archs_hash[$i]=${known_archs_hash[$i]//-/_}
-    done
-    if [[ -n ${hash} ]]; then
-        # shellcheck disable=SC2206
-        test_hash+=(${hash[*]})
-    fi
-    for harch in "${known_archs_hash[@]}"; do
-        local hash_arch="hash_${harch}[*]"
-        if [[ -n ${!hash_arch} ]]; then
-            # shellcheck disable=SC2206
-            test_hash+=(${!hash_arch})
+    local ret=0 test_hash harch test_hashsum_type test_hashsum_style test_hash_arch test_hashsum_method test_hashsum_value
+    local known_archs_hash=("amd64" "arm64" "armel" "armhf" "i386" "mips64el" "ppc64el" "riscv64" "s390x")
+    local test_hashsums=("b2" "sha512" "sha384" "sha256" "sha224" "sha1" "md5")
+    for test_hashsum_type in "${test_hashsums[@]}"; do
+        test_hashsum_style="${test_hashsum_type}sums[*]"
+        if [[ -n ${!test_hashsum_style} ]]; then
+            if [[ -z ${test_hash} ]]; then 
+                # shellcheck disable=SC2206
+                test_hash=(${!test_hashsum_style})
+                test_hashsum_method="${test_hashsum_type}"
+            else
+                fancy_message error "Only one checksum method can be provided for hashes"
+                unset test_hash
+                ret=1
+                break
+            fi
         fi
+    done
+    for test_hashsum_type in "${test_hashsums[@]}"; do
+        if ((ret==1)); then
+            break
+        fi
+        test_hashsum_style="${test_hashsum_type}sums[*]"
+        for harch in "${known_archs_hash[@]}"; do
+            test_hash_arch="${test_hashsum_type}sums_${harch}[*]"
+            if [[ -n ${!test_hash_arch} ]]; then
+                if [[ -z ${!test_hashsum_style} && -z ${test_hash} ]]; then
+                    if [[ -z ${test_hashsum_method} ]]; then
+                        # shellcheck disable=SC2206
+                        test_hash=(${!test_hash_arch})
+                        test_hashsum_method="${test_hashsum_type}"
+                    else
+                        fancy_message error "Only one checksum method can be provided for hashes"
+                        unset test_hash
+                        ret=1
+                        break
+                    fi
+                elif [[ -n ${test_hashsum_method} && ${test_hashsum_method} == "${test_hashsum_type}" ]]; then
+                    # shellcheck disable=SC2206
+                    test_hash+=(${!test_hash_arch})
+                else
+                    fancy_message error "Only one checksum method can be provided for hashes"
+                    unset test_hash
+                    ret=1
+                    break
+                fi
+            fi
+        done
     done
     # shellcheck disable=SC2128
     if [[ -n ${test_hash} ]]; then
+        case ${test_hashsum_method} in
+            ${test_hashsums[0]} | ${test_hashsums[1]}) test_hashsum_value=128 ;;
+            ${test_hashsums[2]}) test_hashsum_value=96 ;;
+            ${test_hashsums[3]}) test_hashsum_value=64 ;;
+            ${test_hashsums[4]}) test_hashsum_value=56 ;;
+            ${test_hashsums[5]}) test_hashsum_value=40 ;;
+            ${test_hashsums[6]}) test_hashsum_value=32 ;;
+        esac
         for i in ${!test_hash[*]}; do
             if [[ ${test_hash[i]} == "SKIP" ]]; then
                 ret=0
-            elif ((${#test_hash[i]} != 64)); then
+
+            elif ((${#test_hash[i]} != ${test_hashsum_value})) || [[ ! ${test_hash[i]} =~ ^[a-fA-F0-9]+$ ]]; then
                 fancy_message error "'hash' is improperly formatted"
                 ret=1
+                break
             fi
         done
     fi
+    echo "${test_hash[*]}"
     return "${ret}"
 }
 

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -349,6 +349,7 @@ function file_down() {
         }
         export srcdir="${PWD}"
     else
+        hashcheck_down
         gather_down
     fi
 }

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -359,7 +359,7 @@ function append_archAndHash_entry() {
     # shellcheck disable=SC2153
     source_arch="source_${CARCH}[*]"
     if [[ -n ${!source_arch} ]]; then
-        if [[ -z ${source} ]];then
+        if [[ -z ${source} ]]; then
             # shellcheck disable=SC2206
             source=(${!source_arch})
         else
@@ -540,16 +540,16 @@ function compare_remote_version() {
     local remotever
     remotever="$(
         unset pkgrel
-        source <(curl -s -- "$remoterepo/packages/$crv_input/$crv_input.pacscript") && \
-        if [[ ${pkgname} == *-git ]]; then
-            parse_source_entry "${source[0]}"
-            calc_git_pkgver
-            echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}~git${comp_git_pkgver}"
-        elif [[ ${pkgname} == *-deb ]]; then
-            echo "${epoch+$epoch:}${pkgver}"
-        else
-            echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}"
-        fi
+        source <(curl -s -- "$remoterepo/packages/$crv_input/$crv_input.pacscript") \
+            && if [[ ${pkgname} == *-git ]]; then
+                parse_source_entry "${source[0]}"
+                calc_git_pkgver
+                echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}~git${comp_git_pkgver}"
+            elif [[ ${pkgname} == *-deb ]]; then
+                echo "${epoch+$epoch:}${pkgver}"
+            else
+                echo "${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}"
+            fi
     )" > /dev/null
     if [[ $crv_input == *"-git" ]]; then
         if [[ $(pacstall -Qi "$crv_input" version) != "$remotever" ]]; then

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -359,7 +359,7 @@ function append_archAndHash_entry() {
     # shellcheck disable=SC2153
     source_arch="source_${CARCH}[*]"
     if [[ -n ${!source_arch} ]]; then
-        if [[ -z ${source} ]]; then
+        if [[ -z ${source[*]} ]]; then
             # shellcheck disable=SC2206
             source=(${!source_arch})
         else
@@ -381,7 +381,7 @@ function append_archAndHash_entry() {
         # shellcheck disable=SC2153
         hash_arch="${hashsum_type}sums_${CARCH}[*]"
         if [[ -n ${!hash_arch} ]]; then
-            if [[ -z ${!hashsum_style} && -z ${hash} ]]; then
+            if [[ -z ${!hashsum_style} && -z ${hash[*]} ]]; then
                 # shellcheck disable=SC2206
                 hash=(${!hash_arch})
                 export hashsum_method="${hashsum_type}"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -340,9 +340,7 @@ for i in "${!source[@]}"; do
         *)
             net_down
             hashcheck_down
-            if [[ ${source[i]} != "${source[0]}" ]]; then
-                gather_down
-            fi
+            gather_down
             ;;
     esac
     unset expectedHash dest url git_branch git_tag git_commit ext_deps ext_method

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -254,7 +254,7 @@ fi
 
 unset dest_list
 declare -A dest_list
-append_arch_entry
+append_archAndHash_entry
 for i in "${!source[@]}"; do
     parse_source_entry "${source[$i]}"
     dest="${dest%.git}"
@@ -345,7 +345,7 @@ for i in "${!source[@]}"; do
             fi
             ;;
     esac
-    unset expectedHash dest url git_branch git_tag git_commit ext_deps ext_method
+    unset expectedHash dest url git_branch git_tag git_commit ext_deps ext_method hashsum_method
 done
 
 export pacdir="$PWD"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -345,8 +345,9 @@ for i in "${!source[@]}"; do
             fi
             ;;
     esac
-    unset expectedHash dest url git_branch git_tag git_commit ext_deps ext_method hashsum_method
+    unset expectedHash dest url git_branch git_tag git_commit ext_deps ext_method
 done
+unset hashsum_method
 
 export pacdir="$PWD"
 sudo chown -R "$PACSTALL_USER":"$PACSTALL_USER" . 2> /dev/null


### PR DESCRIPTION
## Purpose

PKGBUILD parity, see: https://wiki.archlinux.org/title/PKGBUILD#Integrity

## Approach

turn hash into an internally appended array that takes `{b2 sha512 sha384 sha256 sha224 sha1 md5}sums=` or `*sums_${CARCH}=`

checksum methods are mutually exclusive for pacscripts

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
