### PR TITLE
fix(checks.sh): fix `source_CARCH` appending

### DIFF
--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -172,7 +172,7 @@ function lint_source() {
                 if [[ -n ${source[0]} ]]; then
                     { (("${#carch_source[@]}"<=1 && "${#source[@]}"<=1)) \
                         && [[ "${carch_source[0]}" == "${source[0]}" ]]; } \
-                    && test_source+=("${source[@]}")
+                    || test_source+=("${source[@]}")
                 fi
                 test_source+=("${!source_arch}")
                 if [[ -n ${test_source[1]} ]]; then

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -165,15 +165,16 @@ function lint_source() {
         ret=1
     else
         for sarch in "${known_archs_source[@]}"; do
-            local source_arch="source_${sarch}[@]"
+            local source_arch="source_${sarch}[@]" raw_carch_source="source_${CARCH}[@]" carch_source
+            carch_source=("${!raw_carch_source}")
             [[ ${sarch} != "${CARCH}" ]] && if [[ -n ${!source_arch} ]]; then
                 test_source=()
                 if [[ -n ${source[0]} ]]; then
-                    # shellcheck disable=SC2206
-                    test_source+=(${source[*]})
+                    { (("${#carch_source[@]}"<=1 && "${#source[@]}"<=1)) \
+                        && [[ "${carch_source[0]}" == "${source[0]}" ]]; } \
+                    && test_source+=("${source[@]}")
                 fi
-                # shellcheck disable=SC2206
-                test_source+=(${!source_arch})
+                test_source+=("${!source_arch}")
                 if [[ -n ${test_source[1]} ]]; then
                     lint_source_deb_test "${test_source[@]}"
                     if ((ret == 1)); then


### PR DESCRIPTION
## Purpose

source_CARCH is appended to source prior to checks being run; when I made that check earlier in develop, this was not the case at the time
so now it’s getting doubled up
but it needs to check if both source and source_CARCH exist and contain debs, and fail out in that instance

## Approach

if source length is <= 1, and if source_CARCH length <= 1, and if source == source_CARCH, dont append it to test_source

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
