### PR TITLE
chan!(download-local.sh): break out `srcdir` -> `srcdir` + `_archive`

### DIFF
--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -44,7 +44,7 @@ function cleanup() {
     fi
     sudo rm -rf "${STOWDIR}/${pkgname:-$PACKAGE}.deb"
     rm -f /tmp/pacstall-select-options
-    unset pkgname repology pkgver git_pkgver epoch source_url source depends makedepends conflicts breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible compatible optinstall srcdir url backup pkgrel mask pac_functions repo priority noextract 2> /dev/null
+    unset pkgname repology pkgver git_pkgver epoch source_url source depends makedepends conflicts breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible compatible optinstall srcdir url backup pkgrel mask pac_functions repo priority noextract _archive 2> /dev/null
     unset -f pre_install pre_upgrade pre_remove post_install post_upgrade post_remove prepare build check package 2> /dev/null
     sudo rm -f "${pacfile}"
 }

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -185,9 +185,6 @@ function gather_down() {
             export srcdir="${PACDIR}/${PACKAGE}~${pkgver}"
         fi
     fi
-    if [[ -z ${_archive} ]]; then
-        export _archive="${srcdir}"
-    fi
     mkdir -p "${srcdir}"
     cd "${srcdir}" || {
         error_log 1 "gather-main $PACKAGE"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -323,6 +323,7 @@ else
 fi
 
 mkdir -p "${PACDIR}"
+gather_down
 
 for i in "${!source[@]}"; do
     parse_source_entry "${source[$i]}"
@@ -369,6 +370,9 @@ for i in "${!source[@]}"; do
 done
 unset hashsum_method
 
+if [[ -z ${_archive} ]]; then
+    export _archive="${srcdir}"
+fi
 export pacdir="$PWD"
 sudo chown -R "$PACSTALL_USER":"$PACSTALL_USER" . 2> /dev/null
 


### PR DESCRIPTION
## Purpose

if we are doing so many breaking changes, it is better to make our formatting future proof. also, PKGBUILD parity.

we entered the first source entry to maintain pacscript compat. but that causes problems, because all subsequent entries are placed here, meaning if a user cp'd the whole directory, it would have carried too much.

## Approach

- introduce the PKGBUILD `_archive` variable; users can set it for usage in their script, or it will fall back to the first source entry's extracted directory
- change `srcdir` to always be `/tmp/pacstall/$pkgname~$pkgver` or `/tmp/pacstall-pacdep` if PACSTALL_PAYLOAD
- cd back to `srcdir` for everyone after down/extr, regardless of if we cd'd


- all current pacscripts should start with `cd $_archive` in prepare, build, and package
- pacscripts which used `cd ..` should instead `cd $srcdir`

After this, we have the following:
### how to convert 4.3.2 pacscripts to 5.0.0 pacscripts:
1. convert any existing pkgname declarations into gives
3. convert name declarations into pkgname
4. convert url variable to source array
5. convert maintainer variable to an array
6. convert replace variable to replaces variable
7. convert homepage variable to url variable
8. for -git packages, remove pkgver() usage
9. for -git packages, if their source entry does not end in *.git, append https:// -> git+https://
10. convert hash variable to sha256sums array
11. convert any SRCDIR usage to srcdir
12. packages which previously used wget or curl should now use the source array; there are just short of 50 of these packages
13. said packages will need to refer to the files from ${srcdir}/file, and may also want to use SKIP for their hashes
14. all current pacscripts should start with cd $_archive in prepare, build, and package
15. pacscripts which used cd .. should instead cd $srcdir

### how to convert PKGBUILDs to 5.0.0 pacscripts:
1. add maintainer array instead of comment
3. change arch variable to dpkg naming scheme (this goes for source_{arch} variables as well)
4. change necessary depends and makedepends to debian/ubuntu assocations; some may need to be moved from depends to makedepends, or add pacdeps
5. sudo may need to be used during prepare/build/package steps until bwrap is done
6. drop pkgver() function usage, as we do it internally
7. validpgpkeys is not currently supported
8. if arch-meson is used, subsidize with regular meson

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
