### PR TITLE
fix(upgrade): insane stty 3: return of the king

### DIFF
--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -91,7 +91,7 @@ N="$(nproc)"
 (
     for i in "${list[@]}"; do
         ((n = n % N))
-        ((n++ == 0)) && wait
+        ((n++ == 0)) && wait && stty "$tty_settings"
         (
             source "$METADIR/$i"
 


### PR DESCRIPTION
## Purpose

Fix insane stty behaviour on ubuntu 22.04  after `pacstall -Up` caused by multiprocess `wait`

## Approach

Same approach as #577 and #1084

## Progress

It works on my machine

## Addendum

Related to #571. Hopefully this is the last one.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
