### PR TITLE
fix(upgrade.sh): ensure `PACDIR` exists before creating tmps

### DIFF
--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -80,6 +80,7 @@ dep_tree.loop_traits update_order "${list[@]}"
 tput cnorm # Show cursor again
 list=("${update_order[@]}")
 
+mkdir -p "${PACDIR}"
 up_list="$(mktemp /tmp/XXXXXX-pacstall-up-list)"
 up_print="$(mktemp /tmp/XXXXXX-pacstall-up-print)"
 up_urls="$(mktemp /tmp/XXXXXX-pacstall-up-urls)"
@@ -205,7 +206,6 @@ ${BOLD}$(cat "${up_print}")${NC}\n"
     upgrade=("${update_order[@]}")
 
     export local='no'
-    mkdir -p "$PACDIR"
     if ! cd "$PACDIR" 2> /dev/null; then
         error_log 1 "upgrade"
         fancy_message error "Could not enter ${PACDIR}"


### PR DESCRIPTION
## Purpose

![image](https://github.com/pacstall/pacstall/assets/104327997/25b60ccc-67f7-42a8-922d-f7390302b893)

## Approach

move the mkdir

## Addendum

<!--Link any issues with this PR and/or write something that you want to inform us about (optional)-->

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
