### PR TITLE
fix({fetch-sources,checks}.sh): override with enhanced source for `-deb` pkgs

### DIFF
--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -199,7 +199,7 @@ function lint_source() {
                             || ${distver_carch_source[0]} == "${source[0]}" ]]; } \
                     || test_source+=("${source[@]}")
                 fi
-                [[ ${pkgname} == *"-deb" ]] || test_source+=("${!source_arch}")
+                [[ ${pkgname} == *"-deb" ]] && test_source=("${!source_arch}") || test_source+=("${!source_arch}")
                 if [[ -n ${test_source[1]} ]]; then
                     lint_source_deb_test "${test_source[@]}"
                     if ((ret == 1)); then

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -199,7 +199,7 @@ function lint_source() {
                             || ${distver_carch_source[0]} == "${source[0]}" ]]; } \
                     || test_source+=("${source[@]}")
                 fi
-                test_source+=("${!source_arch}")
+                [[ ${pkgname} == *"-deb" ]] || test_source+=("${!source_arch}")
                 if [[ -n ${test_source[1]} ]]; then
                     lint_source_deb_test "${test_source[@]}"
                     if ((ret == 1)); then

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -400,13 +400,13 @@ function append_hash_entry() {
             if [[ -n ${!hash_arr} && -z ${extend} ]]; then
                 export exp_method="${type}"
                 for a in ${!hash_arr}; do
-                    append+=("${a}")
+                    [[ ${pkgname} == *"-deb" ]] && append=("${a}") || append+=("${a}")
                 done
                 break
             elif [[ -n ${!hash_arch} ]]; then
                 [[ -z ${!hash_arr} && -z ${append[*]} ]] && export exp_method="${type}"
                 for a in ${!hash_arch}; do
-                    append+=("${a}")
+                    [[ ${pkgname} == *"-deb" ]] && append=("${a}") || append+=("${a}")
                 done
                 break
             fi
@@ -419,7 +419,9 @@ function append_var_arch() {
     declare -n ref_inputvar="${inputvar}"
     if [[ -n ${!inputvar_arch} ]]; then
         for inp in ${!inputvar_arch}; do
-            if ! array.contains ref_inputvar "${inp}" || [[ ${inputvar} == "source" ]]; then
+            if [[ ${pkgname} == *"-deb" && ${inputvar} == "source" ]]; then
+                ref_inputvar=("${inp}")
+            elif ! array.contains ref_inputvar "${inp}" || [[ ${inputvar} == "source" ]]; then
                 ref_inputvar+=("${inp}")
             fi
         done


### PR DESCRIPTION
## Purpose

to avoid having to declare a million distro arrays

## Approach

don't append enhanced source for deb pkgs, override them
this means the arrays will work functionally different to normal `source`, and should be treated with care

for the example here: 
https://github.com/pacstall/pacstall-programs/blob/a55708b38c384737909462ce54cb0eca669a2fbf/packages/virtualbox-deb/virtualbox-deb.pacscript#L11C1-L12C85
instead of 
```bash
source_bookworm=("https://download.virtualbox.org/virtualbox/${pkgver}/virtualbox-7.0_${pkgver}-${release}~Debian~bookworm_amd64.deb")
sha256sums_bookworm="a8a65f3b77ace18abf48440859ba0fcfe33cba02d745ab7f12eb19fc18338298"
source_ubuntu=("https://download.virtualbox.org/virtualbox/${pkgver}/virtualbox-7.0_${pkgver}-${release}~Ubuntu~jammy_amd64.deb")
sha256sums_ubuntu="9676421d588478d389d87dbc29bc0a259163c061ae9bd763e43ff807650bf9b6"
```
we can do
```bash
source_bookworm=("https://download.virtualbox.org/virtualbox/${pkgver}/virtualbox-7.0_${pkgver}-${release}~Debian~bookworm_amd64.deb")
sha256sums_bookworm=("a8a65f3b77ace18abf48440859ba0fcfe33cba02d745ab7f12eb19fc18338298")
source=("https://download.virtualbox.org/virtualbox/${pkgver}/virtualbox-7.0_${pkgver}-${release}~Ubuntu~jammy_amd64.deb")
sha256sums=("9676421d588478d389d87dbc29bc0a259163c061ae9bd763e43ff807650bf9b6")
```

also not sure how that non-array slipped through.

## Progress

- [x] do it
- [x] test it

## Addendum

https://github.com/pacstall/pacstall-programs/issues/6061

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
