### PR TITLE
fix(upgrade.sh)!: repair old REPOS code

### DIFF
--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -560,6 +560,7 @@ function install_builddepends() {
 function compare_remote_version() {
     local crv_input="${1}" remote_tmp remote_safe
     source "$METADIR/$crv_input" || return 1
+    [[ ${_remoterepo} == "orphan" ]] && _remoterepo="${REPO}"
     if [[ -z ${_remoterepo} ]]; then
         return 0
     elif [[ ${_remoterepo} == *"github.com"* ]]; then

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -209,14 +209,24 @@ elif [[ -n $UPGRADE ]]; then
     REPOS=()
     # Return list of repos with the package
     for IDX in $IDXSEARCH; do
-        ! [[ " ${REPOS[@]} " =~ " ${URLLIST[$IDX]} " ]] && mapfile -t -O"${#REPOS[@]}" REPOS <<< "${URLLIST[$IDX]}"
+        ! array.contains REPOS "${URLLIST[$IDX]}" && mapfile -t -O"${#REPOS[@]}" REPOS <<< "${URLLIST[$IDX]}"
     done
     export REPOS
     return 0
 # Check if its being used for search
 elif [[ -n $SEARCH ]]; then
     for IDX in $IDXSEARCH; do
-        echo -e "$GREEN${PACKAGELIST[$IDX]} $PURPLE@ $CYAN$(parseRepo "${URLLIST[$IDX]}") $NC"
+        searchedrepo="$(parseRepo "${URLLIST[$IDX]}")"
+        if [[ ${URLLIST[$IDX]} == *"github"* ]]; then
+            srBRANCH="${URLLIST[$IDX]##*/}"
+        elif [[ ${URLLIST[$IDX]} == *"gitlab"* ]]; then
+            srBRANCH="${URLLIST[$IDX]##*/-/raw/}"
+        else
+            unset srBRANCH
+        fi
+        [[ -n ${srBRANCH} && ${srBRANCH} != "master" && ${srBRANCH} != "main" ]] && searchedrepo+="${YELLOW}#${srBRANCH}${NC}"
+        echo -e "$GREEN${PACKAGELIST[$IDX]} $PURPLE@ $CYAN${searchedrepo} $NC"
+        unset searchedrepo srBRANCH
     done
     return 0
 # Options left: install or download

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -143,7 +143,7 @@ while IFS= read -r URL; do
             || fancy_message warn "Replace '~' with the full home path on \e]8;;file://$STGDIR/repo/pacstallrepo\a$CYAN$STGDIR/repo/pacstallrepo$NC\e]8;;\a"
         URL="${URL/'~'/$HOME}"
     fi
-    if ! check_url "${URL}/packagelist"; then
+    if [[ ${URL} != "#"* ]] && ! check_url "${URL}/packagelist"; then
         if [[ -z $REPOMSG ]]; then
             fancy_message warn "Skipping repo $CYAN$(parseRepo "${URL}")$NC"
             fancy_message warn "You can remove or fix the URL by editing $CYAN$STGDIR/repo/pacstallrepo$NC"

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -122,7 +122,7 @@ N="$(nproc)"
             else
                 parsedrepo="$(parseRepo "${remoterepo}")"
                 if [[ -n ${remotebranch} ]]; then
-                    parsedrepo+="/${remotebranch}"
+                    parsedrepo+="${YELLOW}#${remotebranch}${NC}"
                 fi
                 [[ ${remoterepo} != "orphan" ]] && fancy_message warn "Package ${GREEN}${i}${NC} is not on ${CYAN}${parsedrepo}${NC} anymore" \
                     && sudo sed -i 's/_remoterepo=".*"/_remoterepo="orphan"/g' "$METADIR/$i" && sudo sed -i '/_remotebranch=/d' "$METADIR/$i"
@@ -172,7 +172,7 @@ N="$(nproc)"
                     echo "$i" | tee -a "${up_list}" > /dev/null
                     updaterepo="$(parseRepo "${remoteurl}")"
                     if [[ -n ${upBRANCH} && ${upBRANCH} != "master" && ${upBRANCH} != "main" ]]; then
-                        updaterepo+="/${upBRANCH}"
+                        updaterepo+="${YELLOW}#${upBRANCH}${NC}"
                     fi
                     printf "\t%s%s%s @ %s%s ( %s%s%s -> %s%s%s )\n" \
                     "${GREEN}" "${i}" "${CYAN}" "${updaterepo}" "${NC}" "${BLUE}" "${localver:-unknown}" "${NC}" "${BLUE}" "${remotever:-unknown}" "${NC}" | tee -a "${up_print}" > /dev/null

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -120,7 +120,7 @@ N="$(nproc)"
                 unset comp_repo_ver
                 remoteurl="${REPOS[$IDXMATCH]}"
             else
-                parsedrepo="$(parseRepo ${remoterepo})"
+                parsedrepo="$(parseRepo "${remoterepo}")"
                 if [[ -n ${remotebranch} ]]; then
                     parsedrepo+="/${remotebranch}"
                 fi
@@ -170,11 +170,11 @@ N="$(nproc)"
             if [[ -n $remotever ]]; then
                 if ver_compare "$localver" "$remotever"; then
                     echo "$i" | tee -a "${up_list}" > /dev/null
-                    updaterepo="$(parseRepo ${remoteurl})"
+                    updaterepo="$(parseRepo "${remoteurl}")"
                     if [[ -n ${upBRANCH} && ${upBRANCH} != "master" && ${upBRANCH} != "main" ]]; then
                         updaterepo+="/${upBRANCH}"
                     fi
-                    echo "\t${GREEN}${i}${CYAN} @ ${updaterepo}${NC} ( ${BLUE}${localver:-unknown}${NC} -> ${BLUE}${remotever:-unknown}${NC} )" | tee -a "${up_print}" > /dev/null
+                    printf "\t${GREEN}${i}${CYAN} @ ${updaterepo}${NC} ( ${BLUE}${localver:-unknown}${NC} -> ${BLUE}${remotever:-unknown}${NC} )\n" | tee -a "${up_print}" > /dev/null
                     echo "$remoteurl" | tee -a "${up_urls}" > /dev/null
                     unset upBRANCH updaterepo
                 fi

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -174,7 +174,8 @@ N="$(nproc)"
                     if [[ -n ${upBRANCH} && ${upBRANCH} != "master" && ${upBRANCH} != "main" ]]; then
                         updaterepo+="/${upBRANCH}"
                     fi
-                    printf "\t${GREEN}${i}${CYAN} @ ${updaterepo}${NC} ( ${BLUE}${localver:-unknown}${NC} -> ${BLUE}${remotever:-unknown}${NC} )\n" | tee -a "${up_print}" > /dev/null
+                    printf "\t%s%s%s @ %s%s ( %s%s%s -> %s%s%s )\n" \
+                    "${GREEN}" "${i}" "${CYAN}" "${updaterepo}" "${NC}" "${BLUE}" "${localver:-unknown}" "${NC}" "${BLUE}" "${remotever:-unknown}" "${NC}" | tee -a "${up_print}" > /dev/null
                     echo "$remoteurl" | tee -a "${up_urls}" > /dev/null
                     unset upBRANCH updaterepo
                 fi


### PR DESCRIPTION
## Purpose

when a package's `_remoterepo` is no longer existent in the `pacstallrepo` file during `-Up`, we are currently removing the repo link from the metadata of the package. This is bad practice, as in the case of simply switching to an updated repo (like `5.0.0-master`), packages are wiped from being updatable until re-installing.

## Approach

- Fix up ancient code regarding `REPOS` + `remoterepo` that was written by someone who was not paying any attention to what they were doing. 
- When a repo mismatch happens, now rather than removing their remoterepo entirely, we are replacing it with the string `_remoterepo="orphan"`, which gives the packages special treatment separate from a `local` install, where they can still be found by `-Up`.
- Also, if a repo was commented out in the `pacstallrepo` file, it would cause `-Up` to break as well - fix that by simply ignoring ones that start with `#`.
- Also, `-git` packages were erroneously getting special treatment, which caused them to have issues compared to the rest of packages for updating. Fixed that, and confirmed they work correctly now.
- Also, if repo is github or gitlab, display branch in outputs. For notification of orphaning, branch info will always be shown. For showing a valid update, branch info will be shown if branch is not `master` or `main`, otherwise it will just show same as before. 

## Progress

- [x] Do it
- [x] Test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
