### PR TITLE
fix(bwrap): dns resolution in the sandbox

### DIFF
--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -117,12 +117,13 @@ EOF
     if [[ ! -d ${LOGDIR} ]]; then
         sudo mkdir -p "${LOGDIR}"
     fi
-    local share_net
+    local share_net dns_resolve
     if [[ ${external_connection} == "true" ]]; then
         share_net="--share-net"
+        dns_resolve="--ro-bind /run/systemd/resolve /run/systemd/resolve"
     fi
     sudo bwrap --unshare-all ${share_net} --die-with-parent --new-session --ro-bind / / \
-        --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --dev-bind /dev/null /dev/null \
+        --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run ${dns_resolve} --dev-bind /dev/null /dev/null \
         --bind "$STAGEDIR" "$STAGEDIR" --bind "$PACDIR" "$PACDIR" --setenv LOGDIR "$LOGDIR" \
         --setenv SCRIPTDIR "$SCRIPTDIR" --setenv STAGEDIR "$STAGEDIR" --setenv pkgdir "$pkgdir" \
         --setenv _archive "$_archive" --setenv srcdir "$srcdir" --setenv git_pkgver "$git_pkgver" \

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -122,6 +122,7 @@ EOF
         share_net="--share-net"
         dns_resolve="--ro-bind /run/systemd/resolve /run/systemd/resolve"
     fi
+    # shellcheck disable=SC2086
     sudo bwrap --unshare-all ${share_net} --die-with-parent --new-session --ro-bind / / \
         --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run ${dns_resolve} --dev-bind /dev/null /dev/null \
         --bind "$STAGEDIR" "$STAGEDIR" --bind "$PACDIR" "$PACDIR" --setenv LOGDIR "$LOGDIR" \

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -125,8 +125,9 @@ EOF
         fi
     fi
     # shellcheck disable=SC2086
-    sudo bwrap --unshare-all ${share_net} --die-with-parent --new-session --ro-bind / / \
-        --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run ${dns_resolve} --dev-bind /dev/null /dev/null \
+    sudo bwrap --unshare-all ${share_net} --die-with-parent --new-session \
+        --ro-bind / / --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run ${dns_resolve} \
+        --dev-bind /dev/null /dev/null --tmpfs /root --tmpfs /home \
         --bind "$STAGEDIR" "$STAGEDIR" --bind "$PACDIR" "$PACDIR" --setenv LOGDIR "$LOGDIR" \
         --setenv SCRIPTDIR "$SCRIPTDIR" --setenv STAGEDIR "$STAGEDIR" --setenv pkgdir "$pkgdir" \
         --setenv _archive "$_archive" --setenv srcdir "$srcdir" --setenv git_pkgver "$git_pkgver" \

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -120,7 +120,9 @@ EOF
     local share_net dns_resolve
     if [[ ${external_connection} == "true" ]]; then
         share_net="--share-net"
-        dns_resolve="--ro-bind /run/systemd/resolve /run/systemd/resolve"
+        if [[ -d "/run/systemd/resolve" ]]; then
+            dns_resolve="--ro-bind /run/systemd/resolve /run/systemd/resolve"
+        fi
     fi
     # shellcheck disable=SC2086
     sudo bwrap --unshare-all ${share_net} --die-with-parent --new-session --ro-bind / / \


### PR DESCRIPTION
## Purpose

Since we tmpfs `/run` with bwrap, dns resolution is borked. So we just need to ro-bind the `/run/systemd/resolve` dir.

## Approach

Add the flag to bwrap

## Progress

Done and tested with cargo packages

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
