### PR TITLE
feat(*): add many more `var_CARCH` style arrays

### DIFF
--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -35,7 +35,7 @@ function safe_source() {
     tmpfile="$(sudo mktemp -p "${PACDIR}")"
     local allsource allsums allvar src sum a_sum known_hashsums_src=("b2" "sha512" "sha384" "sha256" "sha224" "sha1" "md5") known_archs_src=("amd64" "arm64" "armel" "armhf" "i386" "mips64el" "ppc64el" "riscv64" "s390x")
     for src in "${known_archs_src[@]}"; do
-        for vars in {source,depends,makedepends,optdepends,pacdeps,checkdepends,provides,conflicts,breaks,replaces}; do
+        for vars in {source,depends,makedepends,optdepends,pacdeps,checkdepends,provides,conflicts,breaks,replaces,gives}; do
             allsource+="${vars}_${src},"
         done
     done

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -35,7 +35,9 @@ function safe_source() {
     tmpfile="$(sudo mktemp -p "${PACDIR}")"
     local allsource allsums allvar src sum a_sum known_hashsums_src=("b2" "sha512" "sha384" "sha256" "sha224" "sha1" "md5") known_archs_src=("amd64" "arm64" "armel" "armhf" "i386" "mips64el" "ppc64el" "riscv64" "s390x")
     for src in "${known_archs_src[@]}"; do
-        allsource+="source_${src},"
+        for vars in {source,depends,makedepends,optdepends,pacdeps,checkdepends,provides,conflicts,breaks,replaces}; do
+            allsource+="${vars}_${src},"
+        done
     done
     allsource="${allsource/%,/}"
     for sum in "${known_hashsums_src[@]}"; do

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -144,8 +144,7 @@ function lint_source_deb_test() {
 }
 
 function lint_source() {
-    local ret=0 test_source has_source=0 known_archs_source=()
-    mapfile -t known_archs_source < <(dpkg-architecture --list-known)
+    local ret=0 test_source has_source=0 known_archs_source=("amd64" "arm64" "armel" "armhf" "i386" "mips64el" "ppc64el" "riscv64" "s390x")
     for i in "${!known_archs_source[@]}"; do
         # shellcheck disable=SC2004
         known_archs_source[$i]=${known_archs_source[$i]//-/_}
@@ -171,7 +170,7 @@ function lint_source() {
     else
         for sarch in "${known_archs_source[@]}"; do
             local source_arch="source_${sarch}[@]"
-            if [[ -n ${!source_arch} ]]; then
+            [[ ${sarch} != "${CARCH}" ]] && if [[ -n ${!source_arch} ]]; then
                 test_source=()
                 if [[ -n ${source[0]} ]]; then
                     # shellcheck disable=SC2206
@@ -235,7 +234,7 @@ function lint_deps() {
         local -n type_array="${dep_type}"
         dep_array=("${type_array[@]}")
         for kdarch in "${known_archs_deps[@]}"; do
-            lint_var_arch "${dep_type}" "${kdarch}"
+            [[ ${kdarch} != "${CARCH}" ]] && lint_var_arch "${dep_type}" "${kdarch}"
         done
         idx=0
         if [[ -n ${dep_array[*]} ]]; then
@@ -302,7 +301,7 @@ function lint_relations() {
         local -n rtype_array="${rel_type}"
         rel_array=("${rtype_array[@]}")
         for rdarch in "${known_archs_rel[@]}"; do
-            lint_var_arch "${rel_type}" "${rdarch}"
+            [[ ${rdarch} != "${CARCH}" ]] && lint_var_arch "${rel_type}" "${rdarch}"
         done
         idx=0
         if [[ -n ${rel_array[*]} ]]; then
@@ -347,7 +346,7 @@ function lint_hash() {
         test_hashsum_style="${test_hashsum_type}sums[*]"
         for harch in "${known_archs_hash[@]}"; do
             test_hash_arch="${test_hashsum_type}sums_${harch}[*]"
-            if [[ -n ${!test_hash_arch} ]]; then
+            [[ ${harch} != "${CARCH}" ]] && if [[ -n ${!test_hash_arch} ]]; then
                 if [[ -z ${!test_hashsum_style} && -z ${test_hash[*]} ]]; then
                     if [[ -z ${test_hashsum_method} ]]; then
                         # shellcheck disable=SC2206

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -210,15 +210,34 @@ function lint_maintainer() {
     return 0
 }
 
+function lint_var_arch() {
+    local tinp tinputvar="${1}" tinputvar_array="${1}[*]" tinputvar_arch="${1}_${2}[*]"
+    declare -n test_ref_inputvar="test_${tinputvar}"
+    if [[ -n ${!tinputvar_arch} ]]; then
+        for tinp in ${!tinputvar_arch}; do
+            if [[ -z ${!tinputvar_array} ]]; then
+                test_ref_inputvar=("${tinp}")
+            elif ! array.contains ref_inputvar "${tinp}"; then
+                test_ref_inputvar+=("${tinp}")
+            fi
+        done
+    fi
+}
+
 function lint_pipe_check() {
     perl -ne 'exit 1 unless /^(?:[^\s|:]+(?::[^\s|:]+)?\s\|\s)+[^\s|:]+(?::[^\s|:]+)?(?::\s[^|:]+)?(?<!\s)$/' <<< "$1"
 }
 
 function lint_deps() {
-    local dep_type dep_array ret=0 dep idx
+    local dep_type dep_array ret=0 dep idx kdarch known_archs_deps=("amd64" "arm64" "armel" "armhf" "i386" "mips64el" "ppc64el" "riscv64" "s390x")
     for dep_type in "depends" "makedepends" "optdepends" "checkdepends" "pacdeps"; do
+        local -n dep_array="test_${dep_type}"
+        local -n type_array="${dep_type}"
+        dep_array=("${type_array[@]}")
+        for kdarch in "${known_archs_deps[@]}"; do
+            lint_var_arch "${dep_type}" "${kdarch}"
+        done
         idx=0
-        local -n dep_array="${dep_type}"
         if [[ -n ${dep_array[*]} ]]; then
             for dep in "${dep_array[@]}"; do
                 if [[ -z ${dep} ]]; then
@@ -276,45 +295,29 @@ function lint_ppa() {
     return "${ret}"
 }
 
-function lint_conflicts() {
-    local ret=0 conflict idx=0
-    if [[ -n ${conflicts[*]} ]]; then
-        for conflict in "${conflicts[@]}"; do
-            if [[ -z ${conflict} ]]; then
-                fancy_message error "'conflicts' index '${idx}' cannot be empty"
-                ret=1
-            fi
-            ((idx++))
+function lint_relations() {
+    local rel_type rel_array ret=0 rela idx rdarch known_archs_rel=("amd64" "arm64" "armel" "armhf" "i386" "mips64el" "ppc64el" "riscv64" "s390x")
+    for rel_type in "conflicts" "breaks" "replaces" "provides"; do
+        local -n rel_array="test_${rel_type}"
+        local -n rtype_array="${rel_type}"
+        rel_array=("${rtype_array[@]}")
+        for rdarch in "${known_archs_rel[@]}"; do
+            lint_var_arch "${rel_type}" "${rdarch}"
         done
-    fi
-    return "${ret}"
-}
-
-function lint_breaks() {
-    local ret=0 break idx=0
-    if [[ -n ${breaks[*]} ]]; then
-        for break in "${breaks[@]}"; do
-            if [[ -z ${break} ]]; then
-                fancy_message error "'breaks' index '${idx}' cannot be empty"
-                ret=1
-            fi
-            ((idx++))
-        done
-    fi
-    return "${ret}"
-}
-
-function lint_replaces() {
-    local ret=0 repl idx=0
-    if [[ -n ${replaces[*]} ]]; then
-        for repl in "${replaces[@]}"; do
-            if [[ -z ${repl} ]]; then
-                fancy_message error "'replaces' index '${idx}' cannot be empty"
-                ret=1
-            fi
-            ((idx++))
-        done
-    fi
+        idx=0
+        if [[ -n ${rel_array[*]} ]]; then
+            for rela in "${rel_array[@]}"; do
+                if [[ -z ${rela} ]]; then
+                    fancy_message error "'${rel_type}' index '${idx}' cannot be empty"
+                    ret=1
+                fi
+                ((idx++))
+            done
+        fi
+        if ((ret == 1)); then
+            break
+        fi
+    done
     return "${ret}"
 }
 
@@ -387,34 +390,6 @@ function lint_hash() {
                 ret=1
                 break
             fi
-        done
-    fi
-    return "${ret}"
-}
-
-function lint_patch() {
-    local ret=0 el_patch idx=0
-    if [[ -n ${patch[*]} ]]; then
-        for el_patch in "${patch[@]}"; do
-            if [[ -z ${el_patch} ]]; then
-                fancy_message error "'patch' index '${idx}' cannot be empty"
-                ret=1
-            fi
-            ((idx++))
-        done
-    fi
-    return "${ret}"
-}
-
-function lint_provides() {
-    local ret=0 provide idx=0
-    if [[ -n ${provides[*]} ]]; then
-        for provide in "${provides[@]}"; do
-            if [[ -z ${provide} ]]; then
-                fancy_message error "'provides' index '${idx}' cannot be empty"
-                ret=1
-            fi
-            ((idx++))
         done
     fi
     return "${ret}"
@@ -549,7 +524,7 @@ function lint_license() {
 }
 
 function checks() {
-    local ret=0 check linting_checks=(lint_pkgname lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_deps lint_ppa lint_conflicts lint_breaks lint_replaces lint_hash lint_patch lint_provides lint_incompatible lint_arch lint_mask lint_priority lint_license)
+    local ret=0 check linting_checks=(lint_pkgname lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_deps lint_ppa lint_relations lint_hash lint_provides lint_incompatible lint_arch lint_mask lint_priority lint_license)
     for check in "${linting_checks[@]}"; do
         "${check}" || ret=1
     done

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -524,7 +524,7 @@ function lint_license() {
 }
 
 function checks() {
-    local ret=0 check linting_checks=(lint_pkgname lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_deps lint_ppa lint_relations lint_hash lint_provides lint_incompatible lint_arch lint_mask lint_priority lint_license)
+    local ret=0 check linting_checks=(lint_pkgname lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_deps lint_ppa lint_relations lint_hash lint_incompatible lint_arch lint_mask lint_priority lint_license)
     for check in "${linting_checks[@]}"; do
         "${check}" || ret=1
     done

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -145,10 +145,6 @@ function lint_source_deb_test() {
 
 function lint_source() {
     local ret=0 test_source has_source=0 known_archs_source=("amd64" "arm64" "armel" "armhf" "i386" "mips64el" "ppc64el" "riscv64" "s390x")
-    for i in "${!known_archs_source[@]}"; do
-        # shellcheck disable=SC2004
-        known_archs_source[$i]=${known_archs_source[$i]//-/_}
-    done
     if [[ -n ${source[0]} ]]; then
         has_source=1
     else

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -427,6 +427,20 @@ function append_archAndHash_entry() {
     done
 }
 
+function append_var_arch() {
+    local inp inputvar="${1}" inputvar_array="${1}[*]" inputvar_arch="${1}_${2}[*]"
+    declare -n ref_inputvar="${inputvar}"
+    if [[ -n ${!inputvar_arch} ]]; then
+        for inp in ${!inputvar_arch}; do
+            if [[ -z ${!inputvar_array} ]]; then
+                ref_inputvar=("${inp}")
+            elif ! array.contains ref_inputvar "${inp}"; then
+                ref_inputvar+=("${inp}")
+            fi
+        done
+    fi
+}
+
 function calc_distro() {
     distro_name="$(lsb_release -si 2> /dev/null)"
     distro_name="${distro_name,,}"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -106,6 +106,8 @@ append_archAndHash_entry
 for i in {depends,makedepends,optdepends,pacdeps,checkdepends,provides,conflicts,breaks,replaces}; do
   append_var_arch "${i}" "${CARCH}"
 done
+gives_arch="gives_${CARCH}"
+[[ -n ${!gives_arch} && -z ${gives} ]] && gives="${!gives_arch}"
 
 # Running `-B` on a deb package doesn't make sense, so let's download instead
 if ((PACSTALL_INSTALL == 0)) && [[ ${pkgname} == *-deb ]]; then

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -102,6 +102,11 @@ if [[ ${external_connection} == "true" ]]; then
     fancy_message warn "This package will connect to the internet during its build process."
 fi
 
+append_archAndHash_entry
+for i in {depends,makedepends,optdepends,pacdeps,checkdepends,provides,conflicts,breaks,replaces}; do
+  append_var_arch "${i}" "${CARCH}"
+done
+
 # Running `-B` on a deb package doesn't make sense, so let's download instead
 if ((PACSTALL_INSTALL == 0)) && [[ ${pkgname} == *-deb ]]; then
     if ! download "${source[0]}"; then
@@ -286,7 +291,6 @@ fi
 
 unset dest_list
 declare -A dest_list
-append_archAndHash_entry
 for i in "${!source[@]}"; do
     parse_source_entry "${source[$i]}"
     dest="${dest%.git}"


### PR DESCRIPTION
## Purpose

PKGBUILDs provide `_architecture` extensions for all these arrays, so we should too

## Approach

make a new function that can loop through them dynamically, and append them to the main array
here's everything that gets the treatment:
- `source` (already had)
- `*sums` (already had)
- `depends`
- `makedepends`
- `optdepends`
- `pacdeps`
- `checkdepends`
- `provides`
- `conflicts`
- `breaks`
- `replaces`
- `gives` is also added, but is treated as a single string instead of an array; so if `gives` is absent but `gives_CARCH` is present, then `gives` becomes that.

These are the architectures we support (the current "officially supported" [Debian ports](https://www.debian.org/ports/)):
- `amd64`
- `arm64`
- `armel`
- `armhf`
- `i386`
- `mips64el`
- `ppc64el`
- `riscv64`
- `s390x`

## Progress

- [x] Do it
- [x] Test it 

## Addendum

<!--Link any issues with this PR and/or write something that you want to inform us about (optional)-->

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
