### PR TITLE
feat(bwrap.sh): `--nosandbox`/`-Ns` flag

### DIFF
--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -70,13 +70,17 @@ done
 export safeenv
 EOF
     sudo chmod +x "$tmpfile"
-
-    sudo env - bwrap --unshare-all --die-with-parent --new-session --ro-bind / / \
-        --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --dev-bind /dev/null /dev/null \
-        --ro-bind "$input" "$input" --bind "$PACDIR" "$PACDIR" --ro-bind "$tmpfile" "$tmpfile" \
-        --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv DISTRO "$DISTRO" --setenv NCPU "$NCPU" \
-        --setenv PACSTALL_USER "$PACSTALL_USER" \
-        "$tmpfile" && sudo rm "$tmpfile"
+    if [[ ${NOSANDBOX} == "true" ]]; then
+        sudo homedir="${homedir}" CARCH="${CARCH}" DISTRO="${DISTRO}" NCPU="${NCPU}" PACSTALL_USER="${PACSTALL_USER}" \
+            "$tmpfile" && sudo rm "$tmpfile"
+    else
+        sudo env - bwrap --unshare-all --die-with-parent --new-session --ro-bind / / \
+            --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --dev-bind /dev/null /dev/null \
+            --ro-bind "$input" "$input" --bind "$PACDIR" "$PACDIR" --ro-bind "$tmpfile" "$tmpfile" \
+            --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv DISTRO "$DISTRO" --setenv NCPU "$NCPU" \
+            --setenv PACSTALL_USER "$PACSTALL_USER" \
+            "$tmpfile" && sudo rm "$tmpfile"
+    fi
 }
 
 function bwrap_function() {
@@ -106,16 +110,23 @@ EOF
             dns_resolve="--ro-bind /run/systemd/resolve /run/systemd/resolve"
         fi
     fi
-    # shellcheck disable=SC2086
-    sudo bwrap --unshare-all ${share_net} --die-with-parent --new-session \
-        --ro-bind / / --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run ${dns_resolve} \
-        --dev-bind /dev/null /dev/null --tmpfs /root --tmpfs /home \
-        --bind "$STAGEDIR" "$STAGEDIR" --bind "$PACDIR" "$PACDIR" --setenv LOGDIR "$LOGDIR" \
-        --setenv SCRIPTDIR "$SCRIPTDIR" --setenv STAGEDIR "$STAGEDIR" --setenv pkgdir "$pkgdir" \
-        --setenv _archive "$_archive" --setenv srcdir "$srcdir" --setenv git_pkgver "$git_pkgver" \
-        --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv DISTRO "$DISTRO" --setenv NCPU "$NCPU" \
-        --setenv PACSTALL_USER "$PACSTALL_USER" \
-        "$tmpfile" && sudo rm "$tmpfile"
+    if [[ ${NOSANDBOX} == "true" ]]; then
+        sudo LOGDIR="${LOGDIR}" SCRIPTDIR="${SCRIPTDIR}" STAGEDIR="${STAGEDIR}" \
+            pkgdir="${pkgdir}" _archive="${_archive}" srcdir="${srcdir}" git_pkgver="${git_pkgver}" \
+            homedir="${homedir}" CARCH="${CARCH}" DISTRO="${DISTRO}" NCPU="${NCPU}" PACSTALL_USER="${PACSTALL_USER}" \
+            "$tmpfile" && sudo rm "$tmpfile"
+    else
+        # shellcheck disable=SC2086
+        sudo bwrap --unshare-all ${share_net} --die-with-parent --new-session \
+            --ro-bind / / --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run ${dns_resolve} \
+            --dev-bind /dev/null /dev/null --tmpfs /root --tmpfs /home \
+            --bind "$STAGEDIR" "$STAGEDIR" --bind "$PACDIR" "$PACDIR" --setenv LOGDIR "$LOGDIR" \
+            --setenv SCRIPTDIR "$SCRIPTDIR" --setenv STAGEDIR "$STAGEDIR" --setenv pkgdir "$pkgdir" \
+            --setenv _archive "$_archive" --setenv srcdir "$srcdir" --setenv git_pkgver "$git_pkgver" \
+            --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv DISTRO "$DISTRO" --setenv NCPU "$NCPU" \
+            --setenv PACSTALL_USER "$PACSTALL_USER" \
+            "$tmpfile" && sudo rm "$tmpfile"
+    fi
 }
 
 # vim:set ft=sh ts=4 sw=4 noet:

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -202,6 +202,7 @@ if [[ -n $pacdeps ]]; then
         [[ $KEEP ]] && cmd+="K"
         [[ $DISABLE_PROMPTS == "yes" ]] && cmd+="P"
         [[ $NOCHECK ]] && cmd+="Nc"
+        [[ $NOSANDBOX ]] && cmd+="Ns"
         ${PACSTALL_VERBOSE} || cmd+="Q"
 
         if pacstall -S "${i}@${REPO}" &> /dev/null; then

--- a/misc/scripts/quality-assurance.sh
+++ b/misc/scripts/quality-assurance.sh
@@ -71,4 +71,5 @@ fancy_message info "Installing ${GREEN}$inst${NC}(${PURPLE}$login${NC}:${RED}$pr
 cmd="-I"
 [[ $KEEP ]] && cmd+="K"
 ((PACSTALL_INSTALL == 0)) && cmd+="B"
