### PR TITLE
refactor(*): parse parent distro if exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -122,9 +122,9 @@ case "$reply" in
 esac
 
 if [[ ${GITHUB_ACTIONS} == "true" ]]; then
-    apt-get install -qq -y sudo wget build-essential unzip git zstd iputils-ping lsb-release aptitude bubblewrap jq distro-info-data ${axel_inst}
+    apt-get install -qq -y sudo wget build-essential unzip git zstd iputils-ping aptitude bubblewrap jq distro-info-data ${axel_inst}
 else
-    apt-get install -y sudo wget build-essential unzip git zstd iputils-ping lsb-release aptitude bubblewrap jq distro-info-data ${axel_inst}
+    apt-get install -y sudo wget build-essential unzip git zstd iputils-ping aptitude bubblewrap jq distro-info-data ${axel_inst}
 fi
 
 METADIR="/var/lib/pacstall/metadata"

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -237,8 +237,9 @@ function prompt_optdepends() {
 }
 
 function generate_changelog() {
+    local real_dist="$(awk -F'=' '$1 == "VERSION_CODENAME" { gsub(/"/, "", $2); print $2 }' "/etc/os-release")"
     printf "%s (%s) %s; urgency=medium\n\n  * Version now at %s.\n\n -- %s %(%a, %d %b %Y %T %z)T\n" \
-        "${pkgname}" "${full_version}" "$(lsb_release -sc)" "${full_version}" "${maintainer[0]}"
+        "${pkgname}" "${full_version}" "${real_dist}" "${full_version}" "${maintainer[0]}"
 }
 
 function clean_logdir() {

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -237,7 +237,8 @@ function prompt_optdepends() {
 }
 
 function generate_changelog() {
-    local real_dist="$(awk -F'=' '$1 == "VERSION_CODENAME" { gsub(/"/, "", $2); print $2 }' "/etc/os-release")"
+    local real_dist
+    real_dist="$(awk -F'=' '$1 == "VERSION_CODENAME" { gsub(/"/, "", $2); print $2 }' "/etc/os-release")"
     printf "%s (%s) %s; urgency=medium\n\n  * Version now at %s.\n\n -- %s %(%a, %d %b %Y %T %z)T\n" \
         "${pkgname}" "${full_version}" "${real_dist}" "${full_version}" "${maintainer[0]}"
 }

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -237,10 +237,8 @@ function prompt_optdepends() {
 }
 
 function generate_changelog() {
-    local real_dist
-    real_dist="$(awk -F'=' '$1 == "VERSION_CODENAME" { gsub(/"/, "", $2); print $2 }' "/etc/os-release")"
     printf "%s (%s) %s; urgency=medium\n\n  * Version now at %s.\n\n -- %s %(%a, %d %b %Y %T %z)T\n" \
-        "${pkgname}" "${full_version}" "${real_dist}" "${full_version}" "${maintainer[0]}"
+        "${pkgname}" "${full_version}" "${CDISTRO#*:}" "${full_version}" "${maintainer[0]}"
 }
 
 function clean_logdir() {

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -71,14 +71,14 @@ export safeenv
 EOF
     sudo chmod +x "$tmpfile"
     if [[ ${NOSANDBOX} == "true" ]]; then
-        sudo homedir="${homedir}" CARCH="${CARCH}" AARCH="${AARCH}" DISTRO="${DISTRO}" NCPU="${NCPU}" PACSTALL_USER="${PACSTALL_USER}" \
+        sudo homedir="${homedir}" CARCH="${CARCH}" AARCH="${AARCH}" DISTRO="${DISTRO}" CDISTRO="${CDISTRO}" NCPU="${NCPU}" PACSTALL_USER="${PACSTALL_USER}" \
             "$tmpfile" && sudo rm "$tmpfile"
     else
         sudo env - bwrap --unshare-all --die-with-parent --new-session --ro-bind / / \
             --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --dev-bind /dev/null /dev/null \
             --ro-bind "$input" "$input" --bind "$PACDIR" "$PACDIR" --ro-bind "$tmpfile" "$tmpfile" \
             --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv AARCH "$AARCH" --setenv DISTRO "$DISTRO" \
-            --setenv NCPU "$NCPU" --setenv PACSTALL_USER "$PACSTALL_USER" \
+            --setenv CDISTRO "$CDISTRO" --setenv NCPU "$NCPU" --setenv PACSTALL_USER "$PACSTALL_USER" \
             "$tmpfile" && sudo rm "$tmpfile"
     fi
 }
