### PR TITLE
feat(*): provide more `control` fields

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -293,7 +293,7 @@ function is_builddep_arch() {
     [[ -n ${!buildar} ]] && appendar+=("${!buildar}")
     [[ -n ${!buildar_distb} ]] && appendar+=("${!buildar_distb}")
     [[ -n ${!buildar_distv} ]] && appendar+=("${!buildar_distv}")
-    [[ -z ${appendar[*]} ]] && return 1 || return 0
+    [[ -n ${appendar[*]} ]]
 }
 
 function makedeb() {

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -386,15 +386,15 @@ function lint_fields() {
             if array.contains deblog_used "${tlogvar}"; then
                 fancy_message error "'${tlogvar}' is already used as a field in pacstall"
                 ret=1
-            elif ! lint_field_fmt "${tlogvar}"; then
+            else
+			    lint_field_fmt "${tlogvar}"
                 case "$?" in
-                    1) fancy_message error "Field names cannot contain a space in 'custom_fields' (${tlogvar})" ;;
-                    2) fancy_message error "Field names cannot contain a number in 'custom_fields' (${tlogvar})" ;;
-                    3) fancy_message error "Field names must capitalize the first letter in 'custom_fields' (${tlogvar})"
-                       fancy_message sub "Field names with multiple words must be hyphen (-) separated"
-                       fancy_message sub "Hyphenated field names must capitalize the first letter of each word, and cannot end with a hyphen" ;;
+                    1) fancy_message error "'${tlogvar}' field name cannot contain a space in 'custom_fields'"; ret=1 ;;
+                    2) fancy_message error "'${tlogvar}' field name cannot contain a number in 'custom_fields'"; ret=1 ;;
+                    3) fancy_message error "'${tlogvar}' field name must capitalize the first letter in 'custom_fields'"
+                       fancy_message sub "Field names with multiple words should be hyphen separated, and cannot end with a hyphen"
+                       fancy_message sub "Hyphenated field names must capitalize the first letter of each word"; ret=1 ;;
                 esac
-                ret=1
             fi
             ((idx++))
         done

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -359,8 +359,12 @@ function lint_relations() {
 function lint_field_fmt() {
     local infield="${1}"
     # ensure no spaces or numbers, first letter is capital, + hyphen is not last char and also follows cap rule
-    if [[ "${infield}" =~ [[:space:]] || "${infield}" =~ [0-9] || ! "${infield}" =~ ^[A-Z][a-z]*(-[A-Z][a-z]*)*$ ]]; then
+    if [[ "${infield}" =~ [[:space:]] ]]; then
         return 1
+    elif [[ "${infield}" =~ [0-9] ]]; then
+        return 2
+    elif [[ ! "${infield}" =~ ^[A-Z][a-z]*(-[A-Z][a-z]*)*$ ]]; then
+        return 3
     else
         return 0
     fi
@@ -383,7 +387,14 @@ function lint_fields() {
                 fancy_message error "'${tlogvar}' is already used as a field in pacstall"
                 ret=1
             elif ! lint_field_fmt "${tlogvar}"; then
-                fancy_message error "'${tlogvar}' is improperly formatted for control fields"
+                fancy_message error "'${tlogvar}' is improperly formatted for 'custom_fields'"
+                case "$?" in
+                    1) fancy_message sub "Field names cannot contain a space" ;;
+                    2) fancy_message sub "Field names cannot contain a number" ;;
+                    3) fancy_message sub "Field names must capitalize the first letter"
+                       fancy_message sub "Field names with multiple words must be hyphen (-) seperated"
+                       fancy_message sub "Hyphenated field names must capitalize the first letter of each word, and cannot end with a hyphen" ;;
+                esac
                 ret=1
             fi
             ((idx++))

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -380,10 +380,10 @@ function lint_fields() {
             fi
             tlogvar="${tfield%:*}"
             if array.contains deblog_used "${tlogvar}"; then
-                fancy_message error "'${tlogvar}' is already used for logging in pacstall"
+                fancy_message error "'${tlogvar}' is already used as a field in pacstall"
                 ret=1
             elif ! lint_field_fmt "${tlogvar}"; then
-                fancy_message error "'${tlogvar}' is improperly formatted"
+                fancy_message error "'${tlogvar}' is improperly formatted for control fields"
                 ret=1
             fi
             ((idx++))

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -391,9 +391,9 @@ function lint_fields() {
                 case "$?" in
                     1) fancy_message error "'${tlogvar}' field name cannot contain a space in 'custom_fields'"; ret=1 ;;
                     2) fancy_message error "'${tlogvar}' field name cannot contain a number in 'custom_fields'"; ret=1 ;;
-                    3) fancy_message error "'${tlogvar}' field name must capitalize the first letter in 'custom_fields'"
+                    3) fancy_message error "'${tlogvar}' field name must capitalize only the first letter in 'custom_fields'"
                        fancy_message sub "Field names with multiple words should be hyphen separated, and cannot end with a hyphen"
