### PR TITLE
feat(*): add `check()` pacscript function

### DIFF
--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -45,7 +45,7 @@ function cleanup() {
     sudo rm -rf "${STOWDIR}/${pkgname:-$PACKAGE}.deb"
     rm -f /tmp/pacstall-select-options
     unset pkgname repology pkgver git_pkgver epoch source_url source depends makedepends conflicts breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible optinstall srcdir url backup pkgrel mask pac_functions repo priority noextract 2> /dev/null
-    unset -f pre_install pre_upgrade pre_remove post_install post_upgrade post_remove prepare build package 2> /dev/null
+    unset -f pre_install pre_upgrade pre_remove post_install post_upgrade post_remove prepare build check package 2> /dev/null
     sudo rm -f "${pacfile}"
 }
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -419,12 +419,19 @@ $(shopt -p -o)"
     eval "$restoreshopt"
     eval "$restoretrap"
 }
-
-for i in {prepare,build,package}; do
-    if is_function "$i"; then
-        pac_functions+=("$i")
-    fi
-done
+if [[ $NOCHECK == true ]]; then
+    for i in {prepare,build,package}; do
+        if is_function "$i"; then
+            pac_functions+=("$i")
+        fi
+    done
+else
+    for i in {prepare,build,check,package}; do
+        if is_function "$i"; then
+            pac_functions+=("$i")
+        fi
+    done
+fi
 if [[ -n ${pac_functions[*]} ]]; then
     fancy_message info "Running functions"
     for function in "${pac_functions[@]}"; do

--- a/pacstall
+++ b/pacstall
@@ -522,7 +522,7 @@ for i in "${@}"; do
     # We remove the '-' prefix as we'll add it later.
     for j in $(sed 's|[[:upper:]]| &|g' <<< "${i:1}"); do
         # If current string is 'P', add to beginning of argument list.
-        if [[ ${j} == "B" || ${j} == "-build-only" || ${j} == "P" || ${j} == "-disable-prompts" || ${j} == "K" || ${j} == "-keep" ]]; then
+        if [[ ${j} == "B" || ${j} == "-build-only" || ${j} == "P" || ${j} == "-disable-prompts" || ${j} == "K" || ${j} == "-keep" || ${j} == "Nc" || ${j} == "-nocheck" ]]; then
             argument_list=("-${j}" "${argument_list[@]}")
         else
             argument_list+=("-${j}")
@@ -587,7 +587,7 @@ while [[ $1 != "--" ]]; do
             ;;
 
         -h | --help)
-            echo -e "Usage: pacstall [-h] [-V] {-I,-S,-R,-D,-A,-U,-L,-Up,-Qi,-T} [-P] [-K] [-B]
+            echo -e "Usage: pacstall [-h] [-V] {-I,-S,-R,-D,-A,-U,-L,-Up,-Qi,-T} [-P] [-K] [-B] [-Nc]
 
 An AUR inspired package manager for Ubuntu.
 
@@ -620,6 +620,8 @@ Options:
 		Keep the build files.
 	${BOLD}-B${NC}, ${BOLD}--build-only${NC}
 		Build the deb but do not install.
+    ${BOLD}-Nc${NC}, ${BOLD}--nocheck${NC}
+        Skip the check() function if present.
 	${BOLD}-V${NC}, ${BOLD}--version${NC}
 		Display the version number.
 	${BOLD}-h${NC}, ${BOLD}--help${NC}
@@ -982,6 +984,11 @@ Helpful links:
         -K | --keep)
             fancy_message info "Keeping build files"
             KEEP=true
+            ;;
+
+        -Nc | --nocheck)
+            fancy_message info "Skipping check() if present"
+            NOCHECK=true
             ;;
 
         *)


### PR DESCRIPTION
## Purpose

PKGBUILD. parity im getting tired of saying it 

## Approach

add check() function between build + package, and add `-Nc/--nocheck` flag to allow skipping of it

## Progress

- [x] Do it
- [x] Test it
- [ ] Make completions for it

## Addendum

test script:
```bash
pkgname="test-pacscript-bin"
source="https://github.com/oklopfer/debs/raw/master/empty.tar.xz"
pkgver="0.0.1"
pkgdesc="test"
maintainer="Oren Klopfer <oren@taumoda.com>"

prepare() {
  echo "this is prepare"
}

build() {
  echo "this is build"
}

check() {
  echo "this is check"
}

package() {
  echo "this is package"
}
```

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
