### PR TITLE
fix(bwrap.sh): drop net

### DIFF
--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -51,7 +51,7 @@ function cleanup() {
     sudo rm -rf "${STOWDIR}/${pkgname:-$PACKAGE}.deb"
     rm -f /tmp/pacstall-select-options
     sudo rm -f "${PACDIR}/bwrapenv.*"
-    unset pkgname repology pkgver git_pkgver epoch source_url source depends makedepends conflicts breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible compatible optinstall srcdir url backup pkgrel mask pac_functions repo priority noextract nosubmodules _archive license bwrapenv safeenv 2> /dev/null
+    unset pkgname repology pkgver git_pkgver epoch source_url source depends makedepends conflicts breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible compatible optinstall srcdir url backup pkgrel mask pac_functions repo priority noextract nosubmodules _archive license bwrapenv safeenv external_connection 2> /dev/null
     unset -f pre_install pre_upgrade pre_remove post_install post_upgrade post_remove prepare build check package 2> /dev/null
     sudo rm -f "${pacfile}"
 }

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -88,8 +88,6 @@ function bwrap_function() {
     tmpfile="$(sudo mktemp -p "${PWD}")"
     sudo tee -a "$tmpfile" > /dev/null <<EOF
 #!/bin/bash -a
-shopt -s expand_aliases
-alias sudo=':'
 mapfile -t OLD_ENV < <(compgen -A variable -P "--unset ")
 source ${bwrapenv}
 ${func} 2>&1 "${LOGDIR}/$(printf '%(%Y-%m-%d_%T)T')-$name-$func.log" && FUNCSTATUS="\${PIPESTATUS[0]}" && \

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -62,7 +62,10 @@ declare -p \${NEW_ENV[@]} >> "${bwrapenv}"
 declare -pf >> "${bwrapenv}"
 echo > "${safeenv}"
 for i in {pkgname,repology,pkgver,git_pkgver,epoch,source_url,source,depends,makedepends,conflicts,breaks,replaces,gives,pkgdesc,hash,optdepends,ppa,arch,maintainer,pacdeps,patch,PACPATCH,NOBUILDDEP,provides,incompatible,compatible,optinstall,srcdir,url,backup,pkgrel,mask,pac_functions,repo,priority,noextract,nosubmodules,_archive,license,${allsource},${allsums},external_connection}; do
-    [[ -z "\${!i}" ]] || declare -p \$i >> "${safeenv}";
+    if [[ -n "\${!i}" ]]; then
+        declare -p \$i >> "${safeenv}";
+        declare -p \$i >> "${bwrapenv}";
+    fi
 done
 [[ \$name == *'-deb' ]] && for i in {post_install,post_remove,post_upgrade,pre_install,pre_remove,pre_upgrade}; do
     [[ \$(type -t "\$i") == "function" ]] && declare -pf \$i >> "${safeenv}";
@@ -108,10 +111,9 @@ EOF
     fi
     sudo bwrap --unshare-all ${share_net} --die-with-parent --new-session --ro-bind / / \
         --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --dev-bind /dev/null /dev/null \
-        --bind "$STOWDIR" "$STOWDIR" --bind "$PACDIR" "$PACDIR" \
-        --setenv LOGDIR "$LOGDIR" --setenv STGDIR "$STGDIR" \
-        --setenv STOWDIR "$STOWDIR" --setenv pkgdir "$pkgdir" \
-        --setenv _archive "$_archive" --setenv srcdir "$srcdir" \
+        --bind "$STOWDIR" "$STOWDIR" --bind "$PACDIR" "$PACDIR" --setenv LOGDIR "$LOGDIR" \
+        --setenv STGDIR "$STGDIR" --setenv STOWDIR "$STOWDIR" --setenv pkgdir "$pkgdir" \
+        --setenv _archive "$_archive" --setenv srcdir "$srcdir" --setenv git_pkgver "$git_pkgver" \
     "$tmpfile" && sudo rm "$tmpfile"
 }
 

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -72,8 +72,7 @@ done
 EOF
     sudo chmod +x "$tmpfile"
 