+[[ $NOSANDBOX ]] && cmd+="Ns"
 pacstall $cmd "$inst" || exit 1

--- a/pacstall
+++ b/pacstall
@@ -547,7 +547,7 @@ for i in "${@}"; do
     # Just add argument if doesn't start with exactly one hyphen.
     if ! [[ ${i} =~ ^-[^-] ]]; then
         # if argument is '-B', '-P', '-K' or '-Nc', add to beginning of argument list.
-        if [[ ${i} == "--build" || ${i} == "--disable-prompts" || ${i} == "--keep" || ${i} == "--nocheck" || ${i} == "--quiet" ]]; then
+        if [[ ${i} == "--build" || ${i} == "--disable-prompts" || ${i} == "--keep" || ${i} == "--nocheck" || ${i} == "--quiet" || ${i} == "--nosandbox" ]]; then
             argument_list=("${i}" "${argument_list[@]}")
         else
             argument_list+=("${i}")
@@ -560,7 +560,7 @@ for i in "${@}"; do
     # Arguments start with uppercase except 'h'.
     for j in $(sed -E 's/[[:upper:]]|h/ &/g' <<< "${i:1}"); do
         # If current string is 'B', 'P', 'K' or 'Nc', add to beginning of argument list.
-        if [[ ${j} == "B" || ${j} == "P" || ${j} == "K" || ${j} == "Nc" || ${j} == "Q" ]]; then
+        if [[ ${j} == "B" || ${j} == "P" || ${j} == "K" || ${j} == "Nc" || ${j} == "Q" || ${j} == "Ns" ]]; then
             argument_list=("-${j}" "${argument_list[@]}")
         else
             argument_list+=("-${j}")
@@ -575,7 +575,7 @@ declare -A arg_map=(
     ["--add-repo"]="-A" ["--update"]="-U" ["--list"]="-L" ["--upgrade"]="-Up"
     ["--query-info"]="-Qi" ["--tree"]="-T" ["--version"]="-V" ["--help"]="-h"
     ["--build"]="-B" ["--keep"]="-K" ["--disable-prompts"]="-P" ["--nocheck"]="-Nc"
-    ["--quality-assurance"]="-Qa" ["--quiet"]="-Q"
+    ["--quality-assurance"]="-Qa" ["--quiet"]="-Q" ["--nosandbox"]="-Ns"
 )
 declare -A hashed_arguments
 unique_argument_list=()
@@ -657,7 +657,7 @@ while [[ $1 != "--" ]]; do
             ;;
 
         -h | --help)
-            echo -e "Usage: pacstall [-h] {-I,-S,-R,-D,-A,-U,-L,-Up,-Qa,-Qi,-T,-V} [-P] [-K] [-B] [-Nc] [-Q]
+            echo -e "Usage: pacstall [-h] {-I,-S,-R,-D,-A,-U,-L,-Up,-Qa,-Qi,-T,-V} [-P] [-K] [-B] [-Nc] [-Q] [-Ns]
 
 An AUR inspired package manager for Ubuntu.
 
@@ -700,6 +700,8 @@ Options:
 		Skip the check() function if present.
 	${BOLD}-Q${NC}, ${BOLD}--quiet${NC}
 		Download package entries quietly.
+    ${BOLD}-Ns${NC}, ${BOLD}--nosandbox${NC}
+        Build the package without bwrap.
 
 Helpful links:
 	${BOLD}https://github.com/pacstall/pacstall${NC}
@@ -1088,6 +1090,12 @@ Helpful links:
         -Q | --quiet)
             fancy_message info "Downloading package entries quietly"
             PACSTALL_VERBOSE=false
+            ;;
+
+        -Ns | --nosandbox)
+            fancy_message warn "Building package without bwrap sandbox"
+            fancy_message sub "Be cautious, this exposes your system to potentional harm"
+            NOSANDBOX=true
             ;;
 
         *)

--- a/pacstall
+++ b/pacstall
@@ -642,6 +642,9 @@ if [[ -n $first ]]; then
     fancy_message info "The other instance has finished running, unlocking"
 fi
 
+# don't allow nosandbox to be run with envars
+unset NOSANDBOX
+
 while [[ $1 != "--" ]]; do
     case "$1" in
         -P | --disable-prompts)

--- a/pacstall
+++ b/pacstall
@@ -1097,7 +1097,7 @@ Helpful links:
 
         -Ns | --nosandbox)
             fancy_message warn "Building package without bwrap sandbox"
-            fancy_message sub "Be cautious, this exposes your system to potentional harm"
+            fancy_message sub "Be cautious, this exposes your system to potential harm"
             NOSANDBOX=true
             ;;
 


### PR DESCRIPTION
## Purpose

some environments, namely chroot style ones, are purely incompatible with bwrap. one such vital example is rhino linux's ISO builder/debian live-build, which uses chroot.

## Approach

add a flag to allow builds in these environments to skip using bwrap, instead just running as sudo. While this is of course how pacstall worked before 5.0.0, we acknowledge that it is dangerous, and provide a strict warning when the flag is used

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
