### PR TITLE
feat({build,install}-local.sh): add `conflicts` array

### DIFF
--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -44,7 +44,7 @@ function cleanup() {
     fi
     sudo rm -rf "${STOWDIR}/${pkgname:-$PACKAGE}.deb"
     rm -f /tmp/pacstall-select-options
-    unset pkgname repology pkgver git_pkgver epoch url source depends makedepends breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible optinstall srcdir homepage backup pkgrel mask pac_functions repo priority noextract 2> /dev/null
+    unset pkgname repology pkgver git_pkgver epoch url source depends makedepends conflicts breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible optinstall srcdir homepage backup pkgrel mask pac_functions repo priority noextract 2> /dev/null
     unset -f post_install post_remove pre_install prepare build package 2> /dev/null
     sudo rm -f "${pacfile}"
 }
@@ -298,7 +298,17 @@ function makedeb() {
         deblog "Provides" "$(sed 's/ /, /g' <<< "${provides[@]}")"
     fi
 
-    if [[ -n $replaces ]]; then
+    if [[ -n ${conflicts[*]} ]]; then
+        # shellcheck disable=SC2001
+        deblog "Conflicts" "$(sed 's/ /, /g' <<< "${conflicts[@]}")"
+    fi  
+
+    if [[ -n ${breaks[*]} ]]; then
+        # shellcheck disable=SC2001
+        deblog "Breaks" "$(sed 's/ /, /g' <<< "${breaks[@]}")"
+    fi
+
+    if [[ -n ${replaces[*]} ]]; then
         # shellcheck disable=SC2001
         deblog "Conflicts" "$(sed 's/ /, /g' <<< "${replaces[@]}")"
         # shellcheck disable=SC2001

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -301,7 +301,7 @@ function makedeb() {
     if [[ -n ${conflicts[*]} ]]; then
         # shellcheck disable=SC2001
         deblog "Conflicts" "$(sed 's/ /, /g' <<< "${conflicts[@]}")"
-    fi  
+    fi
 
     if [[ -n ${breaks[*]} ]]; then
         # shellcheck disable=SC2001

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -312,7 +312,7 @@ function makedeb() {
         # shellcheck disable=SC2001
         deblog "Conflicts" "$(sed 's/ /, /g' <<< "${replaces[@]}")"
         # shellcheck disable=SC2001
-        deblog "Replace" "$(sed 's/ /, /g' <<< "${replaces[@]}")"
+        deblog "Replaces" "$(sed 's/ /, /g' <<< "${replaces[@]}")"
     fi
 
     if [[ -n ${homepage} ]]; then

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -302,6 +302,20 @@ function lint_optdepends() {
     return "${ret}"
 }
 
+function lint_conflicts() {
+    local ret=0 conflict idx=0
+    if [[ -n ${conflicts[*]} ]]; then
+        for conflict in "${conflicts[@]}"; do
+            if [[ -z ${conflict} ]]; then
+                fancy_message error "'conflicts' index '${idx}' cannot be empty"
+                ret=1
+            fi
+            ((idx++))
+        done
+    fi
+    return "${ret}"
+}
+
 function lint_breaks() {
     local ret=0 break idx=0
     if [[ -n ${breaks[*]} ]]; then
@@ -498,7 +512,7 @@ function lint_priority() {
 }
 
 function checks() {
-    local ret=0 check linting_checks=(lint_pkgname lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_makedepends lint_depends lint_pacdeps lint_ppa lint_optdepends lint_breaks lint_replaces lint_hash lint_patch lint_provides lint_incompatible lint_arch lint_mask lint_priority)
+    local ret=0 check linting_checks=(lint_pkgname lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_makedepends lint_depends lint_pacdeps lint_ppa lint_optdepends lint_conflicts lint_breaks lint_replaces lint_hash lint_patch lint_provides lint_incompatible lint_arch lint_mask lint_priority)
     for check in "${linting_checks[@]}"; do
         "${check}" || ret=1
     done

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -219,6 +219,7 @@ if ! is_package_installed "${pkgname}"; then
             # Do we have an apt package installed (but not pacstall)?
             if is_apt_package_installed "${pkg}" && ! is_package_installed "${pkg}"; then
                 # Check if anything in conflicts variable is installed already
+                # shellcheck disable=SC2031
                 fancy_message error "${RED}$pkgname${NC} conflicts with $pkg, which is currently installed by apt"
                 suggested_solution "Remove the apt package by running '${UCyan}sudo apt purge $pkg${NC}'"
                 error_log 13 "install $PACKAGE"
@@ -226,6 +227,7 @@ if ! is_package_installed "${pkgname}"; then
             fi
             if [[ ${pkg} != "${pkgname}" ]] && is_package_installed "${pkg}"; then
                 # Same thing, but check if anything is installed with pacstall
+                # shellcheck disable=SC2031
                 fancy_message error "${RED}$pkgname${NC} conflicts with $pkg, which is currently installed by pacstall"
                 suggested_solution "Remove the pacstall package by running '${UCyan}pacstall -R $pkg${NC}'"
                 error_log 13 "install $PACKAGE"


### PR DESCRIPTION
## Purpose

https://wiki.archlinux.org/title/PKGBUILD#conflicts
https://www.debian.org/doc/debian-policy/ch-relationships.html#packages-which-break-other-packages-breaks
https://www.debian.org/doc/debian-policy/ch-relationships.html#conflicting-binary-packages-conflicts
right now, pacstall has only `breaks`, PKGBUILD has only `conflicts`, but `debian` has both.

## Approach

just duplicate `breaks` array with `conflicts`, except also we weren't `deblog`-ing `breaks` before so we will now

also fix `Replace` -> `Replaces` logging, see: https://www.debian.org/doc/debian-policy/ch-relationships.html#overwriting-files-and-replacing-packages-replaces

it is confusing, not sure if conflicts + replaces should actually be separated completely, but imo it should stay as is for now. Breaks+Replaces situations seem like they are edge.

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