-    sudo env - bwrap --unshare-ipc --unshare-pid --unshare-uts \
-        --unshare-cgroup --die-with-parent --new-session --ro-bind / / \
+    sudo env - bwrap --unshare-all --die-with-parent --new-session --ro-bind / / \
         --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --dev-bind /dev/null /dev/null \
         --ro-bind "$input" "$input" --bind "$PACDIR" "$PACDIR" --ro-bind "$tmpfile" "$tmpfile" \
         --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv DISTRO "$DISTRO" --setenv NCPU "$NCPU" \
@@ -86,6 +85,8 @@ function bwrap_function() {
     tmpfile="$(sudo mktemp -p "${PWD}")"
     sudo tee -a "$tmpfile" > /dev/null <<EOF
 #!/bin/bash -a
+shopt -s expand_aliases
+alias sudo=':'
 mapfile -t OLD_ENV < <(compgen -A variable -P "--unset ")
 source ${bwrapenv}
 ${func} 2>&1 "${LOGDIR}/$(printf '%(%Y-%m-%d_%T)T')-$name-$func.log" && FUNCSTATUS="\${PIPESTATUS[0]}" && \
@@ -101,8 +102,7 @@ EOF
     if [[ ! -d ${LOGDIR} ]]; then
         sudo mkdir -p "${LOGDIR}"
     fi
-    sudo bwrap --unshare-ipc --unshare-pid --unshare-uts \
-        --unshare-cgroup --die-with-parent --new-session --ro-bind / / \
+    sudo bwrap --unshare-all --die-with-parent --new-session --ro-bind / / \
         --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --dev-bind /dev/null /dev/null \
         --bind "$STOWDIR" "$STOWDIR" --bind "$PACDIR" "$PACDIR" \
         --setenv LOGDIR "$LOGDIR" --setenv STGDIR "$STGDIR" \

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -45,7 +45,7 @@ function safe_source() {
         done
     done
     allsums="${allsums/%,/}"
-    for allvar in {pkgname,repology,pkgver,git_pkgver,epoch,source_url,source,depends,makedepends,conflicts,breaks,replaces,gives,pkgdesc,hash,optdepends,ppa,arch,maintainer,pacdeps,patch,PACPATCH,NOBUILDDEP,provides,incompatible,compatible,optinstall,srcdir,url,backup,pkgrel,mask,pac_functions,repo,priority,noextract,nosubmodules,_archive,license,${allsource},${allsums},post_install,post_remove,post_upgrade,pre_install,pre_remove,pre_upgrade,prepare,build,check,package}; do
+    for allvar in {pkgname,repology,pkgver,git_pkgver,epoch,source_url,source,depends,makedepends,conflicts,breaks,replaces,gives,pkgdesc,hash,optdepends,ppa,arch,maintainer,pacdeps,patch,PACPATCH,NOBUILDDEP,provides,incompatible,compatible,optinstall,srcdir,url,backup,pkgrel,mask,pac_functions,repo,priority,noextract,nosubmodules,_archive,license,${allsource},${allsums},post_install,post_remove,post_upgrade,pre_install,pre_remove,pre_upgrade,prepare,build,check,package,external_connection}; do
         unset "${allvar}"
     done
 
@@ -61,7 +61,7 @@ mapfile -t NEW_ENV < <(/bin/env -0 \${__OLD_ENV[@]} | \
 declare -p \${NEW_ENV[@]} >> "${bwrapenv}"
 declare -pf >> "${bwrapenv}"
 echo > "${safeenv}"
-for i in {pkgname,repology,pkgver,git_pkgver,epoch,source_url,source,depends,makedepends,conflicts,breaks,replaces,gives,pkgdesc,hash,optdepends,ppa,arch,maintainer,pacdeps,patch,PACPATCH,NOBUILDDEP,provides,incompatible,compatible,optinstall,srcdir,url,backup,pkgrel,mask,pac_functions,repo,priority,noextract,nosubmodules,_archive,license,${allsource},${allsums}}; do
+for i in {pkgname,repology,pkgver,git_pkgver,epoch,source_url,source,depends,makedepends,conflicts,breaks,replaces,gives,pkgdesc,hash,optdepends,ppa,arch,maintainer,pacdeps,patch,PACPATCH,NOBUILDDEP,provides,incompatible,compatible,optinstall,srcdir,url,backup,pkgrel,mask,pac_functions,repo,priority,noextract,nosubmodules,_archive,license,${allsource},${allsums},external_connection}; do
     [[ -z "\${!i}" ]] || declare -p \$i >> "${safeenv}";
 done
 [[ \$name == *'-deb' ]] && for i in {post_install,post_remove,post_upgrade,pre_install,pre_remove,pre_upgrade}; do
@@ -102,7 +102,11 @@ EOF
     if [[ ! -d ${LOGDIR} ]]; then
         sudo mkdir -p "${LOGDIR}"
     fi
-    sudo bwrap --unshare-all --die-with-parent --new-session --ro-bind / / \
+    local share_net
+    if [[ ${external_connection} == "true" ]]; then
+        share_net="--share-net"
+    fi
+    sudo bwrap --unshare-all ${share_net} --die-with-parent --new-session --ro-bind / / \
         --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --dev-bind /dev/null /dev/null \
         --bind "$STOWDIR" "$STOWDIR" --bind "$PACDIR" "$PACDIR" \
         --setenv LOGDIR "$LOGDIR" --setenv STGDIR "$STGDIR" \

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -98,6 +98,10 @@ if ! source "${safeenv}"; then
     clean_fail_down
 fi
 
+if [[ ${external_connection} == "true" ]]; then
+    fancy_message warn "This package will connect to the internet during its build process."
+fi
+
 # Running `-B` on a deb package doesn't make sense, so let's download instead
 if ((PACSTALL_INSTALL == 0)) && [[ ${pkgname} == *-deb ]]; then
     if ! download "${source[0]}"; then


### PR DESCRIPTION
## Purpose

was too lazy to figure this out yesterday ig

this prevents sudo from being useable in `{prepare,build,check,package}`

## Approach

~~alias sudo inside bwrap functions, then we can block net successfully~~ none of these solutions worked what the frick

## Progress

- [x] Do it
- [x] Test it
- [x] Re-add external_connection option from before
- [x] see if `calc_git_pkgver` requires a special rewrapping (it does)

## About pkgver()

- `pkgver()` (or what replaces it) has new restrictions, and we have switched to using it internally. For the output `.deb`, if the package is a `-git`, then the trailing `git_pkgver` will automatically be calculated during cloning (separate from the defined `pkgver` variable); this includes based on any `#branch=`,`#commit=`, or `#tag=` if provided in the source entry. 
- This calculated output is accessible via `${git_pkgver}` to a pacscript, and can be overwritten for the _functions_ in a pacscript (i.e. setting `git_pkgver=` and then using it in for example `package()`), but it will **not** overwrite the outputted `.deb`'s calculated `git_pkgver`.
- Additionally, one can calculate other `git_pkgver`s for usage with other source entries if need be, with:
```bash
parse_source_entry "${source[#]}"
calc_git_pkgver && echo "${comp_git_pkgver}" # echo is just an example of using the var
```
- where `#` is the bash associated number of the array entry, and `comp_git_pkgver` is a dynamic variable that is outputted from a usage of `calc_git_pkgver`, which depends on `parse_source_entry` to determine the git hash info.
- in order to use `calc_git_pkgver` in pacscripts right now (as of this PR), one must define `external_connection="true"`. (idk why this would be used ever)
    - `${git_pkgver}` is still automatically accessible, as it is calculated during cloning
- this all comes with the limitation that it will always be in the same standard format. We should consider expanding the format to also describe tags if they exist, or finding a way to provide options for this. At some point, it may just be best to re-introduce `pkgver()` altogether, if users want to custom define this, so we should discuss.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