@@ -113,7 +113,7 @@ EOF
     if [[ ${NOSANDBOX} == "true" ]]; then
         sudo LOGDIR="${LOGDIR}" SCRIPTDIR="${SCRIPTDIR}" STAGEDIR="${STAGEDIR}" pkgdir="${pkgdir}" _archive="${_archive}" \
             srcdir="${srcdir}" git_pkgver="${git_pkgver}" homedir="${homedir}" CARCH="${CARCH}" AARCH="${AARCH}" \
-            DISTRO="${DISTRO}" NCPU="${NCPU}" PACSTALL_USER="${PACSTALL_USER}" TAR_OPTIONS='--no-same-owner' \
+            DISTRO="${DISTRO}" CDISTRO="${CDISTRO}" NCPU="${NCPU}" PACSTALL_USER="${PACSTALL_USER}" TAR_OPTIONS='--no-same-owner' \
             "$tmpfile" && sudo rm "$tmpfile"
     else
         # shellcheck disable=SC2086
@@ -124,7 +124,7 @@ EOF
             --setenv SCRIPTDIR "$SCRIPTDIR" --setenv STAGEDIR "$STAGEDIR" --setenv pkgdir "$pkgdir" \
             --setenv _archive "$_archive" --setenv srcdir "$srcdir" --setenv git_pkgver "$git_pkgver" \
             --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv AARCH "$AARCH" --setenv DISTRO "$DISTRO" \