-                       fancy_message sub "Hyphenated field names must capitalize the first letter of each word"; ret=1 ;;
+                       fancy_message sub "Hyphenated field names must capitalize only the first letter of each word"; ret=1 ;;
                 esac
             fi
             ((idx++))

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -382,15 +382,12 @@ function lint_field_fmt() {
     # Ensure first letter is Capital
     elif [[ ${infield} != "${infield^}" ]]; then
         return 3
-        # Ensure names with multiple words are hyphen separated, and don't end with a hyphen
-    elif [[ ${infield} != "${infield^}" ]]; then
-        return 4
-        # Ensure hyphenated field names are capitalized only on the first letter of each word
+    # Ensure hyphenated field names are capitalized only on the first letter of each word
     elif ! lint_capital_check "${infield}"; then
-        return 5
-        # Ensure last or first letter isn't a hyphen
+        return 4
+    # Ensure last or first letter isn't a hyphen
     elif [[ ${infield: -1} != '-' || ${infield:1} != '-' ]]; then
-        return 6
+        return 5
     else
         return 0
     fi
@@ -423,15 +420,11 @@ function lint_fields() {
                         fancy_message error "'${tlogvar}' field name cannot contain a number in 'custom_fields'"
                         ret=1
                         ;;
-                    3 | 5)
+                    3 | 4)
                         fancy_message error "'${tlogvar}' field name must capitalize only the letter of each word in 'custom_fields'"
                         ret=1
                         ;;
-                    4)
-                        fancy_message error "'${tlogvar}' field name with multiple words should be hyphen separated in 'custom_fields'"
-                        ret=1
-                        ;;
-                    6)
+                    5)
                         fancy_message error "'${tlogvar}' cannot start or end with a hyphen in 'custom_fields'"
                         ret=1
                         ;;

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -387,11 +387,10 @@ function lint_fields() {
                 fancy_message error "'${tlogvar}' is already used as a field in pacstall"
                 ret=1
             elif ! lint_field_fmt "${tlogvar}"; then
-                fancy_message error "'${tlogvar}' is improperly formatted for 'custom_fields'"
                 case "$?" in
-                    1) fancy_message sub "Field names cannot contain a space" ;;
-                    2) fancy_message sub "Field names cannot contain a number" ;;
-                    3) fancy_message sub "Field names must capitalize the first letter"
+                    1) fancy_message error "Field names cannot contain a space in 'custom_fields' (${tlogvar})" ;;
+                    2) fancy_message error "Field names cannot contain a number in 'custom_fields' (${tlogvar})" ;;
+                    3) fancy_message error "Field names must capitalize the first letter in 'custom_fields' (${tlogvar})"
                        fancy_message sub "Field names with multiple words must be hyphen (-) seperated"
                        fancy_message sub "Hyphenated field names must capitalize the first letter of each word, and cannot end with a hyphen" ;;
                 esac

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -391,7 +391,7 @@ function lint_fields() {
                     1) fancy_message error "Field names cannot contain a space in 'custom_fields' (${tlogvar})" ;;
                     2) fancy_message error "Field names cannot contain a number in 'custom_fields' (${tlogvar})" ;;
                     3) fancy_message error "Field names must capitalize the first letter in 'custom_fields' (${tlogvar})"
-                       fancy_message sub "Field names with multiple words must be hyphen (-) seperated"
+                       fancy_message sub "Field names with multiple words must be hyphen (-) separated"
                        fancy_message sub "Hyphenated field names must capitalize the first letter of each word, and cannot end with a hyphen" ;;
                 esac
                 ret=1

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -413,19 +413,19 @@ function lint_fields() {
                 lint_field_fmt "${tlogvar}"
                 case "$?" in
                     1)
-                        fancy_message error "'${tlogvar}' field name cannot contain a space in 'custom_fields'"
+                        fancy_message error "'${tlogvar}' custom field cannot contain a space in field name"
                         ret=1
                         ;;
                     2)
-                        fancy_message error "'${tlogvar}' field name cannot contain a number in 'custom_fields'"
+                        fancy_message error "'${tlogvar}' custom field cannot contain a number in field name"
                         ret=1
                         ;;
                     3 | 4)
-                        fancy_message error "'${tlogvar}' field name must capitalize only the letter of each word in 'custom_fields'"
+                        fancy_message error "'${tlogvar}' custom field must capitalize only the first letter of each word in field name"
                         ret=1
                         ;;
                     5)
