### PR TITLE
fix(search.sh): repair `pacdeps` updating

### DIFF
--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -25,7 +25,9 @@
 # This script searches for packages in all repos saved on pacstallrepo
 
 if [[ -n $UPGRADE ]]; then
-    PACKAGE="$i"
+    [[ -f /tmp/pacstall-pacdeps-${PACKAGE%@*} ]] \
+    && PACKAGE="${PACKAGE}" \
+    || PACKAGE="$i"
 fi
 
 function getPath() {

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -25,9 +25,7 @@
 # This script searches for packages in all repos saved on pacstallrepo
 
 if [[ -n $UPGRADE ]]; then
-    [[ -f /tmp/pacstall-pacdeps-${PACKAGE%@*} ]] \
-    && PACKAGE="${PACKAGE}" \
-    || PACKAGE="$i"
+    [[ ! -f /tmp/pacstall-pacdeps-${PACKAGE%@*} ]] && PACKAGE="${i}"
 fi
 
 function getPath() {


### PR DESCRIPTION
## Purpose

![image](https://github.com/pacstall/pacstall/assets/104327997/21564033-2fb8-40fa-aea1-7a6fe9aefcb0)

because of 

![image](https://github.com/pacstall/pacstall/assets/104327997/4cddd483-727c-47f4-9491-dd704e748378)

## Approach

for pacdeps, the `PACKAGE` variable is already available, so just check if the pacdeps file exists for it, and keep the variable as that instead of overwriting with `$i`, which is pulled from the upgrade loop for parents.

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
