### PR TITLE
fix(build-local.sh): report `install_size` like `apt info`

### DIFF
--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -529,6 +529,7 @@ function makedeb() {
         local duargs="b" numargs rawsize
 		((estsize<1024)) && { duargs+="h"; numargs="--from=iec --to=si"; } || numargs="--to=si"
 		rawsize="$(sudo du -s${duargs} --exclude=DEBIAN -- "$STOWDIR/$pkgname" | cut -d$'\t' -f1)"
+	    # shellcheck disable=SC2086
 		install_size="$(numfmt ${numargs} --format="%3.2f" "${rawsize}" \
 			| awk '{
 			    if (match($0, /[A-Za-z]+$/)) {

--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -521,7 +521,17 @@ function makedeb() {
     fi
 
     deblog "Installed-Size" "$(sudo du -s --apparent-size --exclude=DEBIAN -- "$STOWDIR/$pkgname" | cut -d$'\t' -f1)"
-    install_size="$(sudo du -s --apparent-size --exclude=DEBIAN -- "$STOWDIR/$pkgname" | cut -d$'\t' -f1 | numfmt --to=iec)"
+    install_size="$(sudo du -sbh --exclude=DEBIAN -- "$STOWDIR/$pkgname" | cut -d$'\t' -f1 | numfmt --from=iec --to=si --format="%3.2f" | awk '{
+        if (match($0, /[A-Za-z]+$/)) {
+            num = sprintf("%.3g", $1);
+            unit = substr($0, RSTART, RLENGTH);
+            if (unit == "K") unit = "k";
+            printf "%s %sB\n", num, unit;
+        } else {
+            num = sprintf("%3.2f", $1);
+            printf "%s B\n", num;
+        }
+    }')"
     export install_size
 
     generate_changelog | sudo tee -a "$STOWDIR/$pkgname/DEBIAN/changelog" > /dev/null


### PR DESCRIPTION
## Purpose

Pacstall metadata reports `install_size` in the same format of `dpkg` control files, which outputs it into unitless bytes, while `apt info` and `aptitude` are smart enough to convert to human readable format.

## Approach

Report `install_size` with the same formatting and conversion as `apt` does.

## Progress

- [x] do it
- [x] test it

## Addendum

Related to https://github.com/pacstall/pacstall/pull/1082

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
