### PR TITLE
feat(*): allow arch-style architecture naming

### DIFF
--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -71,14 +71,14 @@ export safeenv
 EOF
     sudo chmod +x "$tmpfile"
     if [[ ${NOSANDBOX} == "true" ]]; then
-        sudo homedir="${homedir}" CARCH="${CARCH}" DISTRO="${DISTRO}" NCPU="${NCPU}" PACSTALL_USER="${PACSTALL_USER}" \
+        sudo homedir="${homedir}" CARCH="${CARCH}" AARCH="${AARCH}" DISTRO="${DISTRO}" NCPU="${NCPU}" PACSTALL_USER="${PACSTALL_USER}" \
             "$tmpfile" && sudo rm "$tmpfile"
     else
         sudo env - bwrap --unshare-all --die-with-parent --new-session --ro-bind / / \
             --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --dev-bind /dev/null /dev/null \
             --ro-bind "$input" "$input" --bind "$PACDIR" "$PACDIR" --ro-bind "$tmpfile" "$tmpfile" \
             --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv DISTRO "$DISTRO" --setenv NCPU "$NCPU" \
-            --setenv PACSTALL_USER "$PACSTALL_USER" \
+            --setenv PACSTALL_USER "$PACSTALL_USER" --setenv AARCH "$AARCH" \
             "$tmpfile" && sudo rm "$tmpfile"
     fi
 }
@@ -113,7 +113,7 @@ EOF
     if [[ ${NOSANDBOX} == "true" ]]; then
         sudo LOGDIR="${LOGDIR}" SCRIPTDIR="${SCRIPTDIR}" STAGEDIR="${STAGEDIR}" pkgdir="${pkgdir}" _archive="${_archive}" \
             srcdir="${srcdir}" git_pkgver="${git_pkgver}" homedir="${homedir}" CARCH="${CARCH}" DISTRO="${DISTRO}" \
-            NCPU="${NCPU}" PACSTALL_USER="${PACSTALL_USER}" TAR_OPTIONS='--no-same-owner' \
+            NCPU="${NCPU}" PACSTALL_USER="${PACSTALL_USER}" TAR_OPTIONS='--no-same-owner' AARCH="${AARCH}" \
             "$tmpfile" && sudo rm "$tmpfile"
     else
         # shellcheck disable=SC2086
@@ -124,7 +124,7 @@ EOF
             --setenv SCRIPTDIR "$SCRIPTDIR" --setenv STAGEDIR "$STAGEDIR" --setenv pkgdir "$pkgdir" \
             --setenv _archive "$_archive" --setenv srcdir "$srcdir" --setenv git_pkgver "$git_pkgver" \
             --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv DISTRO "$DISTRO" --setenv NCPU "$NCPU" \
-            --setenv PACSTALL_USER "$PACSTALL_USER" --setenv TAR_OPTIONS '--no-same-owner' \
+            --setenv PACSTALL_USER "$PACSTALL_USER" --setenv TAR_OPTIONS '--no-same-owner' --setenv AARCH "$AARCH" \
             "$tmpfile" && sudo rm "$tmpfile"
     fi
 }

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -77,8 +77,8 @@ EOF
         sudo env - bwrap --unshare-all --die-with-parent --new-session --ro-bind / / \
             --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --dev-bind /dev/null /dev/null \
             --ro-bind "$input" "$input" --bind "$PACDIR" "$PACDIR" --ro-bind "$tmpfile" "$tmpfile" \
-            --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv DISTRO "$DISTRO" --setenv NCPU "$NCPU" \
-            --setenv PACSTALL_USER "$PACSTALL_USER" --setenv AARCH "$AARCH" \
+            --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv AARCH "$AARCH" --setenv DISTRO "$DISTRO" \
+            --setenv NCPU "$NCPU" --setenv PACSTALL_USER "$PACSTALL_USER" \
             "$tmpfile" && sudo rm "$tmpfile"
     fi
 }
