### PR TITLE
feat(*): add `checkdepends` array

### DIFF
--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -51,7 +51,7 @@ function cleanup() {
     sudo rm -rf "${STOWDIR}/${pkgname:-$PACKAGE}.deb"
     rm -f /tmp/pacstall-select-options
     sudo rm -f "${PACDIR}/bwrapenv.*"
-    unset pkgname repology pkgver git_pkgver epoch source_url source depends makedepends conflicts breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible compatible optinstall srcdir url backup pkgrel mask pac_functions repo priority noextract nosubmodules _archive license bwrapenv safeenv external_connection 2> /dev/null
+    unset pkgname repology pkgver git_pkgver epoch source_url source depends makedepends checkdepends conflicts breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps patch PACPATCH NOBUILDDEP provides incompatible compatible optinstall srcdir url backup pkgrel mask pac_functions repo priority noextract nosubmodules _archive license bwrapenv safeenv external_connection 2> /dev/null
     unset -f pre_install pre_upgrade pre_remove post_install post_upgrade post_remove prepare build check package 2> /dev/null
     sudo rm -f "${pacfile}"
 }

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -562,7 +562,7 @@ function install_deb() {
 
 function repacstall() {
     # shellcheck disable=SC2034
-    local depends_array unpackdir depends_line deper pacgives meper pacdep depends_array_form repac_depends_str upcontrol input_dest="${1}"
+    local depends_array unpackdir depends_line deper pacgives meper ceper pacdep depends_array_form repac_depends_str upcontrol input_dest="${1}"
     unpackdir="${STOWDIR}/${pkgname}"
     upcontrol="${unpackdir}/DEBIAN/control"
     sudo mkdir -p "${unpackdir}"
@@ -588,6 +588,14 @@ function repacstall() {
         for deper in "${depends[@]}"; do
             if ! array.contains depends_array "${deper}"; then
                 depends_array+=("${deper}")
+            fi
+        done
+    fi
+    if [[ -n ${checkdepends[*]} ]]; then
+        # shellcheck disable=SC2076
+        for ceper in "${checkdepends[@]}"; do
+            if ! array.contains depends_array "${ceper}"; then
+                depends_array+=("${ceper}")
             fi
         done
     fi

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -583,19 +583,19 @@ function repacstall() {
             fi
         done
     fi
-    if [[ -n ${depends[*]} ]]; then
-        # shellcheck disable=SC2076
-        for deper in "${depends[@]}"; do
-            if ! array.contains depends_array "${deper}"; then
-                depends_array+=("${deper}")
-            fi
-        done
-    fi
     if [[ -n ${checkdepends[*]} ]] && is_function "check"; then
         # shellcheck disable=SC2076
         for ceper in "${checkdepends[@]}"; do
             if ! array.contains depends_array "${ceper}"; then
                 depends_array+=("${ceper}")
+            fi
+        done
+    fi
+    if [[ -n ${depends[*]} ]]; then
+        # shellcheck disable=SC2076
+        for deper in "${depends[@]}"; do
+            if ! array.contains depends_array "${deper}"; then
+                depends_array+=("${deper}")
             fi
         done
     fi

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -591,7 +591,7 @@ function repacstall() {
             fi
         done
     fi
-    if [[ -n ${checkdepends[*]} ]]; then
+    if [[ -n ${checkdepends[*]} ]] && is_function "check"; then
         # shellcheck disable=SC2076
         for ceper in "${checkdepends[@]}"; do
             if ! array.contains depends_array "${ceper}"; then

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -343,8 +343,12 @@ function makedeb() {
     fi
 
     if [[ -n ${makedepends[*]} ]]; then
+        local builddepends builddepends_str
+        [[ -n ${checkdepends[*]} ]] && makedepends+="${checkdepends[@]}"
+        dep_const.format_control makedepends builddepends
+        dep_const.comma_array builddepends builddepends_str
         # shellcheck disable=SC2001
-        deblog "Build-Depends" "$(sed 's/ /, /g' <<< "${makedepends[@]}")"
+        deblog "Build-Depends" "${builddepends_str}"
     fi
 
     if [[ -n ${provides[*]} ]]; then
@@ -556,7 +560,7 @@ function install_deb() {
 }
 
 function repacstall() {
-    local depends_array unpackdir depends_line deper pacgives meper pacdep repac_depends_str upcontrol input_dest="${1}"
+    local depends_array unpackdir depends_line deper pacgives meper pacdep depends_array_form repac_depends_str upcontrol input_dest="${1}"
     unpackdir="${STOWDIR}/${pkgname}"
     upcontrol="${unpackdir}/DEBIAN/control"
     sudo mkdir -p "${unpackdir}"
@@ -601,7 +605,8 @@ function repacstall() {
             fi
         done
     fi
-    dep_const.comma_array depends_array repac_depends_str
+    dep_const.format_control depends_array depends_array_form
+    dep_const.comma_array depends_array_form repac_depends_str
     sudo sed -i '/^Depends:/d' "${upcontrol}"
     sudo sed -i "/Installed-Size:/a Depends: ${repac_depends_str}" "${upcontrol}"
     sudo sed -i "/Description:/i Modified-By-Pacstall: yes" "${upcontrol}"

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -343,6 +343,7 @@ function makedeb() {
     fi
 
     if [[ -n ${makedepends[*]} ]]; then
+        # shellcheck disable=SC2034
         local builddepends builddepends_str
         [[ -n ${checkdepends[*]} ]] && makedepends+=("${checkdepends[@]}")
         dep_const.format_control makedepends builddepends
@@ -560,6 +561,7 @@ function install_deb() {
 }
 
 function repacstall() {
+    # shellcheck disable=SC2034
     local depends_array unpackdir depends_line deper pacgives meper pacdep depends_array_form repac_depends_str upcontrol input_dest="${1}"
     unpackdir="${STOWDIR}/${pkgname}"
     upcontrol="${unpackdir}/DEBIAN/control"

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -345,7 +345,7 @@ function makedeb() {
     if [[ -n ${makedepends[*]} ]]; then
         # shellcheck disable=SC2034
         local builddepends builddepends_str
-        [[ -n ${checkdepends[*]} ]] && makedepends+=("${checkdepends[@]}")
+        is_function "check" && [[ -n ${checkdepends[*]} ]] && makedepends+=("${checkdepends[@]}")
         dep_const.format_control makedepends builddepends
         dep_const.comma_array builddepends builddepends_str
         # shellcheck disable=SC2001

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -344,7 +344,7 @@ function makedeb() {
 
     if [[ -n ${makedepends[*]} ]]; then
         local builddepends builddepends_str
-        [[ -n ${checkdepends[*]} ]] && makedepends+="${checkdepends[@]}"
+        [[ -n ${checkdepends[*]} ]] && makedepends+=("${checkdepends[@]}")
         dep_const.format_control makedepends builddepends
         dep_const.comma_array builddepends builddepends_str
         # shellcheck disable=SC2001

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -45,7 +45,7 @@ function safe_source() {
         done
     done
     allsums="${allsums/%,/}"
-    for allvar in {pkgname,repology,pkgver,git_pkgver,epoch,source_url,source,depends,makedepends,conflicts,breaks,replaces,gives,pkgdesc,hash,optdepends,ppa,arch,maintainer,pacdeps,patch,PACPATCH,NOBUILDDEP,provides,incompatible,compatible,optinstall,srcdir,url,backup,pkgrel,mask,pac_functions,repo,priority,noextract,nosubmodules,_archive,license,${allsource},${allsums},post_install,post_remove,post_upgrade,pre_install,pre_remove,pre_upgrade,prepare,build,check,package,external_connection}; do
+    for allvar in {pkgname,repology,pkgver,git_pkgver,epoch,source_url,source,depends,makedepends,checkdepends,conflicts,breaks,replaces,gives,pkgdesc,hash,optdepends,ppa,arch,maintainer,pacdeps,patch,PACPATCH,NOBUILDDEP,provides,incompatible,compatible,optinstall,srcdir,url,backup,pkgrel,mask,pac_functions,repo,priority,noextract,nosubmodules,_archive,license,${allsource},${allsums},post_install,post_remove,post_upgrade,pre_install,pre_remove,pre_upgrade,prepare,build,check,package,external_connection}; do
         unset "${allvar}"
     done
 
@@ -61,7 +61,7 @@ mapfile -t NEW_ENV < <(/bin/env -0 \${__OLD_ENV[@]} | \
 declare -p \${NEW_ENV[@]} >> "${bwrapenv}"
 declare -pf >> "${bwrapenv}"
 echo > "${safeenv}"
-for i in {pkgname,repology,pkgver,git_pkgver,epoch,source_url,source,depends,makedepends,conflicts,breaks,replaces,gives,pkgdesc,hash,optdepends,ppa,arch,maintainer,pacdeps,patch,PACPATCH,NOBUILDDEP,provides,incompatible,compatible,optinstall,srcdir,url,backup,pkgrel,mask,pac_functions,repo,priority,noextract,nosubmodules,_archive,license,${allsource},${allsums},external_connection}; do
+for i in {pkgname,repology,pkgver,git_pkgver,epoch,source_url,source,depends,makedepends,checkdepends,conflicts,breaks,replaces,gives,pkgdesc,hash,optdepends,ppa,arch,maintainer,pacdeps,patch,PACPATCH,NOBUILDDEP,provides,incompatible,compatible,optinstall,srcdir,url,backup,pkgrel,mask,pac_functions,repo,priority,noextract,nosubmodules,_archive,license,${allsource},${allsums},external_connection}; do
     if [[ -n "\${!i}" ]]; then
         declare -p \$i >> "${safeenv}";
         declare -p \$i >> "${bwrapenv}";

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -216,7 +216,7 @@ function lint_pipe_check() {
 
 function lint_deps() {
     local dep_type dep_array ret=0 dep idx
-    for dep_type in "depends" "makedepends" "optdepends" "pacdeps"; do
+    for dep_type in "depends" "makedepends" "optdepends" "checkdepends" "pacdeps"; do
         idx=0
         local -n dep_array="${dep_type}"
         if [[ -n ${dep_array[*]} ]]; then

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -552,7 +552,8 @@ function install_builddepends() {
             dep_const.format_control not_installed_yet_builddepends bdeps_array
             dep_const.comma_array bdeps_array bdeps_form
             fancy_message info "${BLUE}$pkgname${NC} requires ${CYAN}${not_installed_yet_builddepends[*]}${NC} to install"
-            if ! sudo apt-get satisfy -y "${bdeps_form}"; then
+            sudo apt-get update -yq \
+            && if ! sudo apt-get satisfy -y "${bdeps_form}"; then
                 fancy_message error "Failed to install build dependencies"
                 error_log 8 "install $PACKAGE"
                 clean_fail_down
@@ -575,7 +576,8 @@ function install_checkdepends() {
             dep_const.format_control not_installed_yet_checkdepends cdeps_array
             dep_const.comma_array cdeps_array cdeps_form
             fancy_message info "${BLUE}$pkgname${NC} requires ${CYAN}${not_installed_yet_checkdepends[*]}${NC} to perform checks"
-            if ! sudo apt-get satisfy -y "${cdeps_form}"; then
+            sudo apt-get update -yq \
+            && if ! sudo apt-get satisfy -y "${cdeps_form}"; then
                 fancy_message error "Failed to install check dependencies"
                 error_log 8 "install $PACKAGE"
                 clean_fail_down

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -575,7 +575,7 @@ function install_builddepends() {
     if ((${#not_installed_yet_builddepends[@]} != 0)) || ((${#not_installed_yet_checkdepends[@]} != 0)); then
         fancy_message sub "Fetching apt repositories"
         sudo apt-get update -qq --allow-releaseinfo-change \
-        && if ! sudo apt-get satisfy -yqq "${bdeps_str}"; then
+        && if ! sudo apt-get satisfy -yq "${bdeps_str}"; then
             fancy_message error "Failed to install build or check dependencies"
             error_log 8 "install $PACKAGE"
             clean_fail_down

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -538,6 +538,7 @@ function is_compatible_arch() {
 }
 
 function install_builddepends() {
+    # shellcheck disable=SC2034
     local build_dep not_installed_yet_builddepends bdeps_array bdeps_form
     if [[ -n ${makedepends[*]} ]]; then
         for build_dep in "${makedepends[@]}"; do
@@ -561,6 +562,7 @@ function install_builddepends() {
 }
 
 function install_checkdepends() {
+    # shellcheck disable=SC2034
     local check_dep not_installed_yet_checkdepends cdeps_array cdeps_form
     if [[ -n ${checkdepends[*]} ]]; then
         for check_dep in "${checkdepends[@]}"; do

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -320,7 +320,7 @@ function deb_down() {
             exit 1
         fi
     fi
-    if [[ -n ${pacdeps[*]} || ${depends[*]} || ${makedepends[*]} ]] && repacstall "${dest}" || sudo apt install -y -f ./"${dest}" 2> /dev/null; then
+    if [[ -n ${pacdeps[*]} || ${depends[*]} || ${makedepends[*]} || ${checkdepends[*]} ]] && repacstall "${dest}" || sudo apt install -y -f ./"${dest}" 2> /dev/null; then
         meta_log
         if [[ -f /tmp/pacstall-pacdeps-"$pkgname" ]]; then
             sudo apt-mark auto "${gives:-$pkgname}" 2> /dev/null

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -574,6 +574,7 @@ function install_builddepends() {
     fi
     if ((${#not_installed_yet_builddepends[@]} != 0)) || ((${#not_installed_yet_checkdepends[@]} != 0)); then
         fancy_message sub "Fetching apt repositories"
+        # shellcheck disable=SC2015
         sudo apt-get update -qq --allow-releaseinfo-change \
         && sudo apt-get satisfy -yq "${bdeps_str}" \
         || {

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -554,7 +554,7 @@ function install_builddepends() {
             fancy_message info "${BLUE}$pkgname${NC} requires ${CYAN}${not_installed_yet_builddepends[*]}${NC} to install"
             fancy_message sub "Fetching apt repositories"
             sudo apt-get update -qq --allow-releaseinfo-change \
-            && if ! sudo apt-get satisfy -y "${bdeps_form}"; then
+            && if ! sudo apt-get satisfy -yqq "${bdeps_form}"; then
                 fancy_message error "Failed to install build dependencies"
                 error_log 8 "install $PACKAGE"
                 clean_fail_down
@@ -579,7 +579,7 @@ function install_checkdepends() {
             fancy_message info "${BLUE}$pkgname${NC} requires ${CYAN}${not_installed_yet_checkdepends[*]}${NC} to perform checks"
             fancy_message sub "Fetching apt repositories"
             sudo apt-get update -qq --allow-releaseinfo-change \
-            && if ! sudo apt-get satisfy -y "${cdeps_form}"; then
+            && if ! sudo apt-get satisfy -yqq "${cdeps_form}"; then
                 fancy_message error "Failed to install check dependencies"
                 error_log 8 "install $PACKAGE"
                 clean_fail_down

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -575,11 +575,12 @@ function install_builddepends() {
     if ((${#not_installed_yet_builddepends[@]} != 0)) || ((${#not_installed_yet_checkdepends[@]} != 0)); then
         fancy_message sub "Fetching apt repositories"
         sudo apt-get update -qq --allow-releaseinfo-change \
-        && if ! sudo apt-get satisfy -yq "${bdeps_str}"; then
-            fancy_message error "Failed to install build or check dependencies"
-            error_log 8 "install $PACKAGE"
+        && sudo apt-get satisfy -yq "${bdeps_str}" \
+        || {
+            fancy_message error "Failed to install build or check dependencies";
+            error_log 8 "install $PACKAGE";
             clean_fail_down
-        fi
+        }
     fi
 }
 

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -553,7 +553,7 @@ function install_builddepends() {
             dep_const.comma_array bdeps_array bdeps_form
             fancy_message info "${BLUE}$pkgname${NC} requires ${CYAN}${not_installed_yet_builddepends[*]}${NC} to install"
             fancy_message sub "Fetching apt repositories"
-            sudo apt-get update -yqq \
+            sudo apt-get update -qq --allow-releaseinfo-change \
             && if ! sudo apt-get satisfy -y "${bdeps_form}"; then
                 fancy_message error "Failed to install build dependencies"
                 error_log 8 "install $PACKAGE"
@@ -578,7 +578,7 @@ function install_checkdepends() {
             dep_const.comma_array cdeps_array cdeps_form
             fancy_message info "${BLUE}$pkgname${NC} requires ${CYAN}${not_installed_yet_checkdepends[*]}${NC} to perform checks"
             fancy_message sub "Fetching apt repositories"
-            sudo apt-get update -yqq \
+            sudo apt-get update -qq --allow-releaseinfo-change \
             && if ! sudo apt-get satisfy -y "${cdeps_form}"; then
                 fancy_message error "Failed to install check dependencies"
                 error_log 8 "install $PACKAGE"

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -552,7 +552,8 @@ function install_builddepends() {
             dep_const.format_control not_installed_yet_builddepends bdeps_array
             dep_const.comma_array bdeps_array bdeps_form
             fancy_message info "${BLUE}$pkgname${NC} requires ${CYAN}${not_installed_yet_builddepends[*]}${NC} to install"
-            sudo apt-get update -yq \
+            fancy_message sub "Fetching apt repositories"
+            sudo apt-get update -yqq \
             && if ! sudo apt-get satisfy -y "${bdeps_form}"; then
                 fancy_message error "Failed to install build dependencies"
                 error_log 8 "install $PACKAGE"
@@ -576,7 +577,8 @@ function install_checkdepends() {
             dep_const.format_control not_installed_yet_checkdepends cdeps_array
             dep_const.comma_array cdeps_array cdeps_form
             fancy_message info "${BLUE}$pkgname${NC} requires ${CYAN}${not_installed_yet_checkdepends[*]}${NC} to perform checks"
-            sudo apt-get update -yq \
+            fancy_message sub "Fetching apt repositories"
+            sudo apt-get update -yqq \
             && if ! sudo apt-get satisfy -y "${cdeps_form}"; then
                 fancy_message error "Failed to install check dependencies"
                 error_log 8 "install $PACKAGE"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -317,6 +317,8 @@ install_builddepends
 
 prompt_optdepends || return 1
 
+is_function "check" && install_checkdepends
+
 fancy_message info "Retrieving packages"
 if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
     mkdir -p "/tmp/pacstall-pacdep"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -317,8 +317,6 @@ install_builddepends
 
 prompt_optdepends || return 1
 
-is_function "check" && install_checkdepends
-
 fancy_message info "Retrieving packages"
 if [[ -f /tmp/pacstall-pacdeps-"$PACKAGE" ]]; then
     mkdir -p "/tmp/pacstall-pacdep"

--- a/pacstall
+++ b/pacstall
@@ -490,7 +490,7 @@ function getMasks_offending_pkg() {
 }
 
 # run sudo apt update if it's been more than a week
-[[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -7)" ]] && sudo apt-get update -qq
+[[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -7)" ]] && sudo apt-get update -qq --allow-releaseinfo-change
 
 # shellcheck source=./misc/scripts/error_log.sh
 source "$STGDIR/scripts/error_log.sh"


### PR DESCRIPTION
## Purpose

also fixes makedepends logging with constraints

## Approach

if, and only if, both the `checkdepends` array and the `checks` function are present in the pacscript, then the array will also be considered with installing build depends (though they remain separate when providing output for distinction)
<img width="729" alt="Screenshot 2024-04-06 at 5 51 37 PM" src="https://github.com/pacstall/pacstall/assets/104327997/88e8b0bb-fff6-4035-8198-93acb8d661e0">
<img width="436" alt="Screenshot 2024-04-06 at 5 52 03 PM" src="https://github.com/pacstall/pacstall/assets/104327997/347438b8-f8b7-43b7-8158-552502d9168e">
<img width="503" alt="Screenshot 2024-04-06 at 5 52 13 PM" src="https://github.com/pacstall/pacstall/assets/104327997/b9195f26-4440-4d98-9b5d-0e49dc6b233f">

## Progress

<!--Make a checklist of your progress-->

- [x] do it
- [x] test it

## Addendum

<!--Link any issues with this PR and/or write something that you want to inform us about (optional)-->

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
