### PR TITLE
fix(main): improve flag-aware lock

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -319,7 +319,7 @@ function download() {
             PACSTALL_DOWNLOADER=curl
         fi
     fi
-    [[ ${PACSTALL_VERBOSE} && ${PACSTALL_DOWNLOADER} != "verbose-"* ]] && PACSTALL_DOWNLOADER="verbose-${PACSTALL_DOWNLOADER}"
+    ${PACSTALL_VERBOSE} && [[ ${PACSTALL_DOWNLOADER} != "verbose-"* ]] && PACSTALL_DOWNLOADER="verbose-${PACSTALL_DOWNLOADER}"
 
     case "$PACSTALL_DOWNLOADER" in
         verbose-axel)

--- a/pacstall
+++ b/pacstall
@@ -604,8 +604,8 @@ while lock $@; do
     sleep 1
 done
 if [[ -n $first ]]; then
-        unset first
-        fancy_message info "The other instance has finished running, unlocking"
+    unset first
+    fancy_message info "The other instance has finished running, unlocking"
 fi
 
 while [[ $1 != "--" ]]; do

--- a/pacstall
+++ b/pacstall
@@ -586,7 +586,11 @@ function lock() {
     done
 
     if [[ -f "/usr/share/pacstall/repo/pacstallrepo.pacstall-qa.bak" ]]; then
-        return 1
+        instances=($(pidof -o %PPID -x "$0"))
+        if [[ ${#instances[@]} -lt 2 ]]; then
+            return 1
+        fi
+        return 0
     fi
 
     pidof -o %PPID -x "$0" > /dev/null && return 0 || return 1

--- a/pacstall
+++ b/pacstall
@@ -661,8 +661,8 @@ Options:
 		Build the deb but do not install.
 	${BOLD}-Nc${NC}, ${BOLD}--nocheck${NC}
 		Skip the check() function if present.
-        ${BOLD}-Q${NC}, ${BOLD}--quiet${NC}
-                Download package entries quietly.
+	${BOLD}-Q${NC}, ${BOLD}--quiet${NC}
+		Download package entries quietly.
 
 Helpful links:
 	${BOLD}https://github.com/pacstall/pacstall${NC}

--- a/pacstall
+++ b/pacstall
@@ -603,7 +603,10 @@ while lock $@; do
     fi
     sleep 1
 done
-unset first
+if [[ -n $first ]]; then
+        unset first
+        fancy_message info "The other instance has finished running, unlocking"
+fi
 
 while [[ $1 != "--" ]]; do
     case "$1" in

--- a/pacstall
+++ b/pacstall
@@ -569,34 +569,30 @@ fi
 unset short_commands long_commands commands matches arguments_list unique_arguments_list hashed_arguments
 
 function lock() {
+    # Total number of options flags, increase when needed
+    local option_flags=5
     local ignore_short="-S -D -A -V -L -Qi -T -h"
     local ignore_long="--search --download --add-repo --version --query-info --tree --help"
     local ignore="$ignore_short $ignore_long"
-    if [[ $ignore =~ (^|[[:space:]])"$1"($|[[:space:]]) ]]; then
-        return 1
-    elif [[ $ignore =~ (^|[[:space:]])"$2"($|[[:space:]]) ]]; then
-        return 1
-    elif [[ $ignore =~ (^|[[:space:]])"$3"($|[[:space:]]) ]]; then
-        return 1
-    elif [[ $ignore =~ (^|[[:space:]])"$4"($|[[:space:]]) ]]; then
-        return 1
-    elif [[ $ignore =~ (^|[[:space:]])"$5"($|[[:space:]]) ]]; then
-        return 1
-    elif [[ -f "/tmp/pacstall-pacdeps-${2%%@*}" ]]; then
-        return 1
-    elif [[ -f "/tmp/pacstall-pacdeps-${3%%@*}" ]]; then
-        return 1
-    elif [[ -f "/tmp/pacstall-pacdeps-${4%%@*}" ]]; then
-        return 1
-    elif [[ -f "/tmp/pacstall-pacdeps-${5%%@*}" ]]; then
-        return 1
-    elif [[ -f "/usr/share/pacstall/repo/pacstallrepo.pacstall-qa.bak" ]]; then
+
+    for ((i=1;i<=option_flags+1;i++)); do
+        if [[ $ignore =~ (^|[[:space:]])"${!i}"($|[[:space:]]) ]]; then
+            return 1
+        fi
+        j=$(( i+1 ))
+        if [[ -f "/tmp/pacstall-pacdeps-${!j%%@*}" ]]; then
+            return 1
+        fi
+    done
+
+    if [[ -f "/usr/share/pacstall/repo/pacstallrepo.pacstall-qa.bak" ]]; then
         return 1
     fi
+
     pidof -o %PPID -x "$0" > /dev/null && return 0 || return 1
 }
 
-while lock $1 $2 $3 $4 $5; do
+while lock $@; do
     if [[ -z $first ]]; then
         first=1
         fancy_message warn "Pacstall is already running another instance"


### PR DESCRIPTION
## Purpose

Fix and improve the broken lock function, since it breaks everytime you guys add a new option flag. Now all you need to do is increase a variable.

## Approach

Make the lock interate over a sequence of numbers, and use indirect expasion to access the args. We currently have `5` option flags. We check if any of the args from `1` to `$option_flags+1` is an ignored command flag, or if any of the args from `2` to `$option_flags+2` is a pacdep, since those are all the possible positions.

## Progress

Done and tested.

## Addendum

Why are there so many option flags?

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
