### PR TITLE
fix({fetch-sources,package}.sh): install builddeps as a dummy

### DIFF
--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -574,7 +574,7 @@ function is_compatible_arch() {
 
 function install_builddepends() {
     # shellcheck disable=SC2034
-    local build_dep not_installed_yet_builddepends bdeps_array bdeps_str check_dep not_installed_yet_checkdepends cdeps_array
+    local build_dep not_installed_yet_builddepends bdeps_array bdeps_str check_dep not_installed_yet_checkdepends cdeps_array bcons_array bcons_str
     if [[ -n ${makedepends[*]} ]]; then
         for build_dep in "${makedepends[@]}"; do
             if ! is_apt_package_installed "${build_dep}"; then
@@ -610,11 +610,14 @@ function install_builddepends() {
     if ((${#not_installed_yet_builddepends[@]} != 0)) || ((${#not_installed_yet_checkdepends[@]} != 0)); then
         fancy_message sub "Creating dependency dummy package"
         (
-            unset pre_{upgrade,install,remove} post_{upgrade,install,remove} priority provides conflicts replaces breaks gives
+            unset pre_{upgrade,install,remove} post_{upgrade,install,remove} priority provides conflicts replaces breaks gives enhances recommends custom_fields
             # shellcheck disable=SC2030
             pkgname="${pkgname}-dummy-builddeps"
             sudo mkdir -p "${STAGEDIR}/${pkgname}/DEBIAN"
             deblog "Depends" "${bdeps_str}"
+            bcons_array=("${makeconflicts[@]}" "${checkconflicts[@]}")
+            dep_const.comma_array bcons_array bcons_str
+            deblog "Conflicts" "${bcons_str}"
             makedeb
         ) || {
                 fancy_message error "Failed to install build or check dependencies"

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -615,6 +615,7 @@ function install_builddepends() {
             pkgname="${pkgname}-dummy-builddeps"
             sudo mkdir -p "${STAGEDIR}/${pkgname}/DEBIAN"
             deblog "Depends" "${bdeps_str}"
+            # shellcheck disable=SC2034
             bcons_array=("${makeconflicts[@]}" "${checkconflicts[@]}")
             dep_const.comma_array bcons_array bcons_str
             deblog "Conflicts" "${bcons_str}"

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -611,6 +611,7 @@ function install_builddepends() {
         fancy_message sub "Creating dependency dummy package"
         (
             unset pre_{upgrade,install,remove} post_{upgrade,install,remove} priority provides conflicts replaces breaks gives
+            # shellcheck disable=SC2030
             pkgname="${pkgname}-dummy-builddeps"
             sudo mkdir -p "${STAGEDIR}/${pkgname}/DEBIAN"
             deblog "Depends" "${bdeps_str}"

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -612,7 +612,7 @@ function install_builddepends() {
         (
             unset pre_{upgrade,install,remove} post_{upgrade,install,remove} priority provides conflicts replaces breaks gives enhances recommends custom_fields
             # shellcheck disable=SC2030
-            pkgname="${pkgname}-dummy-builddeps"
+            pkgname="${PACKAGE}-dummy-builddeps"
             sudo mkdir -p "${STAGEDIR}/${pkgname}/DEBIAN"
             deblog "Depends" "${bdeps_str}"
             # shellcheck disable=SC2034

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -607,8 +607,8 @@ function install_builddepends() {
         dep_const.comma_array bdeps_array bdeps_str
         fancy_message info "${BLUE}$pkgname${NC} requires ${CYAN}${not_installed_yet_builddepends[*]}${NC} to build, and ${CYAN}${not_installed_yet_checkdepends[*]}${NC} to perform checks"
     fi
-    if ((${#not_installed_yet_builddepends[@]} != 0)) || ((${#not_installed_yet_checkdepends[@]} != 0)); then
-        fancy_message sub "Creating dependency dummy package"
+    if ((${#not_installed_yet_builddepends[@]} != 0 || ${#not_installed_yet_checkdepends[@]} != 0 || ${#makeconflicts[@]} != 0 || ${#checkconflicts[@]} != 0 )); then
+        fancy_message sub "Creating build dependency/conflicts dummy package"
         (
             unset pre_{upgrade,install,remove} post_{upgrade,install,remove} priority provides conflicts replaces breaks gives enhances recommends custom_fields
             # shellcheck disable=SC2030

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -472,10 +472,8 @@ cd "$HOME" 2> /dev/null || (
     fancy_message warn "Could not enter into ${HOME}"
 )
 
-# shellcheck disable=SC2031
-if is_apt_package_installed "${pkgname}-dummy-builddeps"; then
-    # shellcheck disable=SC2031
-    sudo apt-get purge "${pkgname}-dummy-builddeps" -y > /dev/null
+if is_apt_package_installed "${PACKAGE}-dummy-builddeps"; then
+    sudo apt-get purge "${PACKAGE}-dummy-builddeps" -y > /dev/null
 fi
 makedeb
 

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -473,6 +473,9 @@ cd "$HOME" 2> /dev/null || (
 )
 
 makedeb
+if is_apt_package_installed "${pkgname}-dummy-builddeps"; then
+    sudo apt-get purge "${pkgname}-dummy-builddeps" -y > /dev/null
+fi
 
 # Metadata writing
 meta_log

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -472,10 +472,10 @@ cd "$HOME" 2> /dev/null || (
     fancy_message warn "Could not enter into ${HOME}"
 )
 
-makedeb
 if is_apt_package_installed "${pkgname}-dummy-builddeps"; then
     sudo apt-get purge "${pkgname}-dummy-builddeps" -y > /dev/null
 fi
+makedeb
 
 # Metadata writing
 meta_log

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -472,7 +472,9 @@ cd "$HOME" 2> /dev/null || (
     fancy_message warn "Could not enter into ${HOME}"
 )
 
+# shellcheck disable=SC2031
 if is_apt_package_installed "${pkgname}-dummy-builddeps"; then
+    # shellcheck disable=SC2031
     sudo apt-get purge "${pkgname}-dummy-builddeps" -y > /dev/null
 fi
 makedeb


### PR DESCRIPTION
## Purpose

unneeded builddeps can be marked for auto removal 

## Approach

build a dummy

## Progress

- [x] do it
- [x] test it
- [x] test it extensively
- [x] wait for https://github.com/pacstall/pacstall/pull/1134 to log checkconflicts + makeconflicts as conflicts for the dummy

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
