### PR TITLE
feat(add-repo.sh): allow `-Rr`/`--remove-repo`

### DIFF
--- a/misc/scripts/add-repo.sh
+++ b/misc/scripts/add-repo.sh
@@ -23,6 +23,7 @@
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
 parse_repo() {
+    local ADDR
     IFS=':' read -ra ADDR <<< "$1"
     PROV="${ADDR[0]}"
     USER=$(echo "${ADDR[1]}" | cut -d'/' -f1)

--- a/misc/scripts/add-repo.sh
+++ b/misc/scripts/add-repo.sh
@@ -75,7 +75,7 @@ esac
 
 case ${REPOCMD} in
     add)
-        ask "Do you want to add \"$REPO\" to the repo list?" N
+        ask "Do you want to add ${CYAN}${REPO}${NC} to the repo list?" Y
         if ((answer == 0)); then
             exit 3
         fi
@@ -91,7 +91,7 @@ case ${REPOCMD} in
         REPOLIST+=("$REPO")
         ;;
     remove)
-        ask "Do you want to remove \"$REPO\" from the repo list?" N
+        ask "Do you want to remove ${CYAN}${REPO}${NC} from the repo list?" Y
         if ((answer == 0)); then
             exit 3
         fi

--- a/misc/scripts/add-repo.sh
+++ b/misc/scripts/add-repo.sh
@@ -22,47 +22,77 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
+parse_repo() {                                  
+    IFS=':' read -ra ADDR <<< "$1"
+    PROV="${ADDR[0]}"
+    USER=$(echo "${ADDR[1]}" | cut -d'/' -f1)
+    HEAD=$(echo "${ADDR[1]}" | cut -d'/' -f2 | cut -d'#' -f1)
+    if [[ ${ADDR[1]} =~ "#" ]]; then
+        BRANCH="$(echo "${ADDR[1]}" | cut -d'#' -f2)"
+    else
+        BRANCH="master"
+        fancy_message warn "Assuming that git branch is ${GREEN}master${NC}"
+    fi
+}
+
 REPO="${2%/}"
 
-if [[ $REPO == *"github.com"* ]]; then
-    REPO="${REPO/'github.com'/'raw.githubusercontent.com'}"
-    if [[ $REPO != *"/tree/"* ]]; then
-        REPO="$REPO/master"
-        fancy_message warn "Assuming that git branch is ${GREEN}master${NC}"
-    else
-        REPO="${URL/'/tree/'/'/'}"
-    fi
-elif [[ $REPO == *"gitlab.com"* ]]; then
-    if [[ $REPO != *"/tree/"* ]]; then
-        REPO="$REPO/-/raw/master"
-        fancy_message warn "Assuming that git branch is ${GREEN}master${NC}"
-    else
-        REPO="${REPO/"/tree/"/"/raw/"}"
-    fi
-elif [[ -d $REPO ]] > /dev/null; then
-    if [[ $REPO != *"file://"* ]]; then
-        REPO="file://$(readlink -f "$REPO")"
-    fi
-else
-    fancy_message warn "The repo link must be the root to the raw files"
-    fancy_message warn "Make sure the repo contains a package list"
+case ${REPO} in
+    *"github.com"*)
+        REPO="${REPO/'github.com'/'raw.githubusercontent.com'}"
+        if [[ $REPO != *"/tree/"* ]]; then
+            REPO="$REPO/master"
+            fancy_message warn "Assuming that git branch is ${GREEN}master${NC}"
+        else
+            REPO="${REPO/'/tree/'/'/'}"
+        fi
+    ;;
+    *"gitlab.com"*)
+        if [[ $REPO != *"/tree/"* ]]; then
+            REPO="$REPO/-/raw/master"
+            fancy_message warn "Assuming that git branch is ${GREEN}master${NC}"
+        else
+            REPO="${REPO/"/tree/"/"/raw/"}"
+        fi
+    ;;
+    *"github:"*)
+        parse_repo "${REPO}"
+        REPO="https://raw.${PROV}usercontent.com/${USER}/${HEAD}/${BRANCH}"
+    ;;
+    *"gitlab:"*)
+        parse_repo "${REPO}"
+        REPO="https://${PROV}.com/${USER}/${HEAD}/-/raw/${BRANCH}"
+    ;;
+    *)
+        [[ ${REPO} == "local:"* ]] && REPO="file://${REPO/local:/}"
+        if [[ -d $REPO ]] > /dev/null; then
+            if [[ $REPO != *"file://"* ]]; then
+                REPO="file://$(readlink -f "$REPO")"
+            fi
+        fi
+    ;;
+esac
 
