### PR TITLE
fix(*): adjust `PACSTALL_PAYLOAD` to be array compatible

### DIFF
--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -363,7 +363,7 @@ function file_down() {
     # shellcheck disable=SC2031
     cp -r "${source_url}" "${dest}" || fail_down
     genextr_declare
-    if [[ ${pkgname} == *"-deb" ]]; then
+    if [[ ${dest} == *".deb" ]]; then
         deb_down
     elif [[ -n ${ext_method} ]]; then
         genextr_down

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -179,11 +179,7 @@ function fail_down() {
 
 function gather_down() {
     if [[ -z ${srcdir} ]]; then
-        if [[ -n $PACSTALL_PAYLOAD ]]; then
-            export srcdir="/tmp/pacstall-pacdep"
-        else
-            export srcdir="${PACDIR}/${PACKAGE}~${pkgver}"
-        fi
+        export srcdir="${PACDIR}/${PACKAGE}~${pkgver}"
     fi
     mkdir -p "${srcdir}"
     cd "${srcdir}" || {

--- a/misc/scripts/download-local.sh
+++ b/misc/scripts/download-local.sh
@@ -363,7 +363,9 @@ function file_down() {
     # shellcheck disable=SC2031
     cp -r "${source_url}" "${dest}" || fail_down
     genextr_declare
-    if [[ -n ${ext_method} ]]; then
+    if [[ ${pkgname} == *"-deb" ]]; then
+        deb_down
+    elif [[ -n ${ext_method} ]]; then
         genextr_down
     elif [[ ${source[i]} == "${source[0]}" && -d ${dest} ]]; then
         # cd in

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -345,7 +345,7 @@ gather_down
 
 unset payload_arr
 if [[ -n $PACSTALL_PAYLOAD && ! -f "/tmp/pacstall-pacdeps-$PACKAGE" ]]; then
-    IFS=$'\n' read -rd '' -a payload_arr <<< "$(awk -v RS=';:' '{if (NF) print $0}' <<< $PACSTALL_PAYLOAD)"
+    IFS=$'\n' read -rd '' -a payload_arr <<< "$(awk -v RS=';:' '{if (NF) print $0}' <<< "${PACSTALL_PAYLOAD}")"
 fi
 
 for i in "${!source[@]}"; do

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -345,7 +345,7 @@ gather_down
 
 unset payload_arr
 if [[ -n $PACSTALL_PAYLOAD && ! -f "/tmp/pacstall-pacdeps-$PACKAGE" ]]; then
-    read -ra payload_arr <<< $(awk -v RS=';:' -v ORS=' ' '{print $0}' <<< "$PACSTALL_PAYLOAD")
+    IFS=$'\n' read -rd '' -a payload_arr <<< "$(awk -v RS=';:' '{if (NF) print $0}' <<< $PACSTALL_PAYLOAD)"
 fi
 
 for i in "${!source[@]}"; do

--- a/pacstall
+++ b/pacstall
@@ -560,17 +560,6 @@ while lock $1 $2 $3 $4; do
 done
 unset first
 
-if [[ -n $PACSTALL_PAYLOAD && ! -f "/tmp/pacstall-pacdeps-$PACKAGE" ]]; then
-    export PACSTALL_DOWNLOADER="payload"
-
-    if [[ ! -f $PACSTALL_PAYLOAD ]]; then
-        fancy_message error "Payload not found"
-        exit 1
-    fi
-    mkdir -p "${PACDIR:?}"
-    cp "$PACSTALL_PAYLOAD" "${PACDIR:?}"
-fi
-
 while [[ $1 != "--" ]]; do
     case "$1" in
         -P | --disable-prompts)
@@ -687,6 +676,14 @@ Helpful links:
                     if [[ -z $PACKAGE ]]; then
                         fancy_message error "You failed to specify a package"
                         exit 1
+                    fi
+
+                    if [[ -n $PACSTALL_PAYLOAD && ! -f "/tmp/pacstall-pacdeps-$PACKAGE" ]]; then
+                        export PACSTALL_DOWNLOADER="payload"
+                        if [[ ! -f $PACSTALL_PAYLOAD ]]; then
+                            fancy_message error "Payload not found"
+                            exit 1
+                        fi
                     fi
 
                     # Make the directory if not exist


### PR DESCRIPTION
## Purpose

it doesnt work rn with 5.0.0

## Approach

let `PACSTALL_PAYLOAD` still be a string, that can pass `;:` (semicolon first) as a delimiter, which pacstall can then split into an array.
utilize our new `file://` download function that copies local stuff, and inject it into payload array urls

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
