### PR TITLE
fix(*-local.sh)!: mark `pacdeps` as deps for `-deb` pacs

### DIFF
--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -510,14 +510,12 @@ function repacstall() {
         depends_array=("${depends_array[@]/# /}")
         depends_array=("${depends_array[@]/% /}")
     fi
-    if [[ -n ${pacdeps[*]} ]]; then
-        for pacdep in "${pacdeps[@]}"; do
-            pacgives=$(awk '/_gives/ {print; exit}' "/var/lib/pacstall/metadata/${pacdep}")
-            if [[ -z ${pacgives} ]]; then
-                pacgives=$(awk '/_name/ {print; exit}' "/var/lib/pacstall/metadata/${pacdep}")
+    if [[ -n ${makedepends[*]} ]]; then
+        # shellcheck disable=SC2076
+        for meper in "${makedepends[@]}"; do
+            if ! [[ " ${depends_array[*]} " =~ " ${meper} " ]]; then
+                depends_array+=("${meper}")
             fi
-            eval "pacgives=${pacgives#*=}"
-            depends_array+=("${pacgives}")
         done
     fi
     if [[ -n ${depends[*]} ]]; then
@@ -528,12 +526,14 @@ function repacstall() {
             fi
         done
     fi
-    if [[ -n ${makedepends[*]} ]]; then
-        # shellcheck disable=SC2076
-        for meper in "${makedepends[@]}"; do
-            if ! [[ " ${depends_array[*]} " =~ " ${meper} " ]]; then
-                depends_array+=("${meper}")
+    if [[ -n ${pacdeps[*]} ]]; then
+        for pacdep in "${pacdeps[@]}"; do
+            pacgives=$(awk '/_gives/ {print; exit}' "/var/lib/pacstall/metadata/${pacdep}")
+            if [[ -z ${pacgives} ]]; then
+                pacgives=$(awk '/_name/ {print; exit}' "/var/lib/pacstall/metadata/${pacdep}")
             fi
+            eval "pacgives=${pacgives#*=}"
+            depends_array+=("${pacgives}")
         done
     fi
     sudo sed -i '/^Depends:/d' "${upcontrol}"

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -454,7 +454,10 @@ function makedeb() {
         cleanup
         return 1
     fi
+    install_deb
+}
 
+function install_deb() {
     if ((PACSTALL_INSTALL != 0)); then
         # --allow-downgrades is to allow git packages to "downgrade", because the commits aren't necessarily a higher number than the last version
         if ! sudo -E apt-get install --reinstall "$STOWDIR/$pkgname.deb" -y --allow-downgrades 2> /dev/null; then
@@ -491,6 +494,48 @@ function makedeb() {
         cleanup
         exit 0
     fi
+}
+
+function repacstall() {
+    local depends_array unpackdir depends_line deper meper pacdep evaline upcontrol input_dest="${1}"
+    unpackdir="${STOWDIR}/${pkgname}"
+    upcontrol="${unpackdir}/DEBIAN/control"
+    sudo mkdir -p "${unpackdir}"
+    sudo rm -rf "${unpackdir}"/*
+    fancy_message sub "Repacking ${CYAN}${pkgname/\-deb/}.deb${NC}"
+    sudo dpkg-deb -R "${input_dest}" "${unpackdir}"
+    depends_line=$(awk '/^Depends:/ {print; exit}' "${upcontrol}")
+    if [[ -n ${depends_line} ]]; then
+      readarray -t depends_array <<< "$(echo "${depends_line#Depends: }" | tr ',' '\n')"
+      depends_array=("${depends_array[@]/# /}")
+      depends_array=("${depends_array[@]/% /}")
+    fi
+    if [[ -n ${pacdeps[*]} ]]; then
+      for pacdep in "${pacdeps[@]}"; do
+        depends_array+=($(source /var/lib/pacstall/metadata/${pacdep} && echo ${_gives}))
+      done
+      for deper in "${depends[@]}"; do
+        if ! [[ " ${depends_array[*]} " =~ " ${deper} " ]]; then
+          depends_array+=("${deper}")
+        fi
+      done
+      for meper in "${makedepends[@]}"; do
+        if ! [[ " ${depends_array[*]} " =~ " ${meper} " ]]; then
+          depends_array+=("${meper}")
+        fi
+      done
+    fi
+    sudo sed -i '/^Depends:/d' "${upcontrol}"
+    evaline=$(echo "Depends: $(perl -pe 's/ /, /g; s/, (?=\()/ /g; s/([=<>|]),/$1 /g' <<< "${depends_array[@]}")")
+    sudo sed -i "/Installed-Size:/a ${evaline}" "${upcontrol}"
+    if ! createdeb "${pkgname}"; then
+        fancy_message error "Could not create package"
+        error_log 5 "install $PACKAGE"
+        fancy_message info "Cleaning up"
+        cleanup
+        return 1
+    fi
+    install_deb
 }
 
 function write_meta() {

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -513,7 +513,7 @@ function repacstall() {
     if [[ -n ${makedepends[*]} ]]; then
         # shellcheck disable=SC2076
         for meper in "${makedepends[@]}"; do
-            if ! [[ " ${depends_array[*]} " =~ " ${meper} " ]]; then
+            if ! array.contains depends_array "${meper}"; then
                 depends_array+=("${meper}")
             fi
         done
@@ -521,7 +521,7 @@ function repacstall() {
     if [[ -n ${depends[*]} ]]; then
         # shellcheck disable=SC2076
         for deper in "${depends[@]}"; do
-            if ! [[ " ${depends_array[*]} " =~ " ${deper} " ]]; then
+            if ! array.contains depends_array "${deper}"; then
                 depends_array+=("${deper}")
             fi
         done

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -539,6 +539,7 @@ function repacstall() {
     sudo sed -i '/^Depends:/d' "${upcontrol}"
     evaline="Depends: $(perl -pe 's/ /, /g; s/, (?=\()/ /g; s/([=<>|]),/$1 /g' <<< "${depends_array[@]}")"
     sudo sed -i "/Installed-Size:/a ${evaline}" "${upcontrol}"
+    sudo sed -i "/APT-Sources:/a Modified-By-Pacstall: yes" "${upcontrol}"
     if ! createdeb "${pkgname}"; then
         fancy_message error "Could not create package"
         error_log 5 "install $PACKAGE"

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -539,7 +539,7 @@ function repacstall() {
     sudo sed -i '/^Depends:/d' "${upcontrol}"
     evaline="Depends: $(perl -pe 's/ /, /g; s/, (?=\()/ /g; s/([=<>|]),/$1 /g' <<< "${depends_array[@]}")"
     sudo sed -i "/Installed-Size:/a ${evaline}" "${upcontrol}"
-    sudo sed -i "/APT-Sources:/a Modified-By-Pacstall: yes" "${upcontrol}"
+    sudo sed -i "/Description:/i Modified-By-Pacstall: yes" "${upcontrol}"
     if ! createdeb "${pkgname}"; then
         fancy_message error "Could not create package"
         error_log 5 "install $PACKAGE"

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -316,7 +316,7 @@ function deb_down() {
             exit 1
         fi
     fi
-    if sudo apt install -y -f ./"${dest}" 2> /dev/null; then
+    if [[ -n ${pacdeps[*]} || ${depends[*]} || ${makedepends[*]} ]] && repacstall "${dest}" || sudo apt install -y -f ./"${dest}" 2> /dev/null; then
         meta_log
         if [[ -f /tmp/pacstall-pacdeps-"$pkgname" ]]; then
             sudo apt-mark auto "${gives:-$pkgname}" 2> /dev/null

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -100,6 +100,10 @@ if ((PACSTALL_INSTALL == 0)) && [[ ${pkgname} == *-deb ]]; then
     if ! download "${source[0]}"; then
         fancy_message error "Failed to download '${source[0]}'"
         return 1
+    else
+        parse_source_entry "${source[0]}"
+        fancy_message info "Moving ${BGreen}$PACDIR/${dest}${NC} to ${BGreen}/tmp/pacstall-no-build/${dest}${NC}"
+        sudo mkdir -p "/tmp/pacstall-no-build/" && sudo mv ./"${dest}" "/tmp/pacstall-no-build/"
     fi
     return 0
 fi

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -76,7 +76,10 @@ if [[ -n ${_pacstall_depends} ]]; then
 else
     install_type="explicitly installed"
 fi
-
+get_field "$PACKAGE" Modified-By-Pacstall mbp
+if [[ ${mbp} != "yes" ]]; then
+    mbp="no"
+fi
 if [[ -n ${_mask[*]} ]]; then
     mask="${_mask[*]}"
 fi
@@ -120,5 +123,8 @@ if [[ -v dependencies ]]; then
     echo -e "${BGreen}dependencies${NC}: ${dependencies}"
 fi
 echo -e "${BGreen}install type${NC}: ${install_type}"
+if [[ ${PACKAGE} == *"-deb" ]]; then
+    echo -e "${BGreen}modified by pacstall${NC}: ${mbp}"
+fi
 exit 0
 # vim:set ft=sh ts=4 sw=4 noet:


### PR DESCRIPTION
## Purpose

if a `-deb` script defined a pacdep, or a dependency that the deb did not think it needs, it wasn't actually marked as a dependency by dpkg. 

Also, downloading a deb with -B needed verbosity.

## Approach

Unpack the deb in a temp location, parse the control file for the Depends line, create an array, insert pacdeps, depends, and makedepends into the array, print it back out into the control file, repack the deb, install it.

also give downloading them with -B verbosity

## Progress

- [x] do it
- [x] test it
- [x] test it more

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
