### PR TITLE
fix(upgrade): insane stty 2: electric boogaloo

### DIFF
--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -86,6 +86,7 @@ up_urls="$(mktemp /tmp/XXXXXX-pacstall-up-urls)"
 
 fancy_message sub "Checking versions"
 
+tty_settings=$(stty -g)
 N="$(nproc)"
 (
     for i in "${list[@]}"; do
@@ -180,7 +181,7 @@ N="$(nproc)"
             fi
         ) &
     done
-    wait
+    wait && stty "$tty_settings"
 )
 
 if [[ ! -s ${up_list} ]]; then


### PR DESCRIPTION
## Purpose

Fix insane stty behaviour on ubuntu 22.04  after `pacstall -Up` caused by multiprocess `wait`

## Approach

Same approach as #577

## Progress

It works on my machine

## Addendum

Related to #571

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
