### PR TITLE
fix(*): `-deb` handling

### DIFF
--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -649,6 +649,7 @@ function repacstall() {
 function write_meta() {
     echo "_name=\"$pkgname\""
     echo "_version=\"${full_version}\""
+    [[ -z ${install_size} ]] && install_size="$(apt info -a ${gives:-${pkgname}} 2> /dev/null | awk '/Installed-Size:/ {print; exit}' | sed -e 's/Installed-Size: //g')"
     echo "_install_size=\"${install_size}\""
     printf '_date=\"%(%a %b %_d %r %Z %Y)T\"\n'
     if [[ -n ${maintainer[*]} ]]; then

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -649,7 +649,7 @@ function repacstall() {
 function write_meta() {
     echo "_name=\"$pkgname\""
     echo "_version=\"${full_version}\""
-    [[ -z ${install_size} ]] && install_size="$(apt info -a ${gives:-${pkgname}} 2> /dev/null | awk '/Installed-Size:/ {print; exit}' | sed -e 's/Installed-Size: //g')"
+    [[ -z ${install_size} ]] && install_size="$(apt info -a "${gives:-${pkgname}}" 2> /dev/null | awk '/Installed-Size:/ {print; exit}' | sed -e 's/Installed-Size: //g')"
     echo "_install_size=\"${install_size}\""
     printf '_date=\"%(%a %b %_d %r %Z %Y)T\"\n'
     if [[ -n ${maintainer[*]} ]]; then

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -649,7 +649,7 @@ function repacstall() {
 function write_meta() {
     echo "_name=\"$pkgname\""
     echo "_version=\"${full_version}\""
-    [[ -z ${install_size} ]] && install_size="$(apt info -a "${gives:-${pkgname}}" 2> /dev/null | awk '/Installed-Size:/ {print; exit}' | sed -e 's/Installed-Size: //g')"
+    [[ -z ${install_size} ]] && install_size="$(aptitude search ~i --display-format '%p %I' --sort installsize | awk -v pkg="${gives:-${pkgname}}" '$0 ~ "^" pkg " " {print $2 " " $3}')"
     echo "_install_size=\"${install_size}\""
     printf '_date=\"%(%a %b %_d %r %Z %Y)T\"\n'
     if [[ -n ${maintainer[*]} ]]; then

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -78,11 +78,12 @@ for i in {${allvar_str}}; do
         declare -p \$i >> "${bwrapenv}";
     fi
 done
-[[ \$name == *'-deb' ]] && for i in {${debfunc_str}}; do
+[[ \$pkgname == *'-deb' ]] && for i in {${debfunc_str}}; do
     [[ \$(type -t "\$i") == "function" ]] && declare -pf \$i >> "${safeenv}";
 done || for i in {${debfunc_str},${pacfunc_str}}; do
     [[ \$(type -t "\$i") == "function" ]] && declare -pf \$i >> "${safeenv}";
 done
+export safeenv
 EOF
     sudo chmod +x "$tmpfile"
 

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -183,8 +183,6 @@ if [[ ${pkgname} == *-git ]]; then
     full_version="${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}~git${comp_git_pkgver}"
     git_pkgver="${comp_git_pkgver}"
     export git_pkgver
-elif [[ ${pkgname} == *-deb ]]; then
-    full_version="${epoch+$epoch:}${pkgver}"
 else
     full_version="${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}"
 fi
@@ -384,7 +382,7 @@ for i in "${!source[@]}"; do
             ;;
         *.deb)
             net_down
-            deb_down
+            deb_down && return 0
             ;;
         *.zip | *.tar.gz | *.tgz | *.tar.bz2 | *.tbz2 | *.tar.xz | *.txz | *.tar.zst | *.tzst | *.gz | *.bz2 | *.xz | *.lz | *.lzma | *.zst | *.7z | *.rar | *.lz4 | *.tar)
             net_down

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -50,9 +50,7 @@ function calc_repo_ver() {
     sudo curl -fsSL "$compare_repo/packages/$compare_package/$compare_package.pacscript" -o "${compare_safe}" \
         && safe_source "${compare_safe}" \
         && source "${safeenv}" \
-        && if [[ ${pkgname} == *-deb ]]; then
-            comp_repo_ver="${epoch+$epoch:}${pkgver}"
-        elif [[ ${pkgname} == *-git ]]; then
+        && if [[ ${pkgname} == *-git ]]; then
             parse_source_entry "${source[0]}"
             calc_git_pkgver
             comp_repo_ver="${epoch+$epoch:}${pkgver}-pacstall${pkgrel:-1}~git${comp_git_pkgver}"

--- a/pacstall
+++ b/pacstall
@@ -882,16 +882,7 @@ Helpful links:
                         echo -e "   ${BBlue}gives${NC}        : ${BOLD}${_gives}${NC}"
                     fi
                     echo -e "   ${BBlue}maintainer${NC}   : ${BOLD}${_maintainer:-$(dpkg-query '--showformat=${Maintainer}\n' --show "${_gives:-$_name}")}${NC}"
-                    if [[ ${_name} == *-deb ]]; then
-                        size="$(dpkg-query '--showformat=${Installed-Size}\n' --show "${_gives:-$_name}" | numfmt --to=iec 2> /dev/null)"
-                        if [[ -n ${_size} ]]; then
-                            echo -e "   ${BBlue}size${NC}         : ${BOLD}${size}${NC}"
-                        else
-                            echo -e "   ${BBlue}size${NC}         : ${BOLD}unknown${NC}"
-                        fi
-                    else
-                        echo -e "   ${BBlue}size${NC}         : ${BOLD}${_install_size:-unknown}${NC}"
-                    fi
+                    echo -e "   ${BBlue}size${NC}         : ${BOLD}${_install_size:-unknown}${NC}"
                     echo -e "   ${BBlue}repository${NC}   : ${BOLD}${_remoterepo:-local}${NC}"
                     echo -e "   ${BBlue}install date${NC} : ${BOLD}${_date:-unknown}${NC}"
                     if [[ ${pkg} != "${packages_installed[-1]}" ]]; then


### PR DESCRIPTION
## Purpose

`-deb`s need to work good in 5.0.0

## Approach

- `-deb`s now handle pkgrel
- `-deb`s now properly log installed size
- `-deb`s version checking fixed with -Up
- `-deb`s -Up early exit fixed
- `-deb`s bwrap typo fixed

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
