### PR TITLE
fix(install-local): reenable prompts on pacdeps when prompts are not disabled

### DIFF
--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -207,6 +207,8 @@ if [[ -n $pacdeps ]]; then
         cmd="-I"
         [[ $KEEP ]] && cmd+="K"
         [[ $DISABLE_PROMPTS == "yes" ]] && cmd+="P"
+        [[ $NOCHECK ]] && cmd+="Nc" 
+        ((PACSTALL_INSTALL == 0)) && cmd+="B"
 
         if pacstall -S "${i}@${REPO}" &> /dev/null; then
             repo="@${REPO}"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -224,7 +224,7 @@ if [[ -n $pacdeps ]]; then
             else
                 fancy_message info "The pacstall dependency ${i} is already installed and at latest version"
             fi
-        elif fancy_message info "Installing $i" && ! pacstall "$cmd" "${i}${repo}"; then
+        elif fancy_message info "Installing dependency ${PURPLE}${i}${NC}" && ! pacstall "$cmd" "${i}${repo}"; then
             fancy_message error "Failed to install dependency (${i} from ${PACKAGE})"
             error_log 8 "install $PACKAGE"
             clean_fail_down

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -208,7 +208,6 @@ if [[ -n $pacdeps ]]; then
         [[ $KEEP ]] && cmd+="K"
         [[ $DISABLE_PROMPTS == "yes" ]] && cmd+="P"
         [[ $NOCHECK ]] && cmd+="Nc"
-        ((PACSTALL_INSTALL == 0)) && cmd+="B"
 
         if pacstall -S "${i}@${REPO}" &> /dev/null; then
             repo="@${REPO}"

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -205,9 +205,9 @@ if [[ -n $pacdeps ]]; then
         touch "/tmp/pacstall-pacdeps-$i"
 
         cmd="-I"
-        [[ $KEEP ]] && cmd+="K"        
+        [[ $KEEP ]] && cmd+="K"
         [[ $DISABLE_PROMPTS == "yes" ]] && cmd+="P"
-        
+
         if pacstall -S "${i}@${REPO}" &> /dev/null; then
             repo="@${REPO}"
         fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -204,7 +204,10 @@ if [[ -n $pacdeps ]]; then
         # If /tmp/pacstall-pacdeps-"$i" is available, it will trigger the logger to log it as a dependency
         touch "/tmp/pacstall-pacdeps-$i"
 
-        [[ $KEEP ]] && cmd="-KPI" || cmd="-PI"
+        cmd="-I"
+        [[ $KEEP ]] && cmd+="K"        
+        [[ $DISABLE_PROMPTS == "yes" ]] && cmd+="P"
+        
         if pacstall -S "${i}@${REPO}" &> /dev/null; then
             repo="@${REPO}"
         fi

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -207,7 +207,7 @@ if [[ -n $pacdeps ]]; then
         cmd="-I"
         [[ $KEEP ]] && cmd+="K"
         [[ $DISABLE_PROMPTS == "yes" ]] && cmd+="P"
-        [[ $NOCHECK ]] && cmd+="Nc" 
+        [[ $NOCHECK ]] && cmd+="Nc"
         ((PACSTALL_INSTALL == 0)) && cmd+="B"
 
         if pacstall -S "${i}@${REPO}" &> /dev/null; then

--- a/pacstall
+++ b/pacstall
@@ -543,17 +543,26 @@ function lock() {
         return 1
     elif [[ $ignore =~ (^|[[:space:]])"$3"($|[[:space:]]) ]]; then
         return 1
+    elif [[ $ignore =~ (^|[[:space:]])"$4"($|[[:space:]]) ]]; then
+        return 1
+    elif [[ $ignore =~ (^|[[:space:]])"$5"($|[[:space:]]) ]]; then
+        return 1
     elif [[ -f "/tmp/pacstall-pacdeps-${2%%@*}" ]]; then
         return 1
     elif [[ -f "/tmp/pacstall-pacdeps-${3%%@*}" ]]; then
         return 1
     elif [[ -f "/tmp/pacstall-pacdeps-${4%%@*}" ]]; then
         return 1
+    elif [[ -f "/tmp/pacstall-pacdeps-${5%%@*}" ]]; then
+        return 1
+    elif [[ -f "/tmp/pacstall-pacdeps-${6%%@*}" ]]; then
+        return 1
+
     fi
     pidof -o %PPID -x "$0" > /dev/null && return 0 || return 1
 }
 
-while lock $1 $2 $3 $4; do
+while lock $1 $2 $3 $4 $5 $6; do
     if [[ -z $first ]]; then
         first=1
         fancy_message warn "Pacstall is already running another instance"

--- a/pacstall
+++ b/pacstall
@@ -543,6 +543,8 @@ function lock() {
         return 1
     elif [[ $ignore =~ (^|[[:space:]])"$3"($|[[:space:]]) ]]; then
         return 1
+    elif [[ -f "/tmp/pacstall-pacdeps-${2%%@*}" ]]; then
+        return 1
     elif [[ -f "/tmp/pacstall-pacdeps-${3%%@*}" ]]; then
         return 1
     elif [[ -f "/tmp/pacstall-pacdeps-${4%%@*}" ]]; then

--- a/pacstall
+++ b/pacstall
@@ -555,14 +555,11 @@ function lock() {
         return 1
     elif [[ -f "/tmp/pacstall-pacdeps-${5%%@*}" ]]; then
         return 1
-    elif [[ -f "/tmp/pacstall-pacdeps-${6%%@*}" ]]; then
-        return 1
-
     fi
     pidof -o %PPID -x "$0" > /dev/null && return 0 || return 1
 }
 
-while lock $1 $2 $3 $4 $5 $6; do
+while lock $1 $2 $3 $4 $5; do
     if [[ -z $first ]]; then
         first=1
         fancy_message warn "Pacstall is already running another instance"


### PR DESCRIPTION
## Purpose

At the moment we disable prompts on pacdeps regardless of the `-P` flag. We should only disable when the flag is used, as this can be a security risk.

## Approach

Check the `$DISABLE_PROMPTS` variable when setting the pacdep installation command.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