@@ -112,8 +112,8 @@ EOF
     fi
     if [[ ${NOSANDBOX} == "true" ]]; then
         sudo LOGDIR="${LOGDIR}" SCRIPTDIR="${SCRIPTDIR}" STAGEDIR="${STAGEDIR}" pkgdir="${pkgdir}" _archive="${_archive}" \
-            srcdir="${srcdir}" git_pkgver="${git_pkgver}" homedir="${homedir}" CARCH="${CARCH}" DISTRO="${DISTRO}" \
-            NCPU="${NCPU}" PACSTALL_USER="${PACSTALL_USER}" TAR_OPTIONS='--no-same-owner' AARCH="${AARCH}" \
+            srcdir="${srcdir}" git_pkgver="${git_pkgver}" homedir="${homedir}" CARCH="${CARCH}" AARCH="${AARCH}" \
+            DISTRO="${DISTRO}" NCPU="${NCPU}" PACSTALL_USER="${PACSTALL_USER}" TAR_OPTIONS='--no-same-owner' \
             "$tmpfile" && sudo rm "$tmpfile"
     else
         # shellcheck disable=SC2086
@@ -123,8 +123,8 @@ EOF
             --bind "$STAGEDIR" "$STAGEDIR" --bind "$PACDIR" "$PACDIR" --setenv LOGDIR "$LOGDIR" \
             --setenv SCRIPTDIR "$SCRIPTDIR" --setenv STAGEDIR "$STAGEDIR" --setenv pkgdir "$pkgdir" \
             --setenv _archive "$_archive" --setenv srcdir "$srcdir" --setenv git_pkgver "$git_pkgver" \
