### PR TITLE
feat({build,download}-local.sh: add `{pre,post}_upgrade`, `pre_remove`

### DIFF
--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -45,7 +45,7 @@ function cleanup() {
     sudo rm -rf "${STOWDIR}/${pkgname:-$PACKAGE}.deb"
     rm -f /tmp/pacstall-select-options
     unset pkgname repology pkgver git_pkgver epoch url source depends makedepends breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible optinstall srcdir homepage backup pkgrel mask pac_functions repo priority noextract 2> /dev/null
-    unset -f post_install post_remove pre_install pre_upgrade post_upgrade prepare build package 2> /dev/null
+    unset -f pre_install pre_upgrade pre_remove post_install post_upgrade post_remove prepare build package 2> /dev/null
     sudo rm -f "${pacfile}"
 }
 
@@ -350,11 +350,12 @@ function makedeb() {
         post_inst_upg="post_install"
     fi
 
-    for i in {post_remove,"${post_inst_upg}","${pre_inst_upg}"}; do
+    for i in {"${pre_inst_upg}",pre_remove,"${post_inst_upg}",post_remove}; do
         case "$i" in
-            post_remove) export deb_post_file="postrm" ;;
-            "${post_inst_upg}") export deb_post_file="postinst" ;;
             "${pre_inst_upg}") export deb_post_file="preinst" ;;
+            pre_remove) export deb_post_file="prerm" ;;
+            "${post_inst_upg}") export deb_post_file="postinst" ;;
+            post_remove) export deb_post_file="postrm" ;;
         esac
         if is_function "$i"; then
             local pac_min_functions pacmf_out

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -45,7 +45,7 @@ function cleanup() {
     sudo rm -rf "${STOWDIR}/${pkgname:-$PACKAGE}.deb"
     rm -f /tmp/pacstall-select-options
     unset pkgname repology pkgver git_pkgver epoch url source depends makedepends breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible optinstall srcdir homepage backup pkgrel mask pac_functions repo priority noextract 2> /dev/null
-    unset -f post_install post_remove pre_install prepare build package 2> /dev/null
+    unset -f post_install post_remove pre_install pre_upgrade post_upgrade prepare build package 2> /dev/null
     sudo rm -f "${pacfile}"
 }
 
@@ -334,12 +334,27 @@ function makedeb() {
     else
         deblog "Description" "${pkgdesc}"
     fi
+    if is_package_installed "${pkgname}"; then
+        if type -t pre_upgrade &> /dev/null; then
+            pre_inst_upg="pre_upgrade"
+        else
+            pre_inst_upg="pre_install"
+        fi
+        if type -t post_upgrade &> /dev/null; then
+            post_inst_upg="post_upgrade"
+        else
+            post_inst_upg="post_install"
+        fi
+    else
+        pre_inst_upg="pre_install"
+        post_inst_upg="post_install"
+    fi
 
-    for i in {post_remove,post_install,pre_install}; do
+    for i in {post_remove,"${post_inst_upg}","${pre_inst_upg}"}; do
         case "$i" in
             post_remove) export deb_post_file="postrm" ;;
-            post_install) export deb_post_file="postinst" ;;
-            pre_install) export deb_post_file="preinst" ;;
+            "${post_inst_upg}") export deb_post_file="postinst" ;;
+            "${pre_inst_upg}") export deb_post_file="preinst" ;;
         esac
         if is_function "$i"; then
             local pac_min_functions pacmf_out

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -295,7 +295,13 @@ function genextr_down() {
 
 function deb_down() {
     hashcheck_down
-    if type -t pre_install &> /dev/null; then
+    if is_package_installed "${pkgname}" && type -t pre_upgrade &> /dev/null; then
+        if ! pre_upgrade; then
+            error_log 5 "pre_upgrade hook"
+            fancy_message error "Could not run preinst hook successfully"
+            exit 1
+        fi
+    elif type -t pre_install &> /dev/null; then
         if ! pre_install; then
             error_log 5 "pre_install hook"
             fancy_message error "Could not run preinst hook successfully"


### PR DESCRIPTION
## Purpose

say it with me now:  PKG👏BUILD👏parity👏 
https://wiki.archlinux.org/title/PKGBUILD#install
if a package is already installed, PKGBUILDs can run `{pre,post}_upgrade` instead of  `{pre,post}_install`
also `pre_remove`, debian has prerm https://manpages.debian.org/testing/dpkg-dev/deb-prerm.5.en.html

## Approach

if package is installed + an _upgrade option exists, use that for deb's `preinst/postinst` options instead of _install.

If a package is installed but an _upgrade option does not exist, fall back to the _install options.

Added pre_remove/prerm to the list

works, test with:
```bash
pkgname="test-pacscript-bin"
source="https://github.com/oklopfer/debs/raw/master/empty.tar.xz"
pkgver="0.0.1"
pkgdesc="test"
maintainer="Oren Klopfer <oren@taumoda.com>"
pre_install() {
  echo "this is pre-install"
}

pre_upgrade() {
  echo "this is pre-upgrade"
}

pre_remove() {
  echo "this is pre-remove"
}

package() {
  echo "hi"
}

post_install() {
  echo "this is post-install"
}

post_upgrade() {
  echo "this is post-upgrade"
}

post_remove() {
  echo "this is post-remove"
}
```

## Progress

- [x] Do it
- [x] Test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
