### PR TITLE
fix({build,package}.sh): log previously installed pacdeps as such

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -678,9 +678,9 @@ function repacstall() {
 }
 
 function check_if_pacdep() {
-    package="${1}"
-    finddir="${2}"
-    found="$(find "${finddir}" -type f -exec awk -v pkg="${package}" '
+    local package="${1}"
+    local finddir="${2}"
+    local found="$(find "${finddir}" -type f -exec awk -v pkg="${package}" '
         $0 ~ "_pacdeps=\\(\\[" "[0-9]+" "\\]=\"" pkg "\"" {
                 found = 1
         } END {

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -709,7 +709,7 @@ function write_meta() {
     if [[ -n $gives ]]; then
         echo "_gives=\"$gives\""
     fi
-    if [[ -f /tmp/pacstall-pacdeps-"$pkgname" || check_if_pacdep "${pkgname}" "${METADIR}" ]]; then
+    if [[ -f /tmp/pacstall-pacdeps-"$pkgname" ]] || check_if_pacdep "${pkgname}" "${METADIR}"; then
         echo '_pacstall_depends="true"'
     fi
     if [[ $local == 'no' ]]; then

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -677,6 +677,18 @@ function repacstall() {
     install_deb
 }
 
+check_if_pacdep() {
+    package="${1}"
+    finddir="${2}"
+    found="$(find "${finddir}" -type f -exec awk -v pkg="${package}" '
+        $0 ~ "_pacdeps=\\(\\[" "[0-9]+" "\\]=\"" pkg "\"" {
+                found = 1
+        } END {
+                if (!found) {exit 1}
+        }' {} \; -print)"
+    [[ ${found} ]] && return 0 || return 1
+}
+
 function write_meta() {
     echo "_name=\"$pkgname\""
     echo "_version=\"${full_version}\""
@@ -697,7 +709,7 @@ function write_meta() {
     if [[ -n $gives ]]; then
         echo "_gives=\"$gives\""
     fi
-    if [[ -f /tmp/pacstall-pacdeps-"$pkgname" ]]; then
+    if [[ -f /tmp/pacstall-pacdeps-"$pkgname" || check_if_pacdep "${pkgname}" "${METADIR}" ]]; then
         echo '_pacstall_depends="true"'
     fi
     if [[ $local == 'no' ]]; then

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -677,7 +677,7 @@ function repacstall() {
     install_deb
 }
 
-check_if_pacdep() {
+function check_if_pacdep() {
     package="${1}"
     finddir="${2}"
     found="$(find "${finddir}" -type f -exec awk -v pkg="${package}" '

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -678,9 +678,8 @@ function repacstall() {
 }
 
 function check_if_pacdep() {
-    local package="${1}"
-    local finddir="${2}"
-    local found="$(find "${finddir}" -type f -exec awk -v pkg="${package}" '
+    local package="${1}" finddir="${2}" found
+    found="$(find "${finddir}" -type f -exec awk -v pkg="${package}" '
         $0 ~ "_pacdeps=\\(\\[" "[0-9]+" "\\]=\"" pkg "\"" {
                 found = 1
         } END {

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -223,7 +223,7 @@ if [[ -n $pacdeps ]]; then
             else
                 fancy_message info "The pacstall dependency ${i} is already installed and at latest version"
                 if ! awk '/_pacstall_depends="true"/ {found=1; exit} END {if (found != 1) exit 1}' "${METADIR}/${i}"; then
-                    echo '_pacstall_depends="true"' | sudo tee -a "${METADIR}/${i}"
+                    echo '_pacstall_depends="true"' | sudo tee -a "${METADIR}/${i}" > /dev/null
                 fi
             fi
         elif fancy_message info "Installing dependency ${PURPLE}${i}${NC}" && ! pacstall "$cmd" "${i}${repo}"; then

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -222,6 +222,9 @@ if [[ -n $pacdeps ]]; then
                 fi
             else
                 fancy_message info "The pacstall dependency ${i} is already installed and at latest version"
+                if ! awk '/_pacstall_depends="true"/ {found=1; exit} END {if (found != 1) exit 1}' "${METADIR}/${i}"; then
+                    echo '_pacstall_depends="true"' | sudo tee -a "${METADIR}/${i}"
+                fi
             fi
         elif fancy_message info "Installing dependency ${PURPLE}${i}${NC}" && ! pacstall "$cmd" "${i}${repo}"; then
             fancy_message error "Failed to install dependency (${i} from ${PACKAGE})"


### PR DESCRIPTION
## Purpose

if I install a pacdep manually, it loses connection to its parent, and is not properly logged as a pacstall depends in metadata.

## Approach

in build.sh, check if existing metadata lists this package as a pacdep; if so, log it as one. 
in package.sh, if the package is already installed, check if it has the declaration in its metadata; if not, add it

## Progress

- [x] do it
- [x] test it

## Addendum

part of https://github.com/pacstall/pacstall-programs/pull/5986

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
