### PR TITLE
fix(fetch-sources.sh): make git clones follow quiet rules

### DIFF
--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -211,7 +211,7 @@ function git_down() {
     fi
     # git clone quietly, with no history, and if submodules are there, download with 10 jobs
     # shellcheck disable=SC2086,SC2031
-    eval "git clone --depth=1 --jobs=10 ${quiet} \"${source_url}\" \"${dest}\" ${gitopts[@]} ${silence[@]}" || fail_down
+    eval "git clone --depth=1 --jobs=10 ${quiet} \"${source_url}\" \"${dest}\" ${gitopts[*]} ${silence[*]}" || fail_down
     # cd into the directory
     cd "./${dest}" 2> /dev/null || {
         error_log 1 "install $PACKAGE"
@@ -220,8 +220,8 @@ function git_down() {
     }
     if [[ -n ${git_commit} ]]; then
         fancy_message sub "Fetching commit ${CYAN}${git_commit:0:8}${NC}"
-        eval "git fetch ${quiet} origin \"${git_commit}\" ${silence[@]}" || fail_down
-        eval "git checkout ${quiet} --force \"${git_commit}\" ${silence[@]}" || fail_down
+        eval "git fetch ${quiet} origin \"${git_commit}\" ${silence[*]}" || fail_down
+        eval "git checkout ${quiet} --force \"${git_commit}\" ${silence[*]}" || fail_down
     fi
     for no_submodule in "${nosubmodules[@]}"; do
         if [[ ${no_submodule} == "${dest}" ]]; then

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -190,7 +190,8 @@ function gather_down() {
 }
 
 function git_down() {
-    local revision gitopts submodules=true no_submodule
+    local revision gitopts submodules=true no_submodule silence quiet
+    ${PACSTALL_VERBOSE} || silence=("&>" "/dev/null") quiet="--quiet"
     dest="${dest%.git}"
     if [[ -n ${git_branch} || -n ${git_tag} ]]; then
         if [[ -n ${git_branch} ]]; then
@@ -202,7 +203,7 @@ function git_down() {
         fi
         gitopts="-b ${revision}"
     elif [[ -n ${git_commit} ]]; then
-        gitopts="--no-checkout --filter=blob:none"
+        gitopts=("--no-checkout" "--filter=blob:none")
         fancy_message info "Cloning ${BPurple}${dest}${NC} with no blobs"
     else
         unset gitopts
@@ -210,7 +211,7 @@ function git_down() {
     fi
     # git clone quietly, with no history, and if submodules are there, download with 10 jobs
     # shellcheck disable=SC2086,SC2031
-    git clone --quiet --depth=1 --jobs=10 "${source_url}" "${dest}" ${gitopts} &> /dev/null || fail_down
+    eval "git clone --depth=1 --jobs=10 ${quiet} \"${source_url}\" \"${dest}\" ${gitopts[@]} ${silence[@]}" || fail_down
     # cd into the directory
     cd "./${dest}" 2> /dev/null || {
         error_log 1 "install $PACKAGE"
@@ -219,8 +220,8 @@ function git_down() {
     }
     if [[ -n ${git_commit} ]]; then
         fancy_message sub "Fetching commit ${CYAN}${git_commit:0:8}${NC}"
-        git fetch --quiet origin "${git_commit}" &> /dev/null || fail_down
-        git checkout --quiet --force "${git_commit}" &> /dev/null || fail_down
+        eval "git fetch ${quiet} origin \"${git_commit}\" ${silence[@]}" || fail_down
+        eval "git checkout ${quiet} --force \"${git_commit}\" ${silence[@]}" || fail_down
     fi
     for no_submodule in "${nosubmodules[@]}"; do
         if [[ ${no_submodule} == "${dest}" ]]; then
@@ -230,7 +231,7 @@ function git_down() {
     done
     if ${submodules}; then
         # don't send this one to /dev/null like the others
-        git submodule update --quiet --init --recursive --depth=1 || fail_down
+        git submodule update "${quiet[@]}" --init --recursive --depth=1 || fail_down
     else
         fancy_message sub "Not cloning submodules for ${PURPLE}${dest}${NC}"
     fi


### PR DESCRIPTION
## Purpose

they are quiet by default, which is wrong

## Approach

use the power of eval and [@]

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
