### PR TITLE
fix(download-local.sh): be verbose about pacstall hooks for -debs

### DIFF
--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -306,14 +306,14 @@ function deb_down() {
     local upgrade=false
     if is_package_installed "${pkgname}" && type -t pre_upgrade &> /dev/null; then
         upgrade=true
-        fancy_message info "Running pre_upgrade hook"
+        fancy_message sub "Running pre_upgrade hook"
         if ! pre_upgrade; then
             error_log 5 "pre_upgrade hook"
             fancy_message error "Could not run pre_upgrade hook successfully"
             exit 1
         fi
     elif type -t pre_install &> /dev/null; then
-        fancy_message info "Running pre_install hook"
+        fancy_message sub "Running pre_install hook"
         if ! pre_install; then
             error_log 5 "pre_install hook"
             fancy_message error "Could not run pre_install hook successfully"
@@ -325,22 +325,22 @@ function deb_down() {
         if [[ -f /tmp/pacstall-pacdeps-"$pkgname" ]]; then
             sudo apt-mark auto "${gives:-$pkgname}" 2> /dev/null
         fi
+        fancy_message info "Performing post install operations"
         if type -t post_upgrade &> /dev/null && ${upgrade}; then
-            fancy_message info "Running post_upgrade hook"
+            fancy_message sub "Running post_upgrade hook"
             if ! post_upgrade; then
                 error_log 5 "post_upgrade hook"
                 fancy_message error "Could not run post_upgrade hook successfully"
                 exit 1
             fi
         elif type -t post_install &> /dev/null; then
-            fancy_message info "Running post_install hook"
+            fancy_message sub "Running post_install hook"
             if ! post_install; then
                 error_log 5 "post_install hook"
                 fancy_message error "Could not run post_install hook successfully"
                 exit 1
             fi
         fi
-        fancy_message info "Performing post install operations"
         fancy_message sub "Storing pacscript"
         sudo mkdir -p "/var/cache/pacstall/$PACKAGE/${full_version}"
         if ! cd "$DIR" 2> /dev/null; then

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -309,14 +309,14 @@ function deb_down() {
         fancy_message sub "Running pre_upgrade hook"
         if ! pre_upgrade; then
             error_log 5 "pre_upgrade hook"
-            fancy_message error "Could not run pre_upgrade hook successfully"
+            fancy_message error "Could not run preinst hook successfully"
             exit 1
         fi
     elif type -t pre_install &> /dev/null; then
         fancy_message sub "Running pre_install hook"
         if ! pre_install; then
             error_log 5 "pre_install hook"
-            fancy_message error "Could not run pre_install hook successfully"
+            fancy_message error "Could not run preinst hook successfully"
             exit 1
         fi
     fi
@@ -330,14 +330,14 @@ function deb_down() {
             fancy_message sub "Running post_upgrade hook"
             if ! post_upgrade; then
                 error_log 5 "post_upgrade hook"
-                fancy_message error "Could not run post_upgrade hook successfully"
+                fancy_message error "Could not run postinst hook successfully"
                 exit 1
             fi
         elif type -t post_install &> /dev/null; then
             fancy_message sub "Running post_install hook"
             if ! post_install; then
                 error_log 5 "post_install hook"
-                fancy_message error "Could not run post_install hook successfully"
+                fancy_message error "Could not run postinst hook successfully"
                 exit 1
             fi
         fi


### PR DESCRIPTION
## Purpose

pacstall hooks are different from debian hooks when in the case of `-deb`s. 

## Approach

distinguish them with verbosity. Also fix missing post_upgrade hook. Also make final cleanup terminology equal for `-debs` to how it was for everyone else (using `fancy_message sub` and announcing package finished installing)

## Progress

- [x] do it
- [x] test it as always

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
