### PR TITLE
fix(pacstall): fix `-Qa` with packages that have a `.`

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -1089,11 +1089,11 @@ Helpful links:
             ;;
 
         -Qa | --quality-assurance)
-            if [[ $2 =~ ^([a-zA-Z0-9_-]+)?(@(.+))?(#([0-9]+))$ ]]; then
+            if [[ $2 =~ ^([a-zA-Z0-9_.-]+)?(@(.+))?(#([0-9]+))$ ]]; then
                 PACKAGE="${BASH_REMATCH[1]}"
                 METAURL="${BASH_REMATCH[3]}"
                 PRNUM="${BASH_REMATCH[5]}"
-            elif [[ $2 =~ ^([a-zA-Z0-9_-]+)(#([0-9]+))?(@(.+))?$ ]]; then
+            elif [[ $2 =~ ^([a-zA-Z0-9_.-]+)(#([0-9]+))?(@(.+))?$ ]]; then
                 PACKAGE="${BASH_REMATCH[1]}"
                 PRNUM="${BASH_REMATCH[3]}"
                 METAURL="${BASH_REMATCH[5]}"


### PR DESCRIPTION
## Purpose
```bash
rhino@docker-desktop:~$ pacstall -Qa gir1.2-xapp-1.0-deb#6116@github:pacstall/pacstall-programs
[!] ERROR: 'number' and 'package' cannot be empty!
	[>] use the syntax: -Qa package#NUM(@metalink)
```
that aint right

## Approach
allow `.` in the package name character set

## Progress

- [x] do it 
- [x] test it
```bash
rhino@docker-desktop:~$ pacstall -Qa gir1.2-xapp-1.0-deb#6116@github:pacstall/pacstall-programs
[+] INFO: Backing up /usr/share/pacstall/repo/pacstallrepo
[+] INFO: Installing gir1.2-xapp-1.0-deb(Zahrun:6116)
(gir1.2-xapp-1.0-deb) Do you want to view/edit the pacscript? [y/N]
```

## Addendum

tests on https://github.com/pacstall/pacstall-programs/pull/6116 are failing because of this

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
