### PR TITLE
fix(version-constraints.sh): drop parantheses in formatting

### DIFF
--- a/misc/scripts/version-constraints.sh
+++ b/misc/scripts/version-constraints.sh
@@ -190,6 +190,8 @@ function dep_const.extract_description() {
 function dep_const.format_version() {
     local str="${1}" const relation pkg_stuff=() constraints=('<=' '>=' '=' '<' '>')
     local -n out_arr="${2}"
+    str="${str/)/}"
+    str="${str/(/}"
     for const in "${constraints[@]}"; do
         if [[ $str == *"${const}"* ]]; then
             if [[ ${const} =~ ^(<|>)$ ]]; then


### PR DESCRIPTION
## Purpose

eifuvi issue with `repacstall`
```bash
Reading package lists... Error!
	[!] ERROR: Failed to install ulauncher-deb deb
dpkg: warning: ignoring request to remove ulauncher-deb which isn't installed
[+] INFO: Cleaning up
```
```
python3:any ( (>= 3.7~)) libgtk-3-0 ( (>= 3.22)) gir1.2-gtk-3.0 gir1.2-webkit2-4.1 | gir1.2-webkit2-4.0 gir1.2-glib-2.0 gir1.2-gdkpixbuf-2.0 python3-gi python3-gi-cairo gobject-introspection gir1.2-gtklayershell-0.1 python3-xlib gir1.2-xapp-1.0 xapps-common
Package: ulauncher
Version: 6.0.0~beta10
```

## Approach

```bash
python3:any (>= 3.7~) libgtk-3-0 (>= 3.22) gir1.2-gtk-3.0 gir1.2-webkit2-4.1 | gir1.2-webkit2-4.0 gir1.2-glib-2.0 gir1.2-gdkpixbuf-2.0 python3-gi python3-gi-cairo gobject-introspection gir1.2-gtklayershell-0.1 python3-xlib gir1.2-xapp-1.0 xapps-common
Package: ulauncher
Version: 6.0.0~beta10
```
oiefvo
kill pars if they exist
hooha

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