-            --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv DISTRO "$DISTRO" --setenv NCPU "$NCPU" \
-            --setenv PACSTALL_USER "$PACSTALL_USER" --setenv TAR_OPTIONS '--no-same-owner' --setenv AARCH "$AARCH" \
+            --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv AARCH "$AARCH" --setenv DISTRO "$DISTRO" \
+            --setenv NCPU "$NCPU" --setenv PACSTALL_USER "$PACSTALL_USER" --setenv TAR_OPTIONS '--no-same-owner' \
             "$tmpfile" && sudo rm "$tmpfile"
     fi
 }

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -494,8 +494,7 @@ function lint_incompatible() {
 function lint_arch() {
     # shellcheck disable=SC2034
     local ret=0 el_arch key idx=0 has_carch=false has_aarch=false known_archs=("any" "all" "${PACSTALL_KNOWN_ARCH[@]}")
-    local -A AARCHS_MAP
-    AARCHS_MAP=(
+    local -A AARCHS_MAP=(
         ["amd64"]="x86_64"
         ["arm64"]="aarch64"
         ["armel"]="arm"

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -161,7 +161,7 @@ function lint_source() {
             fi
         done
     fi
-    local source_host="source_${CARCH}[*]"
+    local source_host="source_${TARCH}[*]"
     if [[ -z ${source[*]} && -z ${!source_host} ]]; then
         has_source=0
     fi
@@ -170,19 +170,19 @@ function lint_source() {
         ret=1
     else
         for sarch in "${PACSTALL_KNOWN_ARCH[@]}" "${PACSTALL_KNOWN_DISTROS[@]}" "${source_distro_archs[@]}"; do
-            local source_arch="source_${sarch}[@]" raw_carch_source="source_${CARCH}[@]" raw_distbase_source="source_${DISTRO%:*}[@]" \
-            raw_distver_source="source_${DISTRO#*:}[@]" raw_distbase_carch_source="source_${DISTRO%:*}_${CARCH}[@]" \
-            raw_distver_carch_source="source_${DISTRO#*:}_${CARCH}[@]" carch_source distbase_source distver_source distbase_carch_source distver_carch_source
+            local source_arch="source_${sarch}[@]" raw_carch_source="source_${TARCH}[@]" raw_distbase_source="source_${DISTRO%:*}[@]" \
+            raw_distver_source="source_${DISTRO#*:}[@]" raw_distbase_carch_source="source_${DISTRO%:*}_${TARCH}[@]" \
+            raw_distver_carch_source="source_${DISTRO#*:}_${TARCH}[@]" carch_source distbase_source distver_source distbase_carch_source distver_carch_source
             carch_source=("${!raw_carch_source}")
             distbase_source=("${!raw_distbase_source}")
             distver_source=("${!raw_distver_source}")
             distbase_carch_source=("${!raw_distbase_carch_source}")
             distver_carch_source=("${!raw_distver_carch_source}")
-            [[ ${sarch} != "${CARCH}"
+            [[ ${sarch} != "${TARCH}"
                 && ${sarch} != "${DISTRO%:*}"
                 && ${sarch} != "${DISTRO#*:}"
-                && ${sarch} != "${DISTRO%:*}_${CARCH}"
-                && ${sarch} != "${DISTRO#*:}_${CARCH}"
+                && ${sarch} != "${DISTRO%:*}_${TARCH}"
+                && ${sarch} != "${DISTRO#*:}_${TARCH}"
             ]] && if [[ -n ${!source_arch} ]]; then
                 test_source=()
                 if [[ -n ${source[0]} ]]; then
@@ -254,13 +254,13 @@ function lint_deps() {
         local -n type_array="${dep_type}"
         dep_array=("${type_array[@]}")
         for kdarch in "${PACSTALL_KNOWN_ARCH[@]}"; do
-            [[ ${kdarch} != "${CARCH}" ]] && lint_var_arch "${dep_type}" "${kdarch}"
+            [[ ${kdarch} != "${TARCH}" ]] && lint_var_arch "${dep_type}" "${kdarch}"
         done
         for kdistro in "${PACSTALL_KNOWN_DISTROS[@]}"; do
             if [[ ${kdistro} != "${DISTRO%:*}" && ${kdistro} != "${DISTRO#*:}" ]]; then
                 lint_var_arch "${dep_type}" "${kdistro}"
                 for kddarch in "${PACSTALL_KNOWN_ARCH[@]}"; do
-                    [[ ${kddarch} != "${CARCH}" ]] && lint_var_arch "${dep_type}" "${kdistro}" "${kddarch}"
+                    [[ ${kddarch} != "${TARCH}" ]] && lint_var_arch "${dep_type}" "${kdistro}" "${kddarch}"
                 done
             fi
         done
@@ -329,13 +329,13 @@ function lint_relations() {
         local -n rtype_array="${rel_type}"
         rel_array=("${rtype_array[@]}")
         for rdarch in "${PACSTALL_KNOWN_ARCH[@]}"; do
-            [[ ${rdarch} != "${CARCH}" ]] && lint_var_arch "${rel_type}" "${rdarch}"
+            [[ ${rdarch} != "${TARCH}" ]] && lint_var_arch "${rel_type}" "${rdarch}"
         done
         for rdistro in "${PACSTALL_KNOWN_DISTROS[@]}"; do
             if [[ ${rdistro} != "${DISTRO%:*}" && ${rdistro} != "${DISTRO#*:}" ]]; then
                 lint_var_arch "${rel_type}" "${rdistro}"
                 for rddarch in "${PACSTALL_KNOWN_ARCH[@]}"; do
-                    [[ ${rddarch} != "${CARCH}" ]] && lint_var_arch "${rel_type}" "${rdistro}" "${rddarch}"
+                    [[ ${rddarch} != "${TARCH}" ]] && lint_var_arch "${rel_type}" "${rdistro}" "${rddarch}"
                 done
             fi
         done
@@ -358,13 +358,13 @@ function lint_relations() {
 
 function lint_hash() {
     local ret=0 test_hash harch test_hashsum_type test_hashsum_style test_hash_arch test_hashsum_method test_hashsum_value \
-        hash_distro_archs test_hashsums=("b2" "sha512" "sha384" "sha256" "sha224" "sha1" "md5")
+        hash_distro_archs
     for hash_distro in "${PACSTALL_KNOWN_DISTROS[@]}"; do
         for known_arch in "${PACSTALL_KNOWN_ARCH[@]}"; do
             hash_distro_archs+=("${hash_distro}_${known_arch}")
         done
     done
-    for test_hashsum_type in "${test_hashsums[@]}"; do
+    for test_hashsum_type in "${PACSTALL_KNOWN_SUMS[@]}"; do
         test_hashsum_style="${test_hashsum_type}sums[*]"
         if [[ -n ${!test_hashsum_style} ]]; then
             if [[ -z ${test_hash[*]} ]]; then
@@ -379,18 +379,18 @@ function lint_hash() {
             fi
         fi
     done
-    for test_hashsum_type in "${test_hashsums[@]}"; do
+    for test_hashsum_type in "${PACSTALL_KNOWN_SUMS[@]}"; do
         if ((ret == 1)); then
             break
         fi
         test_hashsum_style="${test_hashsum_type}sums[*]"
         for harch in "${PACSTALL_KNOWN_ARCH[@]}" "${PACSTALL_KNOWN_DISTROS[@]}" "${hash_distro_archs[@]}"; do
             test_hash_arch="${test_hashsum_type}sums_${harch}[*]"
-            [[ ${harch} != "${CARCH}"
+            [[ ${harch} != "${TARCH}"
                 && ${harch} != "${DISTRO%:*}"
                 && ${harch} != "${DISTRO#*:}"
-                && ${harch} != "${DISTRO%:*}_${CARCH}"
-                && ${harch} != "${DISTRO#*:}_${CARCH}"
+                && ${harch} != "${DISTRO%:*}_${TARCH}"
+                && ${harch} != "${DISTRO#*:}_${TARCH}"
             ]] && if [[ -n ${!test_hash_arch} ]]; then
                 if [[ -z ${!test_hashsum_style} && -z ${test_hash[*]} ]]; then
                     if [[ -z ${test_hashsum_method} ]]; then
@@ -418,12 +418,12 @@ function lint_hash() {
     # shellcheck disable=SC2128
     if [[ -n ${test_hash} ]]; then
         case ${test_hashsum_method} in
-            "${test_hashsums[0]}" | "${test_hashsums[1]}") test_hashsum_value=128 ;;
-            "${test_hashsums[2]}") test_hashsum_value=96 ;;
-            "${test_hashsums[3]}") test_hashsum_value=64 ;;
-            "${test_hashsums[4]}") test_hashsum_value=56 ;;
-            "${test_hashsums[5]}") test_hashsum_value=40 ;;
-            "${test_hashsums[6]}") test_hashsum_value=32 ;;
+            "${PACSTALL_KNOWN_SUMS[0]}" | "${PACSTALL_KNOWN_SUMS[1]}") test_hashsum_value=128 ;;
+            "${PACSTALL_KNOWN_SUMS[2]}") test_hashsum_value=96 ;;
+            "${PACSTALL_KNOWN_SUMS[3]}") test_hashsum_value=64 ;;
+            "${PACSTALL_KNOWN_SUMS[4]}") test_hashsum_value=56 ;;
+            "${PACSTALL_KNOWN_SUMS[5]}") test_hashsum_value=40 ;;
+            "${PACSTALL_KNOWN_SUMS[6]}") test_hashsum_value=32 ;;
         esac
         for i in ${!test_hash[*]}; do
             if [[ ${test_hash[i]} == "SKIP" ]]; then
@@ -493,7 +493,7 @@ function lint_incompatible() {
 
 function lint_arch() {
     # shellcheck disable=SC2034
-    local ret=0 el_arch idx=0 known_archs=("any" "${PACSTALL_KNOWN_ARCH[@]}")
+    local ret=0 el_arch idx=0 known_archs=("any" "all" "${PACSTALL_KNOWN_ARCH[@]}")
     if [[ -n ${arch[*]} ]]; then
         for el_arch in "${arch[@]}"; do
             if [[ -z ${el_arch} ]]; then

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -542,7 +542,7 @@ function get_incompatible_releases() {
 
 function is_compatible_arch() {
     local input=("${@}") ret=1 pacarch farch
-    # shellcheck disable=SC2076
+    # shellcheck disable=SC2076,SC2153
     if array.contains input "any" \
         || array.contains input "all" \
         || array.contains input "${CARCH}" \

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -541,15 +541,15 @@ function get_incompatible_releases() {
 }
 
 function is_compatible_arch() {
-    local input=("${@}") ret=1 pacarch farch
+    local inarch=("${@}") ret=1 pacarch farch
     # shellcheck disable=SC2076,SC2153
-    if array.contains input "any" \
-        || array.contains input "all" \
-        || array.contains input "${CARCH}" \
-        || array.contains input "${AARCH}"; then
+    if array.contains inarch "any" \
+        || array.contains inarch "all" \
+        || array.contains inarch "${CARCH}" \
+        || array.contains inarch "${AARCH}"; then
         ret=0
     elif [[ -n ${FARCH[*]} ]]; then
-        for pacarch in "${input[@]}"; do
+        for pacarch in "${inarch[@]}"; do
             for farch in "${FARCH[@]}"; do
                 if [[ ${pacarch} == "${farch}" ]]; then
                     fancy_message warn "This package is for ${BBlue}${farch}${NC}, which is a foreign architecture"

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -553,7 +553,7 @@ function is_compatible_arch() {
             for farch in "${FARCH[@]}"; do
                 if [[ ${pacarch} == "${farch}" ]]; then
                     fancy_message warn "This package is for ${BBlue}${farch}${NC}, which is a foreign architecture"
-                    export CARCH="${farch}"
+                    # ideally we want to `export CARCH="${farch}"`, but this won't fundamentally work until we utilize .SRCINFO properly
                     ret=0
                     break
                 fi

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -389,7 +389,7 @@ function file_down() {
     gather_down
 }
 
-# currently expecting: 1=hash 2=hashsum_types 3=hashum_method 4=${CARCH}/${DISTRO} 5=${CARCH}
+# currently expecting: 1=hash 2=PACSTALL_KNOWN_SUMS 3=hashum_method 4=${CARCH}/${DISTRO} 5=${CARCH}
 function append_hash_entry() {
     local -n append="${1}" sums="${2}" exp_method="${3}"
     local hash_arch hash_arr extend="${4}${5:+_$5}"
@@ -429,16 +429,16 @@ function append_var_arch() {
 function append_modifier_entries() {
     unset hashsum_method
 	# shellcheck disable=SC2034
-    local APPARCH="${1}" APPDISTRO="${2}" hashsum_types=("b2" "sha512" "sha384" "sha256" "sha224" "sha1" "md5")
+    local APPARCH="${1}" APPDISTRO="${2}"
     # append arrays from least to most specific
-    append_hash_entry hash hashsum_types hashsum_method
-    append_hash_entry hash hashsum_types hashsum_method "${APPARCH}"
+    append_hash_entry hash PACSTALL_KNOWN_SUMS hashsum_method
+    append_hash_entry hash PACSTALL_KNOWN_SUMS hashsum_method "${APPARCH}"
     # distro base
-    append_hash_entry hash hashsum_types hashsum_method "${APPDISTRO%:*}"
+    append_hash_entry hash PACSTALL_KNOWN_SUMS hashsum_method "${APPDISTRO%:*}"
     # distro version
-    append_hash_entry hash hashsum_types hashsum_method "${APPDISTRO#*:}"
-    append_hash_entry hash hashsum_types hashsum_method "${APPDISTRO%:*}" "${APPARCH}"
-    append_hash_entry hash hashsum_types hashsum_method "${APPDISTRO#*:}" "${APPARCH}"
+    append_hash_entry hash PACSTALL_KNOWN_SUMS hashsum_method "${APPDISTRO#*:}"
+    append_hash_entry hash PACSTALL_KNOWN_SUMS hashsum_method "${APPDISTRO%:*}" "${APPARCH}"
+    append_hash_entry hash PACSTALL_KNOWN_SUMS hashsum_method "${APPDISTRO#*:}" "${APPARCH}"
     for i in {source,depends,makedepends,optdepends,pacdeps,checkdepends,provides,conflicts,breaks,replaces}; do
         append_var_arch "${i}" "${APPARCH}"
         append_var_arch "${i}" "${APPDISTRO%:*}"
@@ -543,15 +543,17 @@ function get_incompatible_releases() {
 function is_compatible_arch() {
     local input=("${@}") ret=1 pacarch farch
     # shellcheck disable=SC2076
-    if [[ " ${input[*]} " =~ " any " ]]; then
-        ret=0
-    elif [[ " ${input[*]} " =~ " ${CARCH} " ]]; then
+    if array.contains input "any" \
+        || array.contains input "all" \
+        || array.contains input "${CARCH}" \
+        || array.contains input "${AARCH}"; then
         ret=0
     elif [[ -n ${FARCH[*]} ]]; then
         for pacarch in "${input[@]}"; do
             for farch in "${FARCH[@]}"; do
                 if [[ ${pacarch} == "${farch}" ]]; then
                     fancy_message warn "This package is for ${BBlue}${farch}${NC}, which is a foreign architecture"
+                    export CARCH="${farch}"
                     ret=0
                     break
                 fi
@@ -562,7 +564,7 @@ function is_compatible_arch() {
         done
     fi
     if ((ret == 1)); then
-        fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}${NC}"
+        fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}/${AARCH}${NC}"
     fi
     return "${ret}"
 }

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -88,6 +88,15 @@ export pacfile
 mapfile -t FARCH < <(dpkg --print-foreign-architectures)
 export FARCH
 export CARCH="$(dpkg --print-architecture)"
+case ${CARCH} in
+    amd64) AARCH='x86_64' ;;
+    i386) AARCH='i686' ;;
+    armel) AARCH='arm' ;;
+    armhf) AARCH='armv7h' ;;
+    arm64) AARCH='aarch64' ;;
+    *) AARCH="${CARCH}" ;;
+esac
+export AARCH
 export DISTRO="$(set_distro)"
 
 # Running source on an isolated env
@@ -102,8 +111,17 @@ if [[ ${external_connection} == "true" ]]; then
     fancy_message warn "This package will connect to the internet during its build process."
 fi
 
+# if using arch-style architectures
+if array.contains arch "${AARCH}"; then
+    # only append arch-style
+    TARCH="${AARCH}"
+else
+    # only append debian-style
+    TARCH="${CARCH}"
+fi
+export TARCH
 # FARCH will be useful here when pkgbase is implemented
-append_modifier_entries "${CARCH}" "${DISTRO}"
+append_modifier_entries "${TARCH}" "${DISTRO}"
 
 # Running `-B` on a deb package doesn't make sense, so let's download instead
 if ((PACSTALL_INSTALL == 0)) && [[ ${pkgname} == *-deb ]]; then

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -89,12 +89,9 @@ mapfile -t FARCH < <(dpkg --print-foreign-architectures)
 export FARCH
 export CARCH="$(dpkg --print-architecture)"
 case ${CARCH} in
-    amd64) AARCH='x86_64' ;;
     i386) AARCH='i686' ;;
-    armel) AARCH='arm' ;;
     armhf) AARCH='armv7h' ;;
-    arm64) AARCH='aarch64' ;;
-    *) AARCH="${CARCH}" ;;
+    *) AARCH="${HOSTTYPE}" ;;
 esac
 export AARCH
 export DISTRO="$(set_distro)"

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -63,6 +63,15 @@ function calc_repo_ver() {
 export UPGRADE="yes"
 # shellcheck disable=SC2155
 export CARCH="$(dpkg --print-architecture)"
+case ${CARCH} in
+    amd64) AARCH='x86_64' ;;
+    i386) AARCH='i686' ;;
+    armel) AARCH='arm' ;;
+    armhf) AARCH='armv7h' ;;
+    arm64) AARCH='aarch64' ;;
+    *) AARCH="${CARCH}" ;;
+esac
+export AARCH
 # shellcheck disable=SC2155
 export DISTRO="$(set_distro)"
 

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -64,12 +64,9 @@ export UPGRADE="yes"
 # shellcheck disable=SC2155
 export CARCH="$(dpkg --print-architecture)"
 case ${CARCH} in