-                        fancy_message error "'${tlogvar}' cannot start or end with a hyphen in 'custom_fields'"
+                        fancy_message error "'${tlogvar}' custom field cannot start or end with a hyphen"
                         ret=1
                         ;;
                 esac

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -359,7 +359,11 @@ function lint_relations() {
 function lint_capital_check() {
     local str="${1}" i=0 c x z split_chars=()
     while printf -v c "%s%n" "${str:i++:1}" x; do
-        ((x)) && split_chars+=("${c}") || break
+        if ((x)); then
+            split_chars+=("${c}")
+        else
+            break
+        fi
     done
     for z in "${!split_chars[@]}"; do
         if [[ ${split_chars[$z]} == '-' ]]; then

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -439,7 +439,7 @@ function append_modifier_entries() {
     append_hash_entry hash PACSTALL_KNOWN_SUMS hashsum_method "${APPDISTRO#*:}"
     append_hash_entry hash PACSTALL_KNOWN_SUMS hashsum_method "${APPDISTRO%:*}" "${APPARCH}"
     append_hash_entry hash PACSTALL_KNOWN_SUMS hashsum_method "${APPDISTRO#*:}" "${APPARCH}"
-    for i in {source,depends,makedepends,optdepends,pacdeps,checkdepends,provides,conflicts,breaks,replaces}; do
+    for i in {source,depends,makedepends,optdepends,pacdeps,checkdepends,provides,conflicts,breaks,replaces,enhances,recommends,makeconflicts,checkconflicts}; do
         append_var_arch "${i}" "${APPARCH}"
         append_var_arch "${i}" "${APPDISTRO%:*}"
         append_var_arch "${i}" "${APPDISTRO#*:}"

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -250,7 +250,7 @@ fi
 
 if ! is_package_installed "${pkgname}"; then
     if [[ -n ${conflicts[*]} ]]; then
-        for pkg in "${conflicts[@]}"; do
+        for pkg in "${conflicts[@]}" "${makeconflicts[@]}" "${checkconflicts[@]}"; do
             # Do we have an apt package installed (but not pacstall)?
             if is_apt_package_installed "${pkg}" && ! is_package_installed "${pkg}"; then
                 # Check if anything in conflicts variable is installed already

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -249,7 +249,7 @@ if [[ -n $pacdeps ]]; then
 fi
 
 if ! is_package_installed "${pkgname}"; then
-    if [[ -n ${conflicts[*]} ]]; then
+    if [[ -n ${conflicts[*]} || -n ${makeconflicts[*]} || -n ${checkconflicts[*]} ]]; then
         # shellcheck disable=SC2031
         for pkg in "${conflicts[@]}" "${makeconflicts[@]}" "${checkconflicts[@]}"; do
             # Do we have an apt package installed (but not pacstall)?

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -250,6 +250,7 @@ fi
 
 if ! is_package_installed "${pkgname}"; then
     if [[ -n ${conflicts[*]} ]]; then
+        # shellcheck disable=SC2031
         for pkg in "${conflicts[@]}" "${makeconflicts[@]}" "${checkconflicts[@]}"; do
             # Do we have an apt package installed (but not pacstall)?
             if is_apt_package_installed "${pkg}" && ! is_package_installed "${pkg}"; then

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -249,6 +249,7 @@ if [[ -n $pacdeps ]]; then
 fi
 
 if ! is_package_installed "${pkgname}"; then
+    # shellcheck disable=SC2031
     if [[ -n ${conflicts[*]} || -n ${makeconflicts[*]} || -n ${checkconflicts[*]} ]]; then
         # shellcheck disable=SC2031
         for pkg in "${conflicts[@]}" "${makeconflicts[@]}" "${checkconflicts[@]}"; do

--- a/pacstall
+++ b/pacstall
@@ -495,13 +495,13 @@ function getMasks_offending_pkg() {
 
 function decl_scriptvars() {
     local _distros _vars _archs _sums distros \
-        vars="source depends makedepends optdepends pacdeps checkdepends provides conflicts breaks replaces" \
+        vars="source depends makedepends optdepends pacdeps checkdepends provides conflicts breaks replaces enhances recommends makeconflicts checkconflicts" \
         archs="amd64 x86_64 arm64 aarch64 armel arm armhf armv7h i386 i686 mips64el ppc64el riscv64 s390x" \
         sums="b2 sha512 sha384 sha256 sha224 sha1 md5"
     pacstallvars=(pkgname repology pkgver git_pkgver epoch source_url source depends makedepends checkdepends conflicts
         breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps NOBUILDDEP provides incompatible
         compatible srcdir url backup pkgrel mask pac_functions repo priority noextract nosubmodules _archive license
-        bwrapenv safeenv external_connection)
+        bwrapenv safeenv external_connection enhances recommends custom_fields makeconflicts checkconflicts)
     mapfile -t distros < <(awk -F ',' -v current_date="$(date +'%Y-%m-%d')" '
       BEGIN {
         is_first = 1


### PR DESCRIPTION
## Purpose

pull in more debian control fields

## Approach

adds the following:
- `enhances` (+ enhanced arrays)
- `recommends`  (+ enh arrs)
- `makeconflicts` (+ enh arrs)
- `checkconflicts` (+ enh arrs)
- `custom_fields` (NO enhanced arrays)
    - has a check to ensure field is not already used by pacstall, and is valid to debian format
        - no space
        - no numbers
        - first uppercase, rest lowercase
        - hyphen not trailing
        - hyphenation follows same case rules
    - array formatted such as:
```bash
 custom_fields=(
  "Example-Field: this, that, those"
  "Exampler: This one is a long description
that goes on multiple lines"
)
```
- breaks `conflicts` off of `replaces` ~~(run tests to ensure this is okay, might need to include `conflicts=("${replaces[@]}")` in packages)~~ can confirm this is all good

 

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
