### PR TITLE
fix(fetch-sources.sh): make sure builddeps always install and not build

### DIFF
--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -609,6 +609,7 @@ function install_builddepends() {
         fancy_message sub "Creating build dependency/conflicts dummy package"
         (
             unset pre_{upgrade,install,remove} post_{upgrade,install,remove} priority provides conflicts replaces breaks gives enhances recommends custom_fields
+            PACSTALL_INSTALL=1
             # shellcheck disable=SC2030
             pkgname="${PACKAGE}-dummy-builddeps"
             sudo mkdir -p "${STAGEDIR}/${pkgname}/DEBIAN"

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -609,6 +609,7 @@ function install_builddepends() {
         fancy_message sub "Creating build dependency/conflicts dummy package"
         (
             unset pre_{upgrade,install,remove} post_{upgrade,install,remove} priority provides conflicts replaces breaks gives enhances recommends custom_fields
+            # shellcheck disable=SC2030
             PACSTALL_INSTALL=1
             # shellcheck disable=SC2030
             pkgname="${PACKAGE}-dummy-builddeps"


### PR DESCRIPTION
## Purpose

in order to build the package (`-B`), we have to install the build deps
## Approach

in the builddep subshell, set `PACSTALL_INSTALL` to `1`, which in this case means `true`

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
