### PR TITLE
fix(version-constraints.sh): correct parentheses check

### DIFF
--- a/misc/scripts/version-constraints.sh
+++ b/misc/scripts/version-constraints.sh
@@ -199,7 +199,7 @@ function dep_const.format_version() {
                 relation="${const}"
             fi
             dep_const.split_name_and_version "${str}" pkg_stuff
-            if [[ ${str} =~ \(*\)* ]]; then
+            if [[ ${str} =~ \(.+\) ]]; then
                 out_arr+=("${pkg_stuff[0]} ${relation} ${pkg_stuff[1]}")
             else
                 out_arr+=("${pkg_stuff[0]} (${relation} ${pkg_stuff[1]})")


### PR DESCRIPTION
## Purpose

I goofed, the check was always returning positive

## Approach

fix it

```bash
rhino@docker-desktop:~$ str="libc6>=2.38" && [[ ${str} =~ \(.+\) ]] && echo yes
rhino@docker-desktop:~$ str="libc6 (>= 2.38)" && [[ ${str} =~ \(.+\) ]] && echo yes
yes
```


## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
