### PR TITLE
fix({build,install}-local.sh): break `pacdeps` loops

### DIFF
--- a/misc/scripts/build-local.sh
+++ b/misc/scripts/build-local.sh
@@ -49,6 +49,7 @@ function cleanup() {
         rm -rf /tmp/pacstall-gives
     fi
     sudo rm -rf "${STOWDIR}/${pkgname:-$PACKAGE}.deb"
+    rm -f "/tmp/pacstall-pacparent-$PACKAGE"
     rm -f /tmp/pacstall-select-options
     sudo rm -f "${PACDIR}/bwrapenv.*"
     local clsrc clsum cla_sum arch_vars \

--- a/misc/scripts/install-local.sh
+++ b/misc/scripts/install-local.sh
@@ -198,6 +198,7 @@ if [[ -n $ppa ]]; then
 fi
 
 if [[ -n $pacdeps ]]; then
+    ((${#pacdeps}>=1)) && touch "/tmp/pacstall-pacparent-$PACKAGE"
     for i in "${pacdeps[@]}"; do
         # If /tmp/pacstall-pacdeps-"$i" is available, it will trigger the logger to log it as a dependency
         touch "/tmp/pacstall-pacdeps-$i"
@@ -222,6 +223,8 @@ if [[ -n $pacdeps ]]; then
             else
                 fancy_message info "The pacstall dependency ${i} is already installed and at latest version"
             fi
+        elif [[ -f "/tmp/pacstall-pacparent-$i" ]]; then
+            fancy_message warn "Pacstall dependency loop detected for ${PURPLE}${i}${NC}, delaying install"
         elif fancy_message info "Installing dependency ${PURPLE}${i}${NC}" && ! pacstall "$cmd" "${i}${repo}"; then
             fancy_message error "Failed to install dependency (${i} from ${PACKAGE})"
             error_log 8 "install $PACKAGE"
@@ -230,6 +233,7 @@ if [[ -n $pacdeps ]]; then
         unset repo
         rm -f "/tmp/pacstall-pacdeps-$i"
     done
+    rm -f "/tmp/pacstall-pacparent-$PACKAGE"
 fi
 
 if ! is_package_installed "${pkgname}"; then


### PR DESCRIPTION
## Purpose

if two packages are pacdeps of each other, they will infinitely attempt to install each other, never installing anything.

## Approach

create `/tmp/pacstall-pacparent-$PACKAGE`, and break the loop by checking for the existence of  `/tmp/pacstall-pacparent-$i`, if the package `$i` is not already installed.

## Progress

- [x] do it
- [x] test it
- [ ] make it work fully

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