-    amd64) AARCH='x86_64' ;;
     i386) AARCH='i686' ;;
-    armel) AARCH='arm' ;;
     armhf) AARCH='armv7h' ;;
-    arm64) AARCH='aarch64' ;;
-    *) AARCH="${CARCH}" ;;
+    *) AARCH="${HOSTTYPE}" ;;
 esac
 export AARCH
 # shellcheck disable=SC2155

--- a/pacstall
+++ b/pacstall
@@ -496,7 +496,7 @@ function getMasks_offending_pkg() {
 function decl_scriptvars() {
     local _distros _vars _archs _sums distros \
         vars="source depends makedepends optdepends pacdeps checkdepends provides conflicts breaks replaces" \
-        archs="amd64 arm64 armel armhf i386 mips64el ppc64el riscv64 s390x" \
+        archs="amd64 x86_64 arm64 aarch64 armel arm armhf armv7h i386 i686 mips64el ppc64el riscv64 s390x" \
         sums="b2 sha512 sha384 sha256 sha224 sha1 md5"
     pacstallvars=(pkgname repology pkgver git_pkgver epoch source_url source depends makedepends checkdepends conflicts
         breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps NOBUILDDEP provides incompatible
@@ -519,7 +519,8 @@ function decl_scriptvars() {
       ($4 <= current_date) && $3 != "experimental" {
         print $3
       }' /usr/share/distro-info/{ubuntu,debian}.csv)
-    export PACSTALL_KNOWN_DISTROS=("${distros[@]}") PACSTALL_KNOWN_ARCH=("amd64" "arm64" "armel" "armhf" "i386" "mips64el" "ppc64el" "riscv64" "s390x")
+    export PACSTALL_KNOWN_DISTROS=("${distros[@]}")
+    eval "PACSTALL_KNOWN_ARCH=(${archs}) PACSTALL_KNOWN_SUMS=(${sums})"
     distros="${distros[*]}"
     _distros="{${distros// /,}}" _vars="{${vars// /,}}" _archs="{${archs// /,}}" _sums="{${sums// /,}}"
     eval "pacstallvars+=(${_vars}_${_distros} ${_vars}_${_archs} ${_vars}_${_distros}_${_archs} ${_sums}sums ${_sums}sums_${_distros} ${_sums}sums_${_archs} ${_sums}sums_${_distros}_${_archs} gives_${_distros} gives_${_archs} gives_${_distros}_${_archs})"


### PR DESCRIPTION
## Purpose

bc I want it and also cross compatibility with PKGBUILDs

## Approach

- export `AARCH` variable for script usage
- if `arch` array contains `AARCH`, use that for appending + checks instead of `CARCH`
- also singularize both known sums + known arch declares
- don't allow mixing and matching, must choose one style

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