-    ask "Do you want to add \"$REPO\" to the repo list?" N
-    if ((answer == 0)); then
-        exit 3
-    fi
-fi
-
-if ! curl --head --location -s --fail -- "$REPO/packagelist" > /dev/null; then
-    fancy_message warn "If the URL is a private repo, edit ${CYAN}\e]8;;file://$SCRIPTDIR/repo/pacstallrepo\a$SCRIPTDIR/repo/pacstallrepo\e]8;;\a${NC}"
-    fancy_message error "packagelist file not found"
-    exit 3
-fi
-REPOLIST=()
-while IFS= read -r REPOURL; do
-    REPOLIST+=("${REPOURL}")
-done < "$SCRIPTDIR/repo/pacstallrepo"
-REPOLIST+=("$REPO")
+case ${REPOCMD} in
+    add)
+        if ! curl --head --location -s --fail -- "$REPO/packagelist" > /dev/null; then
+            fancy_message warn "If the URL is a private repo, edit ${CYAN}\e]8;;file://$SCRIPTDIR/repo/pacstallrepo\a$SCRIPTDIR/repo/pacstallrepo\e]8;;\a${NC}"
+            fancy_message error "packagelist file not found"
+            exit 3
+        fi
+        REPOLIST=()
+        while IFS= read -r REPOURL; do
+            REPOLIST+=("${REPOURL}")
+        done < "$SCRIPTDIR/repo/pacstallrepo"
+        REPOLIST+=("$REPO")
+    ;;
+    remove)
+        REPOLIST=()
+        while IFS= read -r REPOURL; do
+            [[ ${REPOURL} != "$REPO" ]] && REPOLIST+=("${REPOURL}")
+        done < "$SCRIPTDIR/repo/pacstallrepo"
+    ;;
+esac
 
 printf "%s\n" "${REPOLIST[@]}" | sort -u | sudo tee "$SCRIPTDIR/repo/pacstallrepo" > /dev/null
 fancy_message info "The repo list has been updated"