-            --setenv NCPU "$NCPU" --setenv PACSTALL_USER "$PACSTALL_USER" --setenv TAR_OPTIONS '--no-same-owner' \
+            --setenv CDISTRO "$CDISTRO"  --setenv NCPU "$NCPU" --setenv PACSTALL_USER "$PACSTALL_USER" --setenv TAR_OPTIONS '--no-same-owner' \
             "$tmpfile" && sudo rm "$tmpfile"
     fi
 }

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -540,11 +540,19 @@ function get_incompatible_releases() {
     # example for this function is "ubuntu:jammy"
     local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number incomp_list=("${@,,}")
     calc_distro
-    if ! array.contains incomp_list "${distro_name}:${distro_version_name}"; then
-        if [[ -n ${distro_parent_vname} ]] && array.contains incomp_list "${distro_parent}:${distro_parent_vname}"; then
+
+
+    if ! array.contains incomp_list "${distro_name}:${distro_version_name}" && \
+        ! array.contains incomp_list "${distro_name}:${distro_version_number}" && \
+        ! array.contains incomp_list "${distro_name}:*" && \
+        ! array.contains incomp_list "*:${distro_version_name}" && \
+        ! array.contains incomp_list "*:${distro_version_number}"; then
+        if [[ -n ${distro_parent_vname} ]]; then
             distro_name="${distro_parent}"
-            distro_version_number="${distro_parent_number}"
             distro_version_name="${distro_parent_vname}"
+            if [[ -n ${distro_parent_number} ]]; then
+                distro_version_number="${distro_parent_number}"
+            fi
         fi
     fi
     for key in "${incomp_list[@]}"; do

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -482,7 +482,7 @@ function calc_distro() {
             # have to set this empty instead of unsetting as the local is higher up
             distro_parent_vname=""
         else
-            distro_parent_number="$(awk -F',' -v ver="${distro_parent_vname}" '$3 == ver {print $1}' "/usr/share/distro-info/${distro_parent}.csv")"
+            distro_parent_number="$(awk -F',' -v ver="${distro_parent_vname}" '$3 == ver { gsub(" LTS", "", $1); print $1 }' "/usr/share/distro-info/${distro_parent}.csv")"
             [[ ${distro_pretty_name##*/} == "sid" ]] && distro_parent_number="sid"
         fi
     fi

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -547,7 +547,12 @@ function get_incompatible_releases() {
         ! array.contains incomp_list "${distro_name}:*" && \
         ! array.contains incomp_list "*:${distro_version_name}" && \
         ! array.contains incomp_list "*:${distro_version_number}"; then
-        if [[ -n ${distro_parent_vname} ]]; then
+        if [[ -n ${distro_parent_vname} ]] && \
+            { array.contains incomp_list "*:${distro_parent_vname}" || \
+            array.contains incomp_list "*:${distro_parent_number}" || \
+            array.contains incomp_list "${distro_parent}:${distro_parent_vname}" || \
+            array.contains incomp_list "${distro_parent}:${distro_parent_number}";
+        }; then
             distro_name="${distro_parent}"
             distro_version_name="${distro_parent_vname}"
             if [[ -n ${distro_parent_number} ]]; then

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -549,9 +549,7 @@ function get_incompatible_releases() {
         ! array.contains incomp_list "*:${distro_version_number}"; then
         if [[ -n ${distro_parent_vname} ]] && \
             { array.contains incomp_list "*:${distro_parent_vname}" || \
-            array.contains incomp_list "*:${distro_parent_number}" || \
-            array.contains incomp_list "${distro_parent}:${distro_parent_vname}" || \
-            array.contains incomp_list "${distro_parent}:${distro_parent_number}";
+            array.contains incomp_list "*:${distro_parent_number}";
         }; then
             distro_name="${distro_parent}"
             distro_version_name="${distro_parent_vname}"

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -471,7 +471,7 @@ function calc_distro() {
         esac
     done < /etc/os-release
     if [[ "${distro_name}" == "debian" ]]; then
-        distro_version_number="$(awk -F',' -v ver="${distro_version_name}" '$3 == ver {print $1}' /usr/share/distro-info/debian.csv)"
+        distro_version_number="$(awk -F',' -v ver="${distro_version_name}" '$3 == ver {print $1}' "/usr/share/distro-info/debian.csv")"
     fi
     if [[ ${distro_pretty_name##*/} == "sid" ]]; then
         distro_parent="debian"
@@ -482,7 +482,7 @@ function calc_distro() {
             # have to set this empty instead of unsetting as the local is higher up
             distro_parent_vname=""
         else
-            distro_parent_number="$(awk -F',' -v ver="${distro_parent_vname}" '$3 == ver {print $1}' /usr/share/distro-info/${distro_parent}.csv)"
+            distro_parent_number="$(awk -F',' -v ver="${distro_parent_vname}" '$3 == ver {print $1}' "/usr/share/distro-info/${distro_parent}.csv")"
             [[ ${distro_pretty_name##*/} == "sid" ]] && distro_parent_number="sid"
         fi
     fi

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -491,7 +491,11 @@ function calc_distro() {
 function set_distro() {
     local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number
     calc_distro
-    echo "${distro_parent:-${distro_name}}:${distro_parent_vname:-${distro_version_name}}"
+    if [[ ${1} == "parent" ]]; then
+        echo "${distro_parent:-${distro_name}}:${distro_parent_vname:-${distro_version_name}}"
+    else
+        echo "${distro_name}:${distro_version_name}"
+    fi
 }
 
 function get_compatible_releases() {

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -459,7 +459,7 @@ function append_modifier_entries() {
 }
 
 function calc_distro() {
-    local distro_pretty_name
+    local distro_pretty_name key value
     while IFS='=' read -r key value; do
         case "${key}" in
             "ID") distro_name="${value//\"/}" ;;

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -86,15 +86,16 @@ sudo chmod a+r "/tmp/${PACKAGE}.pacscript"
 pacfile="$(readlink -f "/tmp/${PACKAGE}.pacscript")"
 export pacfile
 mapfile -t FARCH < <(dpkg --print-foreign-architectures)
-export FARCH
-export CARCH="$(dpkg --print-architecture)"
+CARCH="$(dpkg --print-architecture)"
 case ${CARCH} in
     i386) AARCH='i686' ;;
     armhf) AARCH='armv7h' ;;
     *) AARCH="${HOSTTYPE}" ;;
 esac
-export AARCH
-export DISTRO="$(set_distro)"
+DISTRO="$(set_distro parent)"
+CDISTRO="$(set_distro)"
+export FARCH CARCH AARCH DISTRO CDISTRO
+
 
 # Running source on an isolated env
 safe_source "${pacfile}"

--- a/misc/scripts/update.sh
+++ b/misc/scripts/update.sh
@@ -35,7 +35,7 @@ PACDIR="/tmp/pacstall"
 PACSTALL_USER=$(logname 2> /dev/null || echo "${SUDO_USER:-${USER:-$(whoami)}}")
 SCRIPTDIR="/usr/share/pacstall"
 
-required_packages=(lsb-release aptitude bubblewrap jq distro-info-data)
+required_packages=(aptitude bubblewrap jq distro-info-data)
 
 function suggested_solution() {
     if [[ -z $PACSTALL_SUPPRESS_SOLUTIONS ]]; then

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -72,16 +72,15 @@ function calc_repo_ver() {
 }
 
 export UPGRADE="yes"
-# shellcheck disable=SC2155
-export CARCH="$(dpkg --print-architecture)"
+CARCH="$(dpkg --print-architecture)"
 case ${CARCH} in
     i386) AARCH='i686' ;;
     armhf) AARCH='armv7h' ;;
     *) AARCH="${HOSTTYPE}" ;;
 esac
-export AARCH
-# shellcheck disable=SC2155
-export DISTRO="$(set_distro)"
+DISTRO="$(set_distro parent)"
+CDISTRO="$(set_distro)"
+export CARCH AARCH DISTRO CDISTRO
 
 fancy_message info "Checking for updates"
 


### PR DESCRIPTION
## Purpose
for distros like pop, elementary, mint, etc, they do not get special enhanced arrays. also removing lsb-release dependency

## Approach
allow them to use the parent distro for enhanced arrays and compatibility checks. This works in different ways for each piece:
#### `set_distro`
the following distro examples are described with the combination `child:codename/num|parent:codename/num`:
```bash
debian:trixie/13|debian:sid/sid
elementary:next/8|ubuntu:noble/24.04
linuxmint:elsie/5|debian:bullseye/11
linuxmint:virginia/21.3|ubuntu:jammy/22.04
pop:focal/20.04|ubuntu:focal/20.04
ubuntu:devel/2024.1
ubuntu:oracular/24.10
```
running `set_distro` results in:
```bash
debian:trixie
elementary:next
linuxmint:elsie
linuxmint:virginia
pop:focal
ubuntu:devel
ubuntu:oracular
```
and `set_distro parent` results in:
```bash
debian:sid
ubuntu:noble
debian:bullseye
ubuntu:jammy
ubuntu:focal
ubuntu:devel
ubuntu:oracular
```
enhanced arrays use the `DISTRO` variable, so `DISTRO` is now equal to `set_distro parent`. We have a new variable for pacscript usage `CDISTRO`, which will be the true current distro, as the `DISTRO` variable previously worked.
#### `get_compatible_releases`
In all cases, if *either* the parent or true distro is found to match in the `compatible` array, then it is marked as compatible. This means in an example where distro is `linuxmint:virginia`, if the compatible array lists `ubuntu:jammy` but not `linuxmint:virginia`, it is still recognized as compatible. For `linuxmint:virginia`, the following would all trigger compatibility:
```bash
"linuxmint:virginia"
"linuxmint:21.3"
"linuxmint:*"
"*:virginia"
"*:21.3"
"ubuntu:jammy"
"ubuntu:22.04"
"ubuntu:*"
"*:jammy"
"*:22.04"
```
#### `get_incompatible_releases`
If no trace of true distro is found in the `incompatible` array:
```bash
"${distro_name}:${distro_version_name}"
"${distro_name}:${distro_version_number}"
"${distro_name}:*"
"*:${distro_version_name}"
"*:${distro_version_number}"
```
then if parent distro exists, and if the `incompatible` array contains either `"*:${distro_parent_vname}"` or `"*:${distro_parent_number}"`, override our incompatible check variables to:
```bash
distro_name="${distro_parent}"
distro_version_name="${distro_parent_vname}"
if [[ -n ${distro_parent_number} ]]; then
    distro_version_number="${distro_parent_number}"
fi
```
this means for `linuxmint:virginia`, the following would trigger incompatibility:
```bash
"linuxmint:virginia"
"linuxmint:21.3"
"linuxmint:*"
"*:virginia"
"*:21.3"
"*:jammy"
"*:22.04"
```
the following would *not* trigger incompatibility:
```bash
"ubuntu:*"
"ubuntu:jammy"
"ubuntu:22.04"
```
## Progress

<!--Make a checklist of your progress-->

- [x] do it 
- [x] test it

## Addendum

<!--Link any issues with this PR and/or write something that you want to inform us about (optional)-->

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
