### PR TITLE
fix(bwrap): missing vars when running functions

### DIFF
--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -123,6 +123,7 @@ EOF
         --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --dev-bind /dev/null /dev/null \
         --bind "$STOWDIR" "$STOWDIR" --bind "$PACDIR" "$PACDIR" --setenv LOGDIR "$LOGDIR" \
         --setenv STGDIR "$STGDIR" --setenv STOWDIR "$STOWDIR" --setenv pkgdir "$pkgdir" \
+        --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv DISTRO "$DISTRO" --setenv NCPU "$NCPU" \
         --setenv _archive "$_archive" --setenv srcdir "$srcdir" --setenv git_pkgver "$git_pkgver" \
     "$tmpfile" && sudo rm "$tmpfile"
 }

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -123,8 +123,9 @@ EOF
         --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --dev-bind /dev/null /dev/null \
         --bind "$STOWDIR" "$STOWDIR" --bind "$PACDIR" "$PACDIR" --setenv LOGDIR "$LOGDIR" \
         --setenv STGDIR "$STGDIR" --setenv STOWDIR "$STOWDIR" --setenv pkgdir "$pkgdir" \
-        --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv DISTRO "$DISTRO" --setenv NCPU "$NCPU" \
         --setenv _archive "$_archive" --setenv srcdir "$srcdir" --setenv git_pkgver "$git_pkgver" \
+        --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv DISTRO "$DISTRO" --setenv NCPU "$NCPU" \
+        --setenv PACSTALL_USER "$PACSTALL_USER" \
     "$tmpfile" && sudo rm "$tmpfile"
 }
 


### PR DESCRIPTION
## Purpose

We need to pass some extra vars to the bwrap-ed functions.

## Approach

set vars inside bwrap

## Progress

Done.

## Addendum

Fixes anything that uses `$NCPU`, among others

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