--- a/pacstall
+++ b/pacstall
@@ -572,7 +572,7 @@ done
 # Remove duplicates
 declare -A arg_map=(
     ["--install"]="-I" ["--search"]="-S" ["--remove"]="-R" ["--download"]="-D"
-    ["--add-repo"]="-A" ["--update"]="-U" ["--list"]="-L" ["--upgrade"]="-Up"
+    ["--add-repo"]="-A" ["--remove-repo"]="-Rr" ["--update"]="-U" ["--list"]="-L" ["--upgrade"]="-Up"
     ["--query-info"]="-Qi" ["--tree"]="-T" ["--version"]="-V" ["--help"]="-h"
     ["--build"]="-B" ["--keep"]="-K" ["--disable-prompts"]="-P" ["--nocheck"]="-Nc"
     ["--quality-assurance"]="-Qa" ["--quiet"]="-Q" ["--nosandbox"]="-Ns"
@@ -588,8 +588,8 @@ for arg in "${argument_list[@]}"; do
 done
 
 # Check if only one command flag is being used
-short_commands=("-I" "-S" "-R" "-D" "-A" "-U" "-L" "-Up" "-Qi" "-Qa" "-T" "-V" "-h")
-long_commands=("--install" "--search" "--remove" "--download" "--add-repo" "--update" "--list" "--upgrade" "--query-info" "--quality-assurance" "--tree" "--version" "--help")
+short_commands=("-I" "-S" "-R" "-D" "-A" "-Rr" "-U" "-L" "-Up" "-Qi" "-Qa" "-T" "-V" "-h")
+long_commands=("--install" "--search" "--remove" "--download" "--add-repo" "--remove-repo" "--update" "--list" "--upgrade" "--query-info" "--quality-assurance" "--tree" "--version" "--help")
 commands=("${short_commands[@]}" "${long_commands[@]}")
 matches=($(comm -12 <(sort <(printf "%s\n" "${unique_argument_list[@]}")) <(sort <(printf "%s\n" "${commands[@]}"))))
 if ((${#matches[@]} <= 1)); then
@@ -605,8 +605,8 @@ unset short_commands long_commands commands matches arguments_list unique_argume
 function lock() {
     # Total number of options flags, increase when needed
     local option_flags=5
-    local ignore_short="-S -D -A -V -L -Qi -T -h"
-    local ignore_long="--search --download --add-repo --version --query-info --tree --help"
+    local ignore_short="-S -D -A -Rr -V -L -Qi -T -h"
+    local ignore_long="--search --download --add-repo --remove-repo --version --query-info --tree --help"
     local ignore="$ignore_short $ignore_long"
 
     for ((i = 1; i <= option_flags + 1; i++)); do
@@ -660,7 +660,7 @@ while [[ $1 != "--" ]]; do
             ;;
 
         -h | --help)
-            echo -e "Usage: pacstall [-h] {-I,-S,-R,-D,-A,-U,-L,-Up,-Qa,-Qi,-T,-V} [-P] [-K] [-B] [-Nc] [-Q] [-Ns]
+            echo -e "Usage: pacstall [-h] {-I,-S,-R,-D,-A,-Rr,-U,-L,-Up,-Qa,-Qi,-T,-V} [-P] [-K] [-B] [-Nc] [-Q] [-Ns]
 
 An AUR inspired package manager for Ubuntu.
 
@@ -675,6 +675,8 @@ Commands:
 		Download a pacscript.
 	${BOLD}-A${NC}, ${BOLD}--add-repo${NC} <repo>
 		Add a repository.
+    ${BOLD}-Rr${NC}, ${BOLD}--remove-repo${NC} <repo>
+        Remove a repository.
 	${BOLD}-U${NC}, ${BOLD}--update${NC} [user] [branch]
 		Update Pacstall.
 	${BOLD}-L${NC}, ${BOLD}--list${NC}
@@ -859,6 +861,7 @@ Helpful links:
 
         -A | --add-repo)
             REPO="$2"
+            REPOCMD="add"
 
             if [[ ! -f "$SCRIPTDIR/repo/pacstallrepo" ]]; then
                 echo 'https://raw.githubusercontent.com/pacstall/pacstall-programs/master' | sudo tee "$SCRIPTDIR/repo/pacstallrepo" > /dev/null
@@ -871,7 +874,27 @@ Helpful links:
                 exit 0
             else
                 fancy_message error "You failed to specify a repo to add"
-                suggested_solution "Add a repository to your command in the following format:" "'${UCyan}pacstall -A https://github.com/username/repository-name${NC}'" "Consult the pacstall man page by running '${UCyan}man pacstall${NC}', and searching for the term '${UPurple}-A${NC}'"
+                suggested_solution "Add a repository in the following format:" "'${UCyan}pacstall -A https://github.com/username/repository-name${NC}'" "Consult the pacstall man page by running '${UCyan}man pacstall${NC}', and searching for the term '${UPurple}-A${NC}'"
+                exit 1
+            fi
+            ;;
+
+        -Rr | --remove-repo)
+            REPO="$2"
+            REPOCMD="remove"
+
+            if [[ ! -f "$SCRIPTDIR/repo/pacstallrepo" ]]; then
+                echo 'https://raw.githubusercontent.com/pacstall/pacstall-programs/master' | sudo tee "$SCRIPTDIR/repo/pacstallrepo" > /dev/null
+                return 0
+            fi
+
+            if [[ -n $REPO ]]; then
+                # shellcheck source=./misc/scripts/add-repo.sh
+                source "$SCRIPTDIR/scripts/add-repo.sh"
+                exit 0
+            else
+                fancy_message error "You failed to specify a repo to remove"
+                suggested_solution "Remove a repository in the following format:" "'${UCyan}pacstall -Rr https://github.com/username/repository-name${NC}'" "Consult the pacstall man page by running '${UCyan}man pacstall${NC}', and searching for the term '${UPurple}-Rr${NC}'"
                 exit 1
             fi
             ;;


### PR DESCRIPTION
## Purpose

we should allow this tbh

## Approach

just look below

## Progress

- [x] allow `-A`/`--add-repo` to accept metalinks
    - `github:user/repo` (defaults to branch `master`) [also works with provider `gitlab`]
    - `github:user/repo#branch` [also works with provider `gitlab`]
    - `local:/path/to/dir`
- [x] create `-R`/`--remove-repo` that uses same file, but slight reversal process
- ~~**add alias options to call repos**~~ save for 5.2.0

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
