### PR TITLE
refactor(*): `stacktrace` and safe `rm`s

### DIFF
--- a/misc/scripts/add-repo.sh
+++ b/misc/scripts/add-repo.sh
@@ -25,6 +25,7 @@
 { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 function parse_repo() {
+    # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ADDR
     IFS=':' read -ra ADDR <<< "$1"

--- a/misc/scripts/add-repo.sh
+++ b/misc/scripts/add-repo.sh
@@ -22,10 +22,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 function parse_repo() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ADDR
     IFS=':' read -ra ADDR <<< "$1"
     PROV="${ADDR[0]}"

--- a/misc/scripts/add-repo.sh
+++ b/misc/scripts/add-repo.sh
@@ -22,11 +22,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 function parse_repo() {
     # shellcheck disable=SC2034
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local ADDR
     IFS=':' read -ra ADDR <<< "$1"
     PROV="${ADDR[0]}"

--- a/misc/scripts/add-repo.sh
+++ b/misc/scripts/add-repo.sh
@@ -22,7 +22,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-parse_repo() {
+trap stacktrace ERR
+
+function parse_repo() {
+    trap stacktrace ERR
     local ADDR
     IFS=':' read -ra ADDR <<< "$1"
     PROV="${ADDR[0]}"

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -79,7 +79,7 @@ function prompt_optdepends() {
         dep_const.apt_compare_to_constraints "${dep}" || { not_satisfied_deps+=("${real_dep}"); continue; }
         # Add to the dependency list if already installed so it doesn't get autoremoved on upgrade
         # If the package is not installed already, add it to the list. It's much easier for a user to choose from a list of uninstalled packages than every single one regardless of i>
-        deps+=("${dep}")
+        deps+=("${real_dep}")
     done
     if [[ -n ${missing_deps[*]} ]]; then
         echo -ne "\t"
@@ -131,7 +131,7 @@ function prompt_optdepends() {
             # Add to the dependency list if already installed so it doesn't get autoremoved on upgrade
             # If the package is not installed already, add it to the list. It's much easier for a user to choose from a list of uninstalled packages than every single one regardless of it's status
             if ! is_apt_package_installed "${opt}"; then
-                suggested_optdeps+=("${optdep}")
+                suggested_optdeps+=("${realopt}: ${optdesc}")
             else
                 already_installed_optdeps+=("${realopt}")
             fi

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 # shellcheck source=./misc/scripts/version-constraints.sh
 source "${SCRIPTDIR}/scripts/version-constraints.sh" || {
@@ -37,7 +37,7 @@ source "${SCRIPTDIR}/scripts/srcinfo.sh" || {
 }
 
 function deblog() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local key="$1"
     shift
     local content=("$@")
@@ -45,13 +45,13 @@ function deblog() {
 }
 
 function clean_builddir() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     sudo rm -rf "${STAGEDIR:?}/${pacname:?}"
     sudo rm -f "${STAGEDIR:?}/${pacname}.deb"
 }
 
 function prompt_optdepends() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local deps optdep opt optdesc just_name=() missing_optdeps=() not_satisfied_optdeps=()
     deps=("${depends[@]}")
     if ((${#optdepends[@]} != 0)); then
@@ -218,13 +218,13 @@ function prompt_optdepends() {
 }
 
 function generate_changelog() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     printf "%s (%s) %s; urgency=medium\n\n  * Version now at %s.\n\n -- %s %(%a, %d %b %Y %T %z)T\n" \
         "${pacname}" "${full_version}" "${CDISTRO#*:}" "${full_version}" "${maintainer[0]}"
 }
 
 function clean_logdir() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     if [[ ! -d ${LOGDIR} ]]; then
         sudo mkdir -p "${LOGDIR}"
     fi
@@ -232,7 +232,7 @@ function clean_logdir() {
 }
 
 function createdeb() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local debname="${1}_${2}_${3}"
     if ((PACSTALL_INSTALL == 0)); then
         # We are not going to immediately install, meaning the user might want to share their deb with someone else, so create the highest compression.
@@ -278,7 +278,7 @@ function createdeb() {
 }
 
 function is_builddep_arch() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local buildar="${1}_${TARCH}[*]" buildar_distb="${1}_${DISTRO%:*}_${TARCH}[*]" buildar_distv="${1}_${DISTRO#*:}_${TARCH}[*]"
     local -n appendar="${2}"
     [[ -n ${!buildar} ]] && appendar+=("${!buildar}")
@@ -288,7 +288,7 @@ function is_builddep_arch() {
 }
 
 function makedeb() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # It looks weird for it to say: `Packaging foo as foo`
     if [[ -n $gives && $pacname != "$gives" ]]; then
         fancy_message info "Packaging ${BGreen}$pacname${NC} as ${BBlue}$gives${NC}"
@@ -608,7 +608,7 @@ function makedeb() {
 }
 
 function install_deb() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local debname="${1}_${2}_${3}"
     if ((PACSTALL_INSTALL != 0)); then
         # --allow-downgrades is to allow git packages to "downgrade", because the commits aren't necessarily a higher number than the last version
@@ -648,7 +648,7 @@ function install_deb() {
 }
 
 function repacstall() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # shellcheck disable=SC2034
     local depends_array unpackdir depends_line deper pacgives meper ceper pacdep depends_array_form repac_depends_str upcontrol input_dest="${1}"
     unpackdir="${STAGEDIR}/${pacname}"
@@ -724,7 +724,7 @@ function repacstall() {
 }
 
 function check_if_pacdep() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local package="${1}" finddir="${2}" found
     found="$(find "${finddir}" -type f -exec awk -v pkg="${package}" '
         $0 ~ "_pacdeps=\\(\\[" "[0-9]+" "\\]=\"" pkg "\"" {
@@ -741,7 +741,7 @@ function check_if_pacdep() {
 }
 
 function write_meta() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     echo "_name=\"$pacname\""
     if [[ -n $pkgbase ]]; then
         echo "_pkgbase=\"$pkgbase\""
@@ -786,7 +786,7 @@ function write_meta() {
 }
 
 function meta_log() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # Origin repo info parsing
     if [[ ${local} == "no" ]]; then
         # shellcheck disable=SC2153

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -601,13 +601,7 @@ function makedeb() {
     else
         local deb_arch="all"
     fi
-    if ! createdeb "${pacname}" "${full_version}" "${deb_arch}"; then
-        fancy_message error "Could not create package"
-        error_log 5 "install $pacname"
-        fancy_message info "Cleaning up"
-        cleanup
-        exit 1
-    fi
+    createdeb "${pacname}" "${full_version}" "${deb_arch}"
     install_deb "${pacname}" "${full_version}" "${deb_arch}"
 }
 
@@ -620,7 +614,7 @@ function install_deb() {
             echo -ne "\t"
             fancy_message error "Failed to install $pacname deb"
             error_log 8 "install $pacname"
-            sudo dpkg -r --force-all "$pacname" > /dev/null
+            sudo dpkg -r --force-all "${gives:-$pacname}" 2> /dev/null
             fancy_message info "Cleaning up"
             cleanup
             exit 1
@@ -717,13 +711,7 @@ function repacstall() {
     else
         local deb_arch="all"
     fi
-    if ! createdeb "${pacname}" "${full_version}" "${deb_arch}"; then
-        fancy_message error "Could not create package"
-        error_log 5 "install $pacname"
-        fancy_message info "Cleaning up"
-        cleanup
-        exit 1
-    fi
+    createdeb "${pacname}" "${full_version}" "${deb_arch}"
     install_deb "${pacname}" "${full_version}" "${deb_arch}"
 }
 

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -602,7 +602,7 @@ function makedeb() {
         error_log 5 "install $pacname"
         fancy_message info "Cleaning up"
         cleanup
-        { ignore_stack=true && return 1; }
+        exit 1
     fi
     install_deb "${pacname}" "${full_version}" "${deb_arch}"
 }
@@ -718,7 +718,7 @@ function repacstall() {
         error_log 5 "install $pacname"
         fancy_message info "Cleaning up"
         cleanup
-        { ignore_stack=true && return 1; }
+        exit 1
     fi
     install_deb "${pacname}" "${full_version}" "${deb_arch}"
 }

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -27,13 +27,13 @@
 # shellcheck source=./misc/scripts/version-constraints.sh
 source "${SCRIPTDIR}/scripts/version-constraints.sh" || {
     fancy_message error "Could not find version-constraints"
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 }
 
 # shellcheck source=./misc/scripts/srcinfo.sh
 source "${SCRIPTDIR}/scripts/srcinfo.sh" || {
     fancy_message error "Could not find srcinfo.sh"
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 }
 
 function deblog() {
@@ -111,7 +111,7 @@ function prompt_optdepends() {
                 for i in "${suggested_optdeps[@]}"; do
                     # print optdepends with bold package name
                     echo -e "\t\t[${BICyan}$z${NC}] ${BOLD}${i%%:\ *}${NC}: ${i#*:\ }"
-                    { ignore_stack=true && ((z++)); }
+                    { ignore_stack=true; ((z++)); }
                 done
                 unset z
                 # tab over the next line
@@ -125,7 +125,7 @@ function prompt_optdepends() {
                         local skip_opt+=("$i")
                         unset 'choices[$choice_inc]'
                     fi
-                    { ignore_stack=true && ((choice_inc++)); }
+                    { ignore_stack=true; ((choice_inc++)); }
                 done
                 if [[ -n ${skip_opt[*]} ]]; then
                     fancy_message warn "${BGreen}${skip_opt[*]}${NC} has exceeded the maximum number of optional dependencies. Skipping"
@@ -200,7 +200,7 @@ function prompt_optdepends() {
             local pipe_nomatch=0
             for ze_dep_split in "${ze_dep_splits[@]}"; do
                 if ! dep_const.apt_compare_to_constraints "${ze_dep_split}"; then
-                    { ignore_stack=true && ((pipe_nomatch++)); }
+                    { ignore_stack=true; ((pipe_nomatch++)); }
                 fi
             done
             if ((pipe_nomatch == ${#ze_dep_splits[@]})); then
@@ -245,13 +245,13 @@ function createdeb() {
         local compression="gz"
         local command="gzip"
     fi
-    cd "$STAGEDIR/$pacname" || { ignore_stack=true && return 1; }
+    cd "$STAGEDIR/$pacname" || { ignore_stack=true; return 1; }
     # https://tldp.org/HOWTO/html_single/Debian-Binary-Package-Building-HOWTO/#AEN66
     echo "2.0" | sudo tee debian-binary > /dev/null
     sudo tar -cf "$PWD/control.tar" -T /dev/null
     local CONTROL_LOCATION="$PWD/control.tar"
     # avoid having to cd back
-    pushd DEBIAN > /dev/null || { ignore_stack=true && return 1; }
+    pushd DEBIAN > /dev/null || { ignore_stack=true; return 1; }
     for i in *; do
         if [[ -f $i ]]; then
             local files_for_control+=("$i")
@@ -259,7 +259,7 @@ function createdeb() {
     done
     fancy_message sub "Packing control.tar"
     sudo tar -rf "$CONTROL_LOCATION" "${files_for_control[@]}"
-    popd > /dev/null || { ignore_stack=true && return 1; }
+    popd > /dev/null || { ignore_stack=true; return 1; }
     sudo tar -cf "$PWD/data.tar" -T /dev/null
     local DATA_LOCATION="$PWD/data.tar"
     # collect every top level file/dir except for deb stuff
@@ -287,7 +287,7 @@ function is_builddep_arch() {
     if [[ -n ${appendar[*]} ]]; then
         return 0
     else
-        { ignore_stack=true && return 1; }
+        { ignore_stack=true; return 1; }
     fi
 }
 
@@ -595,7 +595,7 @@ function makedeb() {
 
     generate_changelog | sudo tee -a "$STAGEDIR/$pacname/DEBIAN/changelog" > /dev/null
 
-    cd "$STAGEDIR" || { ignore_stack=true && return 1; }
+    cd "$STAGEDIR" || { ignore_stack=true; return 1; }
     if array.contains arch "${CARCH}" || array.contains arch "${AARCH}"; then
         local deb_arch="${CARCH}"
     else
@@ -728,7 +728,7 @@ function check_if_pacdep() {
         return 0
     else
         # shellcheck disable=SC2034
-        { ignore_stack=true && return 1; }
+        { ignore_stack=true; return 1; }
     fi
 }
 

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -732,7 +732,12 @@ function check_if_pacdep() {
         } END {
                 if (!found) {exit 1}
         }' {} \; -print)"
-    [[ ${found} ]] && return 0 || { ignore_stack=true && return 1; }
+    if [[ ${found} ]]; then
+        return 0
+    else
+        # shellcheck disable=SC2034
+        { ignore_stack=true && return 1; }
+    fi
 }
 
 function write_meta() {

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -616,7 +616,7 @@ function install_deb() {
             echo -ne "\t"
             fancy_message error "Failed to install $pacname deb"
             error_log 8 "install $pacname"
-            sudo dpkg -r --force-all "$pacname" > /dev/null
+            sudo dpkg -r --force-all "$pacname" 2> /dev/null
             fancy_message info "Cleaning up"
             cleanup
             exit 1

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -786,6 +786,7 @@ function write_meta() {
 }
 
 function meta_log() {
+    # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # Origin repo info parsing
     if [[ ${local} == "no" ]]; then

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -71,7 +71,7 @@ function prompt_optdepends() {
             # Let's get just the name
             dep_const.split_name_and_version "${opt}" just_name
             # Check if package exists in the repos, and if not, go to the next program
-            if [[ -z "$(apt-cache search --no-generate --names-only "^${just_name[0]}\$" 2> /dev/null || apt-cache search --names-only "^${just_name[0]}\$")" ]]; then
+            if [[ -z $(aptitude search --quiet --disable-columns "?exact-name(${just_name[0]%:*})?architecture($(dep_const.get_arch "${just_name[0]}"))" -F "%V") ]]; then
                 missing_optdeps+=("${just_name[0]}")
                 continue
             fi

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -52,8 +52,44 @@ function clean_builddir() {
 
 function prompt_optdepends() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local deps optdep opt optdesc just_name=() missing_optdeps=() not_satisfied_optdeps=()
-    deps=("${depends[@]}")
+    local dep real_dep optdep opt optdesc deps just_name missing_optdeps not_satisfied_optdeps missing_deps not_satisfied_deps
+    for dep in "${depends[@]}"; do
+        # Firstly, check if this is an alt dep list
+        if dep_const.is_pipe "${dep}"; then
+            real_dep="${dep}"
+            dep="$(dep_const.get_pipe "${dep}")"
+        fi
+        # Let's get just the name
+        dep_const.split_name_and_version "${dep}" just_name
+        echo "${just_name[0]}"
+        # Check if package exists in the repos, and if not, go to the next program
+        if [[ -z $(aptitude search --quiet --disable-columns "?exact-name(${just_name[0]%:*})?architecture($(dep_const.get_arch "${just_name[0]}"))" -F "%V") ]]; then
+            missing_deps+=("${real_dep}")
+            continue
+        fi
+        # Next let's check if the version (if available) is in the repos
+        if ! dep_const.apt_compare_to_constraints "${dep}"; then
+            # Just put the name in
+            not_satisfied_deps+=("${real_dep}")
+            continue
+        fi
+        # Add to the dependency list if already installed so it doesn't get autoremoved on upgrade
+        # If the package is not installed already, add it to the list. It's much easier for a user to choose from a list of uninstalled packages than every single one regardless of it'>
+        if ! is_apt_package_installed "${dep}"; then
+            deps+=("${real_dep}")
+        fi
+    done
+    if [[ -n ${missing_deps[*]} ]]; then
+        fancy_message error "${BLUE}${missing_deps[*]}${NC} does not exist in apt repositories"
+    fi
+    if [[ -n ${not_satisfied_deps[*]} ]]; then
+        fancy_message error "${BLUE}${not_satisfied_deps[*]}${NC} versions cannot be satisfied"
+    fi
+    if [[ -n ${missing_deps[*]} || -n ${not_satisfied_deps[*]} ]]; then
+        fancy_message info "Cleaning up"
+        cleanup
+        exit 1
+    fi
     if ((${#optdepends[@]} != 0)); then
         local suggested_optdeps=()
         for optdep in "${optdepends[@]}"; do
@@ -101,7 +137,6 @@ function prompt_optdepends() {
         if [[ -n ${not_satisfied_optdeps[*]} ]]; then
             echo -ne "\t"
             fancy_message warn "${BLUE}${not_satisfied_optdeps[*]}${NC} versions cannot be satisfied"
-
         fi
         if ((${#suggested_optdeps[@]} != 0)); then
             if ((PACSTALL_INSTALL != 0)); then

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -93,6 +93,7 @@ EOF
 }
 
 function bwrap_function() {
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local func="$1"
     tmpfile="$(sudo mktemp -p "${PWD}")"
     sudo tee -a "$tmpfile" > /dev/null << EOF

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -93,6 +93,7 @@ EOF
 
 function bwrap_function() {
     local func="$1"
+    # shellcheck disable=SC2064
     trap "fail_out_functions '$func' || stacktrace" ERR
     tmpfile="$(sudo mktemp -p "${PWD}")"
     sudo tee -a "$tmpfile" > /dev/null << EOF

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -22,10 +22,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 function safe_source() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local input="${1}"
     mkdir -p "${PACDIR}" 2> /dev/null
     tmpfile="$(sudo mktemp -p "${PACDIR}")"

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -25,6 +25,7 @@
 { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 function safe_source() {
+    # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local input="${1}"
     mkdir -p "${PACDIR}" 2> /dev/null

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -22,11 +22,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 function safe_source() {
     # shellcheck disable=SC2034
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local input="${1}"
     mkdir -p "${PACDIR}" 2> /dev/null
     tmpfile="$(sudo mktemp -p "${PACDIR}")"
@@ -94,7 +94,7 @@ EOF
 
 function bwrap_function() {
     # shellcheck disable=SC2034
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local func="$1"
     tmpfile="$(sudo mktemp -p "${PWD}")"
     sudo tee -a "$tmpfile" > /dev/null << EOF

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -93,6 +93,7 @@ EOF
 }
 
 function bwrap_function() {
+    # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local func="$1"
     tmpfile="$(sudo mktemp -p "${PWD}")"

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -22,9 +22,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
+trap stacktrace ERR
+
 function safe_source() {
+    trap stacktrace ERR
     local input="${1}"
-    mkdir "${PACDIR}" 2> /dev/null
+    mkdir -p "${PACDIR}" 2> /dev/null
     tmpfile="$(sudo mktemp -p "${PACDIR}")"
     local allvar_str pacfunc_str debfunc_str pacstall_funcs=("prepare" "build" "check" "package") \
     debian_funcs=("post_install" "post_remove" "post_upgrade" "pre_install" "pre_remove" "pre_upgrade")
@@ -89,6 +92,7 @@ EOF
 }
 
 function bwrap_function() {
+    trap stacktrace ERR
     local func="$1"
     tmpfile="$(sudo mktemp -p "${PWD}")"
     sudo tee -a "$tmpfile" > /dev/null << EOF

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -92,8 +92,8 @@ EOF
 }
 
 function bwrap_function() {
-    trap stacktrace ERR
     local func="$1"
+    trap "fail_out_functions '$func' || stacktrace" ERR
     tmpfile="$(sudo mktemp -p "${PWD}")"
     sudo tee -a "$tmpfile" > /dev/null << EOF
 #!/bin/bash -a
@@ -104,7 +104,7 @@ if [[ \$FUNCSTATUS ]]; then \
     mapfile -t NEW_ENV < <(/bin/env -0 \${OLD_ENV[@]} | \
         sed -ze 's/BASH_FUNC_\(.*\)%%=\(.*\)\$/\\n/g;s/^\\(.[[:alnum:]_]*\\)=\\(.*\\)\$/\\1/g'|tr '\0' '\n'); \
     declare -p \${NEW_ENV[@]} >> "${bwrapenv}"; \
-fi && exit \$FUNCSTATUS
+fi && ignore_stack=true && exit \$FUNCSTATUS
 EOF
     sudo chmod +x "$tmpfile"
 

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -94,8 +94,6 @@ EOF
 
 function bwrap_function() {
     local func="$1"
-    # shellcheck disable=SC2064
-    trap "fail_out_functions '$func' || stacktrace" ERR
     tmpfile="$(sudo mktemp -p "${PWD}")"
     sudo tee -a "$tmpfile" > /dev/null << EOF
 #!/bin/bash -a

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -116,7 +116,7 @@ function lint_epoch() {
 
 function lint_version() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local ret=0 lint_pkgver
+    local ret=0
     if [[ -n $pkgver ]]; then
         # https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
         if [[ ! $pkgver =~ ^[0-9][a-zA-Z0-9.+-~]+$ ]]; then

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -290,7 +290,7 @@ function lint_deps() {
                     fancy_message error "'${dep_type}' index '${idx}' is not formatted correctly"
                     ret=1
                 fi
-                { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
+                { ignore_stack=true && ((idx++)); }
             done
         fi
         if ((ret == 1)); then
@@ -309,7 +309,7 @@ function lint_ppa() {
                 fancy_message error "'ppa' index '${idx}' cannot be empty"
                 ret=1
             fi
-            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
+            { ignore_stack=true && ((idx++)); }
         done
         if ((ret != 0)); then
             { ignore_stack=true && return 1; }
@@ -320,7 +320,7 @@ function lint_ppa() {
                 fancy_message error "'ppa' index '${idx}' cannot start with 'ppa:'"
                 ret=1
             fi
-            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
+            { ignore_stack=true && ((idx++)); }
         done
         idx=0
         for el_ppa in "${ppa[@]}"; do
@@ -328,7 +328,7 @@ function lint_ppa() {
                 fancy_message error "'ppa' index '${idx}' is improperly formatted"
                 ret=1
             fi
-            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
+            { ignore_stack=true && ((idx++)); }
         done
     fi
     { ignore_stack=true && return "${ret}"; }
@@ -359,7 +359,7 @@ function lint_relations() {
                     fancy_message error "'${rel_type}' index '${idx}' cannot be empty"
                     ret=1
                 fi
-                { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
+                { ignore_stack=true && ((idx++)); }
             done
         fi
         if ((ret == 1)); then
@@ -450,7 +450,7 @@ function lint_fields() {
                         ;;
                 esac
             fi
-            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
+            { ignore_stack=true && ((idx++)); }
         done
         { ignore_stack=true && return "${ret}"; }
     fi
@@ -562,7 +562,7 @@ function lint_incompatible() {
                 fancy_message error "'compatible' index '${idx}' cannot be empty"
                 ret=1
             fi
-            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
+            { ignore_stack=true && ((idx++)); }
         done
         idx=0
         for compat in "${compatible[@]}"; do
@@ -570,7 +570,7 @@ function lint_incompatible() {
                 fancy_message error "'compatible' index '${idx}' is improperly formatted"
                 ret=1
             fi
-            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
+            { ignore_stack=true && ((idx++)); }
         done
     elif [[ -n ${incompatible[*]} ]]; then
         if [[ -n ${compatible[*]} ]]; then
@@ -585,7 +585,7 @@ function lint_incompatible() {
                 fancy_message error "'incompatible' index '${idx}' cannot be empty"
                 ret=1
             fi
-            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
+            { ignore_stack=true && ((idx++)); }
         done
         idx=0
         for incompat in "${incompatible[@]}"; do
@@ -593,7 +593,7 @@ function lint_incompatible() {
                 fancy_message error "'incompatible' index '${idx}' is improperly formatted"
                 ret=1
             fi
-            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
+            { ignore_stack=true && ((idx++)); }
         done
     fi
     { ignore_stack=true && return "${ret}"; }
@@ -616,7 +616,7 @@ function lint_arch() {
                 fancy_message error "'arch' index '${idx}' cannot be empty"
                 ret=1
             fi
-            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
+            { ignore_stack=true && ((idx++)); }
         done
         # Fail point
         if ((ret != 0)); then
@@ -653,7 +653,7 @@ function lint_mask() {
                 fancy_message error "'mask' index '${idx}' cannot be empty"
                 ret=1
             fi
-            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
+            { ignore_stack=true && ((idx++)); }
         done
     fi
     { ignore_stack=true && return "${ret}"; }
@@ -686,7 +686,7 @@ function lint_license() {
                 fancy_message error "'license' index '${idx}' cannot be empty"
                 ret=1
             fi
-            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
+            { ignore_stack=true && ((idx++)); }
             if ! array.contains license_list "${linlicense}"; then
                 if [[ ${linlicense} != "custom:"* ]]; then
                     fancy_message error "'${linlicense}' is not a valid license"

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -24,10 +24,10 @@
 
 # A collection of checks to verify a pacscript is correct
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 function lint_pacname() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local ret=0
     if [[ -z $pacname ]]; then
         fancy_message error "Package does not contain 'pacname'"
@@ -55,7 +55,7 @@ function lint_pacname() {
 }
 
 function lint_gives() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local ret=0
     if [[ -z $gives && $pacname == *-deb ]]; then
         fancy_message warn "Deb package does not contain gives"
@@ -85,7 +85,7 @@ function lint_gives() {
 }
 
 function lint_pkgrel() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local ret=0
     if [[ -v pkgrel ]]; then
         if [[ -z ${pkgrel} ]]; then
@@ -100,7 +100,7 @@ function lint_pkgrel() {
 }
 
 function lint_epoch() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local ret=0
     if [[ -v epoch ]]; then
         if [[ -z ${epoch} ]]; then
@@ -115,7 +115,7 @@ function lint_epoch() {
 }
 
 function lint_version() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local ret=0 lint_pkgver
     if [[ -n $pkgver ]]; then
         # https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
@@ -131,7 +131,7 @@ function lint_version() {
 }
 
 function lint_source_deb_test() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # shellcheck disable=SC2206
     local input_source=($@)
     for i in "${!input_source[@]}"; do
@@ -149,7 +149,7 @@ function lint_source_deb_test() {
 }
 
 function lint_source() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local ret=0 test_source has_source=0 source_distro_archs
     for source_distro in "${PACSTALL_KNOWN_DISTROS[@]}"; do
         for known_arch in "${PACSTALL_KNOWN_ARCH[@]}"; do
@@ -222,7 +222,7 @@ function lint_source() {
 }
 
 function lint_pkgdesc() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local ret=0
     if [[ -z $pkgdesc ]]; then
         fancy_message error "Package does not contain 'pkgdesc'"
@@ -232,7 +232,7 @@ function lint_pkgdesc() {
 }
 
 function lint_maintainer() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     if [[ -z ${maintainer[*]} ]]; then
         fancy_message warn "Package does not have a maintainer. Please be advised"
     fi
@@ -240,7 +240,7 @@ function lint_maintainer() {
 }
 
 function lint_var_arch() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local tinp tinputvar="${1}" tinputvar_arch="${1}_${2}${3:+_$3}[*]"
     declare -n test_ref_inputvar="test_${tinputvar}"
     if [[ -n ${!tinputvar_arch} ]]; then
@@ -253,12 +253,12 @@ function lint_var_arch() {
 }
 
 function lint_pipe_check() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     perl -ne 'exit 1 unless /^(?:[^\s|:]+(?::[^\s|:]+)?\s\|\s)+[^\s|:]+(?::[^\s|:]+)?(?::\s[^|:]+)?(?<!\s)$/' <<< "$1"
 }
 
 function lint_deps() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local dep_type dep_array ret=0 dep idx kdarch kdistro kddarch
     for dep_type in "depends" "makedepends" "optdepends" "checkdepends" "pacdeps"; do
         local -n dep_array="test_${dep_type}"
@@ -290,7 +290,7 @@ function lint_deps() {
                     fancy_message error "'${dep_type}' index '${idx}' is not formatted correctly"
                     ret=1
                 fi
-                ((idx++))
+                { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
             done
         fi
         if ((ret == 1)); then
@@ -301,7 +301,7 @@ function lint_deps() {
 }
 
 function lint_ppa() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local ret=0 el_ppa idx=0
     if [[ -n ${ppa[*]} ]]; then
         for el_ppa in "${ppa[@]}"; do
@@ -309,7 +309,7 @@ function lint_ppa() {
                 fancy_message error "'ppa' index '${idx}' cannot be empty"
                 ret=1
             fi
-            ((idx++))
+            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
         done
         if ((ret != 0)); then
             { ignore_stack=true && return 1; }
@@ -320,7 +320,7 @@ function lint_ppa() {
                 fancy_message error "'ppa' index '${idx}' cannot start with 'ppa:'"
                 ret=1
             fi
-            ((idx++))
+            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
         done
         idx=0
         for el_ppa in "${ppa[@]}"; do
@@ -328,14 +328,14 @@ function lint_ppa() {
                 fancy_message error "'ppa' index '${idx}' is improperly formatted"
                 ret=1
             fi
-            ((idx++))
+            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
         done
     fi
     { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_relations() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local rel_type rel_array ret=0 rela idx rdarch rdistro rddarch
     for rel_type in "conflicts" "breaks" "replaces" "provides" "enhances" "recommends" "makeconflicts" "checkconflicts"; do
         local -n rel_array="test_${rel_type}"
@@ -359,7 +359,7 @@ function lint_relations() {
                     fancy_message error "'${rel_type}' index '${idx}' cannot be empty"
                     ret=1
                 fi
-                ((idx++))
+                { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
             done
         fi
         if ((ret == 1)); then
@@ -370,7 +370,7 @@ function lint_relations() {
 }
 
 function lint_capital_check() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local str="${1}" i=0 c x z split_chars=()
     while printf -v c "%s%n" "${str:i++:1}" x; do
         if ((x)); then
@@ -390,7 +390,7 @@ function lint_capital_check() {
 }
 
 function lint_field_fmt() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local infield="${1}"
     # Ensure no spaces
     if [[ ${infield} =~ [[:space:]] ]]; then
@@ -413,7 +413,7 @@ function lint_field_fmt() {
 }
 
 function lint_fields() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # shellcheck disable=SC2034
     local ret=0 idx=0 tfield tlogvar deblog_used=("Suggests" "Depends" "Package" "Version" "Architecture" "Section" "Priority"
         "Essential" "Vcs-Git" "Build-Depends" "Build-Depends-Arch" "Build-Conflicts" "Build-Conflicts-Arch"
@@ -450,14 +450,14 @@ function lint_fields() {
                         ;;
                 esac
             fi
-            ((idx++))
+            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
         done
         { ignore_stack=true && return "${ret}"; }
     fi
 }
 
 function lint_hash() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local ret=0 test_hash harch test_hashsum_type test_hashsum_style test_hash_arch test_hashsum_method test_hashsum_value \
         hash_distro_archs
     for hash_distro in "${PACSTALL_KNOWN_DISTROS[@]}"; do
@@ -547,7 +547,7 @@ function lint_hash() {
 }
 
 function lint_incompatible() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local ret=0 incompat compat idx=0 comp_err=0
     if [[ -n ${compatible[*]} ]]; then
         if [[ -n ${incompatible[*]} ]]; then
@@ -562,7 +562,7 @@ function lint_incompatible() {
                 fancy_message error "'compatible' index '${idx}' cannot be empty"
                 ret=1
             fi
-            ((idx++))
+            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
         done
         idx=0
         for compat in "${compatible[@]}"; do
@@ -570,7 +570,7 @@ function lint_incompatible() {
                 fancy_message error "'compatible' index '${idx}' is improperly formatted"
                 ret=1
             fi
-            ((idx++))
+            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
         done
     elif [[ -n ${incompatible[*]} ]]; then
         if [[ -n ${compatible[*]} ]]; then
@@ -585,7 +585,7 @@ function lint_incompatible() {
                 fancy_message error "'incompatible' index '${idx}' cannot be empty"
                 ret=1
             fi
-            ((idx++))
+            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
         done
         idx=0
         for incompat in "${incompatible[@]}"; do
@@ -593,14 +593,14 @@ function lint_incompatible() {
                 fancy_message error "'incompatible' index '${idx}' is improperly formatted"
                 ret=1
             fi
-            ((idx++))
+            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
         done
     fi
     { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_arch() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # shellcheck disable=SC2034
     local ret=0 el_arch key idx=0 has_carch=false has_aarch=false known_archs=("any" "all" "${PACSTALL_KNOWN_ARCH[@]}")
     local -A AARCHS_MAP=(
@@ -616,7 +616,7 @@ function lint_arch() {
                 fancy_message error "'arch' index '${idx}' cannot be empty"
                 ret=1
             fi
-            ((idx++))
+            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
         done
         # Fail point
         if ((ret != 0)); then
@@ -645,7 +645,7 @@ function lint_arch() {
 }
 
 function lint_mask() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local ret=0 masked idx=0
     if [[ -n ${mask[*]} ]]; then
         for masked in "${mask[@]}"; do
@@ -653,14 +653,14 @@ function lint_mask() {
                 fancy_message error "'mask' index '${idx}' cannot be empty"
                 ret=1
             fi
-            ((idx++))
+            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
         done
     fi
     { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_priority() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     shopt -s extglob
     local ret=0
     if [[ -v priority ]]; then
@@ -677,7 +677,7 @@ function lint_priority() {
 }
 
 function lint_license() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # shellcheck disable=SC2034
     local ret=0 linlicense idx=0 license_list=("0BSD" "ADSL" "AFL-1.1" "AFL-1.2" "AFL-2.0" "AFL-2.1" "AFL-3.0" "AGPL-1.0-only" "AGPL-1.0-or-later" "AGPL-3.0-only" "AGPL-3.0-or-later" "AMDPLPA" "AML" "AMPAS" "APAFML" "APSL-1.0" "APSL-1.1" "APSL-1.2" "APSL-2.0" "Abstyles" "Adobe-2006" "Adobe-Glyph" "Afmparse" "Aladdin" "Apache-1.0" "Apache-1.1" "Apache-2.0" "Artistic-1.0-Perl" "Artistic-1.0-cl8" "Artistic-1.0" "Artistic-2.0" "BSD-1-Clause" "BSD-2-Clause-FreeBSD" "BSD-2-Clause-NetBSD" "BSD-2-Clause-Patent" "BSD-2-Clause" "BSD-3-Clause-Attribution" "BSD-3-Clause-Clear" "BSD-3-Clause-LBNL" "BSD-3-Clause-No-Nuclear-License-2014" "BSD-3-Clause-No-Nuclear-License" "BSD-3-Clause-No-Nuclear-Warranty" "BSD-3-Clause-Open-MPI" "BSD-3-Clause" "BSD-4-Clause-UC" "BSD-4-Clause" "BSD-Protection" "BSD-Source-Code" "BSL-1.0" "Bahyph" "BitTorrent-1.0" "BitTorrent-1.1" "BlueOak-1.0.0" "Borceux" "CATOSL-1.1" "CC-BY-1.0" "CC-BY-2.0" "CC-BY-2.5" "CC-BY-3.0" "CC-BY-4.0" "CC-BY-NC-1.0" "CC-BY-NC-2.0" "CC-BY-NC-2.5" "CC-BY-NC-3.0" "CC-BY-NC-4.0" "CC-BY-NC-ND-1.0" "CC-BY-NC-ND-2.0" "CC-BY-NC-ND-2.5" "CC-BY-NC-ND-3.0" "CC-BY-NC-ND-4.0" "CC-BY-NC-SA-1.0" "CC-BY-NC-SA-2.0" "CC-BY-NC-SA-2.5" "CC-BY-NC-SA-3.0" "CC-BY-NC-SA-4.0" "CC-BY-ND-1.0" "CC-BY-ND-2.0" "CC-BY-ND-2.5" "CC-BY-ND-3.0" "CC-BY-ND-4.0" "CC-BY-SA-1.0" "CC-BY-SA-2.0" "CC-BY-SA-2.5" "CC-BY-SA-3.0" "CC-BY-SA-4.0" "CC-PDDC" "CC0-1.0" "CDDL-1.0" "CDDL-1.1" "CDLA-Permissive-1.0" "CDLA-Sharing-1.0" "CECILL-1.0" "CECILL-1.1" "CECILL-2.0" "CECILL-2.1" "CECILL-B" "CECILL-C" "CERN-OHL-1.1" "CERN-OHL-1.2" "CNRI-Jython" "CNRI-Python-GPL-Compatible" "CNRI-Python" "CPAL-1.0" "CPL-1.0" "CPOL-1.02" "CUA-OPL-1.0" "Caldera" "ClArtistic" "Condor-1.1" "Cube" "D-FSL-1.0" "DSDP" "Dotseqn" "ECL-1.0" "ECL-2.0" "EFL-1.0" "EFL-2.0" "EPL-1.0" "EPL-2.0" "EUDatagrid" "EUPL-1.0" "EUPL-1.1" "EUPL-1.2" "Entessa" "Eurosym" "FSFAP" "FSFUL" "FSFULLR" "FTL" "Frameworx-1.0" "GFDL-1.1-only" "GFDL-1.1-or-later" "GFDL-1.2-only" "GFDL-1.2-or-later" "GFDL-1.3-only" "GFDL-1.3-or-later" "GL2PS" "GPL-1.0-only" "GPL-1.0-or-later" "GPL-2.0-only" "GPL-2.0-or-later" "GPL-3.0-linking-exception" "GPL-3.0-linking-source-exception" "GPL-3.0-only" "GPL-3.0-or-later" "GPL-CC-1.0" "Giftware" "Glulxe" "HPND-sell-variant" "HPND" "HaskellReport" "IBM-pibs" "ICU" "IJG" "IPA" "IPL-1.0" "ISC" "ImageMagick" "Imlib2" "Info-ZIP" "Intel-ACPI" "Intel" "JPNIC" "JSON" "JasPer-2.0" "LAL-1.2" "LAL-1.3" "LGPL-2.0-only" "LGPL-2.0-or-later" "LGPL-2.1-only" "LGPL-2.1-or-later" "LGPL-3.0-only" "LGPL-3.0-or-later" "LGPLLR" "LPL-1.0" "LPL-1.02" "LPPL-1.0" "LPPL-1.1" "LPPL-1.2" "LPPL-1.3a" "LPPL-1.3c" "Latex2e" "Leptonica" "LiLiQ-P-1.1" "LiLiQ-R-1.1" "LiLiQ-Rplus-1.1" "Libpng" "Linux-OpenIB" "Linux-syscall-note" "MIT-0" "MIT-CMU" "MIT-advertising" "MIT-enna" "MIT-feh" "MIT" "MITNFA" "MPL-1.0" "MPL-1.1" "MPL-2.0" "MS-PL" "MS-RL" "MTLL" "MakeIndex" "MirOS" "MulanPSL-1.0" "Multics" "Mup" "NASA-1.3" "NBPL-1.0" "NCSA" "NGPL" "NLOD-1.0" "NLPL" "NPL-1.0" "NPL-1.1" "NPOSL-3.0" "NRL" "NTP-0" "NTP" "Naumen" "Net-SNMP" "NetCDF" "Newsletr" "Nokia" "Noweb" "OCCT-PL" "OCLC-2.0" "ODC-By-1.0" "ODbL-1.0" "OFL-1.0-RFN" "OFL-1.0-no-RFN" "OFL-1.0" "OFL-1.1-RFN" "OFL-1.1-no-RFN" "OFL-1.1" "OGL-Canada-2.0" "OGL-UK-1.0" "OGL-UK-2.0" "OGL-UK-3.0" "OGTSL" "OLDAP-1.1" "OLDAP-1.2" "OLDAP-1.3" "OLDAP-1.4" "OLDAP-2.0.1" "OLDAP-2.0" "OLDAP-2.1" "OLDAP-2.2.1" "OLDAP-2.2.2" "OLDAP-2.2" "OLDAP-2.3" "OLDAP-2.4" "OLDAP-2.5" "OLDAP-2.6" "OLDAP-2.7" "OLDAP-2.8" "OML" "OPL-1.0" "OSET-PL-2.1" "OSL-1.0" "OSL-1.1" "OSL-2.0" "OSL-2.1" "OSL-3.0" "OpenSSL" "PDDL-1.0" "PHP-3.0" "PHP-3.01" "PSF-2.0" "Plexus" "PostgreSQL" "Python-2.0" "QPL-1.0" "Qhull" "RHeCos-1.1" "RPL-1.1" "RPL-1.5" "RPSL-1.0" "RSA-MD" "RSCPL" "Rdisc" "Ruby" "SAX-PD" "SCEA" "SGI-B-1.0" "SGI-B-1.1" "SGI-B-2.0" "SHL-0.5" "SHL-0.51" "SISSL-1.2" "SISSL" "SMLNJ" "SMPPL" "SNIA" "SPL-1.0" "SSH-OpenSSH" "SSPL-1.0" "SWL" "Saxpath" "Sendmail-8.23" "Sendmail" "SimPL-2.0" "Sleepycat" "TAPR-OHL-1.0" "TCL" "TCP-wrappers" "TMate" "TORQUE-1.1" "TOSL" "TU-Berlin-1.0" "TU-Berlin-2.0" "UCL-1.0" "UPL-1.0" "Unicode-DFS-2015" "Unicode-DFS-2016" "Unlicense" "VOSTROM" "VSL-1.0" "Vim" "W3C-19980720" "W3C-20150513" "W3C" "WTFPL" "Wsuipa" "X11" "XFree86-1.1" "Xerox" "Xnet" "ZPL-1.1" "ZPL-2.0" "ZPL-2.1" "Zed" "Zend-2.0" "Zlib" "bzip2-1.0.5" "bzip2-1.0.6" "curl" "eGenix" "etalab-2.0" "gSOAP-1.3b" "gnuplot" "iMatix" "libpng-2.0" "libselinux-1.0" "libtiff" "mpich2" "psfrag" "psutils" "xinetd" "xpp")
     if [[ -n ${license[*]} ]]; then
@@ -686,7 +686,7 @@ function lint_license() {
                 fancy_message error "'license' index '${idx}' cannot be empty"
                 ret=1
             fi
-            ((idx++))
+            { ignore_stack=true ((idx++))((idx++)) ((idx++)); }
             if ! array.contains license_list "${linlicense}"; then
                 if [[ ${linlicense} != "custom:"* ]]; then
                     fancy_message error "'${linlicense}' is not a valid license"
@@ -699,7 +699,7 @@ function lint_license() {
 }
 
 function checks() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local ret=0 check linting_checks=(lint_pacname lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_deps lint_ppa lint_relations lint_fields lint_hash lint_incompatible lint_arch lint_mask lint_priority lint_license)
     for check in "${linting_checks[@]}"; do
         "${check}" || ret=1

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -704,5 +704,6 @@ function checks() {
     for check in "${linting_checks[@]}"; do
         "${check}" || ret=1
     done
+    # shellcheck disable=SC2034
     { ignore_stack=true && return "${ret}"; }
 }

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -24,10 +24,10 @@
 
 # A collection of checks to verify a pacscript is correct
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 function lint_pacname() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ret=0
     if [[ -z $pacname ]]; then
         fancy_message error "Package does not contain 'pacname'"
@@ -55,7 +55,7 @@ function lint_pacname() {
 }
 
 function lint_gives() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ret=0
     if [[ -z $gives && $pacname == *-deb ]]; then
         fancy_message warn "Deb package does not contain gives"
@@ -85,7 +85,7 @@ function lint_gives() {
 }
 
 function lint_pkgrel() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ret=0
     if [[ -v pkgrel ]]; then
         if [[ -z ${pkgrel} ]]; then
@@ -100,7 +100,7 @@ function lint_pkgrel() {
 }
 
 function lint_epoch() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ret=0
     if [[ -v epoch ]]; then
         if [[ -z ${epoch} ]]; then
@@ -115,7 +115,7 @@ function lint_epoch() {
 }
 
 function lint_version() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ret=0 lint_pkgver
     if [[ -n $pkgver ]]; then
         # https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
@@ -131,7 +131,7 @@ function lint_version() {
 }
 
 function lint_source_deb_test() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # shellcheck disable=SC2206
     local input_source=($@)
     for i in "${!input_source[@]}"; do
@@ -149,7 +149,7 @@ function lint_source_deb_test() {
 }
 
 function lint_source() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ret=0 test_source has_source=0 source_distro_archs
     for source_distro in "${PACSTALL_KNOWN_DISTROS[@]}"; do
         for known_arch in "${PACSTALL_KNOWN_ARCH[@]}"; do
@@ -222,7 +222,7 @@ function lint_source() {
 }
 
 function lint_pkgdesc() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ret=0
     if [[ -z $pkgdesc ]]; then
         fancy_message error "Package does not contain 'pkgdesc'"
@@ -232,7 +232,7 @@ function lint_pkgdesc() {
 }
 
 function lint_maintainer() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     if [[ -z ${maintainer[*]} ]]; then
         fancy_message warn "Package does not have a maintainer. Please be advised"
     fi
@@ -240,7 +240,7 @@ function lint_maintainer() {
 }
 
 function lint_var_arch() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local tinp tinputvar="${1}" tinputvar_arch="${1}_${2}${3:+_$3}[*]"
     declare -n test_ref_inputvar="test_${tinputvar}"
     if [[ -n ${!tinputvar_arch} ]]; then
@@ -253,12 +253,12 @@ function lint_var_arch() {
 }
 
 function lint_pipe_check() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     perl -ne 'exit 1 unless /^(?:[^\s|:]+(?::[^\s|:]+)?\s\|\s)+[^\s|:]+(?::[^\s|:]+)?(?::\s[^|:]+)?(?<!\s)$/' <<< "$1"
 }
 
 function lint_deps() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local dep_type dep_array ret=0 dep idx kdarch kdistro kddarch
     for dep_type in "depends" "makedepends" "optdepends" "checkdepends" "pacdeps"; do
         local -n dep_array="test_${dep_type}"
@@ -301,7 +301,7 @@ function lint_deps() {
 }
 
 function lint_ppa() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ret=0 el_ppa idx=0
     if [[ -n ${ppa[*]} ]]; then
         for el_ppa in "${ppa[@]}"; do
@@ -335,7 +335,7 @@ function lint_ppa() {
 }
 
 function lint_relations() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local rel_type rel_array ret=0 rela idx rdarch rdistro rddarch
     for rel_type in "conflicts" "breaks" "replaces" "provides" "enhances" "recommends" "makeconflicts" "checkconflicts"; do
         local -n rel_array="test_${rel_type}"
@@ -370,7 +370,7 @@ function lint_relations() {
 }
 
 function lint_capital_check() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local str="${1}" i=0 c x z split_chars=()
     while printf -v c "%s%n" "${str:i++:1}" x; do
         if ((x)); then
@@ -390,7 +390,7 @@ function lint_capital_check() {
 }
 
 function lint_field_fmt() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local infield="${1}"
     # Ensure no spaces
     if [[ ${infield} =~ [[:space:]] ]]; then
@@ -413,7 +413,7 @@ function lint_field_fmt() {
 }
 
 function lint_fields() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # shellcheck disable=SC2034
     local ret=0 idx=0 tfield tlogvar deblog_used=("Suggests" "Depends" "Package" "Version" "Architecture" "Section" "Priority"
         "Essential" "Vcs-Git" "Build-Depends" "Build-Depends-Arch" "Build-Conflicts" "Build-Conflicts-Arch"
@@ -457,7 +457,7 @@ function lint_fields() {
 }
 
 function lint_hash() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ret=0 test_hash harch test_hashsum_type test_hashsum_style test_hash_arch test_hashsum_method test_hashsum_value \
         hash_distro_archs
     for hash_distro in "${PACSTALL_KNOWN_DISTROS[@]}"; do
@@ -547,7 +547,7 @@ function lint_hash() {
 }
 
 function lint_incompatible() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ret=0 incompat compat idx=0 comp_err=0
     if [[ -n ${compatible[*]} ]]; then
         if [[ -n ${incompatible[*]} ]]; then
@@ -600,7 +600,7 @@ function lint_incompatible() {
 }
 
 function lint_arch() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # shellcheck disable=SC2034
     local ret=0 el_arch key idx=0 has_carch=false has_aarch=false known_archs=("any" "all" "${PACSTALL_KNOWN_ARCH[@]}")
     local -A AARCHS_MAP=(
@@ -645,7 +645,7 @@ function lint_arch() {
 }
 
 function lint_mask() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ret=0 masked idx=0
     if [[ -n ${mask[*]} ]]; then
         for masked in "${mask[@]}"; do
@@ -660,7 +660,7 @@ function lint_mask() {
 }
 
 function lint_priority() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     shopt -s extglob
     local ret=0
     if [[ -v priority ]]; then
@@ -677,7 +677,7 @@ function lint_priority() {
 }
 
 function lint_license() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # shellcheck disable=SC2034
     local ret=0 linlicense idx=0 license_list=("0BSD" "ADSL" "AFL-1.1" "AFL-1.2" "AFL-2.0" "AFL-2.1" "AFL-3.0" "AGPL-1.0-only" "AGPL-1.0-or-later" "AGPL-3.0-only" "AGPL-3.0-or-later" "AMDPLPA" "AML" "AMPAS" "APAFML" "APSL-1.0" "APSL-1.1" "APSL-1.2" "APSL-2.0" "Abstyles" "Adobe-2006" "Adobe-Glyph" "Afmparse" "Aladdin" "Apache-1.0" "Apache-1.1" "Apache-2.0" "Artistic-1.0-Perl" "Artistic-1.0-cl8" "Artistic-1.0" "Artistic-2.0" "BSD-1-Clause" "BSD-2-Clause-FreeBSD" "BSD-2-Clause-NetBSD" "BSD-2-Clause-Patent" "BSD-2-Clause" "BSD-3-Clause-Attribution" "BSD-3-Clause-Clear" "BSD-3-Clause-LBNL" "BSD-3-Clause-No-Nuclear-License-2014" "BSD-3-Clause-No-Nuclear-License" "BSD-3-Clause-No-Nuclear-Warranty" "BSD-3-Clause-Open-MPI" "BSD-3-Clause" "BSD-4-Clause-UC" "BSD-4-Clause" "BSD-Protection" "BSD-Source-Code" "BSL-1.0" "Bahyph" "BitTorrent-1.0" "BitTorrent-1.1" "BlueOak-1.0.0" "Borceux" "CATOSL-1.1" "CC-BY-1.0" "CC-BY-2.0" "CC-BY-2.5" "CC-BY-3.0" "CC-BY-4.0" "CC-BY-NC-1.0" "CC-BY-NC-2.0" "CC-BY-NC-2.5" "CC-BY-NC-3.0" "CC-BY-NC-4.0" "CC-BY-NC-ND-1.0" "CC-BY-NC-ND-2.0" "CC-BY-NC-ND-2.5" "CC-BY-NC-ND-3.0" "CC-BY-NC-ND-4.0" "CC-BY-NC-SA-1.0" "CC-BY-NC-SA-2.0" "CC-BY-NC-SA-2.5" "CC-BY-NC-SA-3.0" "CC-BY-NC-SA-4.0" "CC-BY-ND-1.0" "CC-BY-ND-2.0" "CC-BY-ND-2.5" "CC-BY-ND-3.0" "CC-BY-ND-4.0" "CC-BY-SA-1.0" "CC-BY-SA-2.0" "CC-BY-SA-2.5" "CC-BY-SA-3.0" "CC-BY-SA-4.0" "CC-PDDC" "CC0-1.0" "CDDL-1.0" "CDDL-1.1" "CDLA-Permissive-1.0" "CDLA-Sharing-1.0" "CECILL-1.0" "CECILL-1.1" "CECILL-2.0" "CECILL-2.1" "CECILL-B" "CECILL-C" "CERN-OHL-1.1" "CERN-OHL-1.2" "CNRI-Jython" "CNRI-Python-GPL-Compatible" "CNRI-Python" "CPAL-1.0" "CPL-1.0" "CPOL-1.02" "CUA-OPL-1.0" "Caldera" "ClArtistic" "Condor-1.1" "Cube" "D-FSL-1.0" "DSDP" "Dotseqn" "ECL-1.0" "ECL-2.0" "EFL-1.0" "EFL-2.0" "EPL-1.0" "EPL-2.0" "EUDatagrid" "EUPL-1.0" "EUPL-1.1" "EUPL-1.2" "Entessa" "Eurosym" "FSFAP" "FSFUL" "FSFULLR" "FTL" "Frameworx-1.0" "GFDL-1.1-only" "GFDL-1.1-or-later" "GFDL-1.2-only" "GFDL-1.2-or-later" "GFDL-1.3-only" "GFDL-1.3-or-later" "GL2PS" "GPL-1.0-only" "GPL-1.0-or-later" "GPL-2.0-only" "GPL-2.0-or-later" "GPL-3.0-linking-exception" "GPL-3.0-linking-source-exception" "GPL-3.0-only" "GPL-3.0-or-later" "GPL-CC-1.0" "Giftware" "Glulxe" "HPND-sell-variant" "HPND" "HaskellReport" "IBM-pibs" "ICU" "IJG" "IPA" "IPL-1.0" "ISC" "ImageMagick" "Imlib2" "Info-ZIP" "Intel-ACPI" "Intel" "JPNIC" "JSON" "JasPer-2.0" "LAL-1.2" "LAL-1.3" "LGPL-2.0-only" "LGPL-2.0-or-later" "LGPL-2.1-only" "LGPL-2.1-or-later" "LGPL-3.0-only" "LGPL-3.0-or-later" "LGPLLR" "LPL-1.0" "LPL-1.02" "LPPL-1.0" "LPPL-1.1" "LPPL-1.2" "LPPL-1.3a" "LPPL-1.3c" "Latex2e" "Leptonica" "LiLiQ-P-1.1" "LiLiQ-R-1.1" "LiLiQ-Rplus-1.1" "Libpng" "Linux-OpenIB" "Linux-syscall-note" "MIT-0" "MIT-CMU" "MIT-advertising" "MIT-enna" "MIT-feh" "MIT" "MITNFA" "MPL-1.0" "MPL-1.1" "MPL-2.0" "MS-PL" "MS-RL" "MTLL" "MakeIndex" "MirOS" "MulanPSL-1.0" "Multics" "Mup" "NASA-1.3" "NBPL-1.0" "NCSA" "NGPL" "NLOD-1.0" "NLPL" "NPL-1.0" "NPL-1.1" "NPOSL-3.0" "NRL" "NTP-0" "NTP" "Naumen" "Net-SNMP" "NetCDF" "Newsletr" "Nokia" "Noweb" "OCCT-PL" "OCLC-2.0" "ODC-By-1.0" "ODbL-1.0" "OFL-1.0-RFN" "OFL-1.0-no-RFN" "OFL-1.0" "OFL-1.1-RFN" "OFL-1.1-no-RFN" "OFL-1.1" "OGL-Canada-2.0" "OGL-UK-1.0" "OGL-UK-2.0" "OGL-UK-3.0" "OGTSL" "OLDAP-1.1" "OLDAP-1.2" "OLDAP-1.3" "OLDAP-1.4" "OLDAP-2.0.1" "OLDAP-2.0" "OLDAP-2.1" "OLDAP-2.2.1" "OLDAP-2.2.2" "OLDAP-2.2" "OLDAP-2.3" "OLDAP-2.4" "OLDAP-2.5" "OLDAP-2.6" "OLDAP-2.7" "OLDAP-2.8" "OML" "OPL-1.0" "OSET-PL-2.1" "OSL-1.0" "OSL-1.1" "OSL-2.0" "OSL-2.1" "OSL-3.0" "OpenSSL" "PDDL-1.0" "PHP-3.0" "PHP-3.01" "PSF-2.0" "Plexus" "PostgreSQL" "Python-2.0" "QPL-1.0" "Qhull" "RHeCos-1.1" "RPL-1.1" "RPL-1.5" "RPSL-1.0" "RSA-MD" "RSCPL" "Rdisc" "Ruby" "SAX-PD" "SCEA" "SGI-B-1.0" "SGI-B-1.1" "SGI-B-2.0" "SHL-0.5" "SHL-0.51" "SISSL-1.2" "SISSL" "SMLNJ" "SMPPL" "SNIA" "SPL-1.0" "SSH-OpenSSH" "SSPL-1.0" "SWL" "Saxpath" "Sendmail-8.23" "Sendmail" "SimPL-2.0" "Sleepycat" "TAPR-OHL-1.0" "TCL" "TCP-wrappers" "TMate" "TORQUE-1.1" "TOSL" "TU-Berlin-1.0" "TU-Berlin-2.0" "UCL-1.0" "UPL-1.0" "Unicode-DFS-2015" "Unicode-DFS-2016" "Unlicense" "VOSTROM" "VSL-1.0" "Vim" "W3C-19980720" "W3C-20150513" "W3C" "WTFPL" "Wsuipa" "X11" "XFree86-1.1" "Xerox" "Xnet" "ZPL-1.1" "ZPL-2.0" "ZPL-2.1" "Zed" "Zend-2.0" "Zlib" "bzip2-1.0.5" "bzip2-1.0.6" "curl" "eGenix" "etalab-2.0" "gSOAP-1.3b" "gnuplot" "iMatix" "libpng-2.0" "libselinux-1.0" "libtiff" "mpich2" "psfrag" "psutils" "xinetd" "xpp")
     if [[ -n ${license[*]} ]]; then
@@ -699,7 +699,7 @@ function lint_license() {
 }
 
 function checks() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local ret=0 check linting_checks=(lint_pacname lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_deps lint_ppa lint_relations lint_fields lint_hash lint_incompatible lint_arch lint_mask lint_priority lint_license)
     for check in "${linting_checks[@]}"; do
         "${check}" || ret=1

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -24,11 +24,14 @@
 
 # A collection of checks to verify a pacscript is correct
 
+trap stacktrace ERR
+
 function lint_pacname() {
+    trap stacktrace ERR
     local ret=0
     if [[ -z $pacname ]]; then
         fancy_message error "Package does not contain 'pacname'"
-        return 1
+        { ignore_stack=true && return 1; }
     fi
     # https://www.debian.org/doc/debian-policy/ch-controlfields.html#source
     if ((${#pacname} < 2)); then
@@ -48,10 +51,11 @@ function lint_pacname() {
         fancy_message error "pacname: '${pacname}' contains characters that are not lowercase, digits, minus, or periods"
         ret=1
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_gives() {
+    trap stacktrace ERR
     local ret=0
     if [[ -z $gives && $pacname == *-deb ]]; then
         fancy_message warn "Deb package does not contain gives"
@@ -77,10 +81,11 @@ function lint_gives() {
             ret=1
         fi
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_pkgrel() {
+    trap stacktrace ERR
     local ret=0
     if [[ -v pkgrel ]]; then
         if [[ -z ${pkgrel} ]]; then
@@ -91,10 +96,11 @@ function lint_pkgrel() {
             ret=1
         fi
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_epoch() {
+    trap stacktrace ERR
     local ret=0
     if [[ -v epoch ]]; then
         if [[ -z ${epoch} ]]; then
@@ -105,10 +111,11 @@ function lint_epoch() {
             ret=1
         fi
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_version() {
+    trap stacktrace ERR
     local ret=0 lint_pkgver
     if [[ -n $pkgver ]]; then
         # https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
@@ -120,10 +127,11 @@ function lint_version() {
         fancy_message error "Package does not contain 'pkgver'"
         ret=1
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_source_deb_test() {
+    trap stacktrace ERR
     # shellcheck disable=SC2206
     local input_source=($@)
     for i in "${!input_source[@]}"; do
@@ -141,6 +149,7 @@ function lint_source_deb_test() {
 }
 
 function lint_source() {
+    trap stacktrace ERR
     local ret=0 test_source has_source=0 source_distro_archs
     for source_distro in "${PACSTALL_KNOWN_DISTROS[@]}"; do
         for known_arch in "${PACSTALL_KNOWN_ARCH[@]}"; do
@@ -209,19 +218,21 @@ function lint_source() {
             lint_source_deb_test "${source[@]}"
         fi
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_pkgdesc() {
+    trap stacktrace ERR
     local ret=0
     if [[ -z $pkgdesc ]]; then
         fancy_message error "Package does not contain 'pkgdesc'"
         ret=1
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_maintainer() {
+    trap stacktrace ERR
     if [[ -z ${maintainer[*]} ]]; then
         fancy_message warn "Package does not have a maintainer. Please be advised"
     fi
@@ -229,6 +240,7 @@ function lint_maintainer() {
 }
 
 function lint_var_arch() {
+    trap stacktrace ERR
     local tinp tinputvar="${1}" tinputvar_arch="${1}_${2}${3:+_$3}[*]"
     declare -n test_ref_inputvar="test_${tinputvar}"
     if [[ -n ${!tinputvar_arch} ]]; then
@@ -241,10 +253,12 @@ function lint_var_arch() {
 }
 
 function lint_pipe_check() {
+    trap stacktrace ERR
     perl -ne 'exit 1 unless /^(?:[^\s|:]+(?::[^\s|:]+)?\s\|\s)+[^\s|:]+(?::[^\s|:]+)?(?::\s[^|:]+)?(?<!\s)$/' <<< "$1"
 }
 
 function lint_deps() {
+    trap stacktrace ERR
     local dep_type dep_array ret=0 dep idx kdarch kdistro kddarch
     for dep_type in "depends" "makedepends" "optdepends" "checkdepends" "pacdeps"; do
         local -n dep_array="test_${dep_type}"
@@ -283,10 +297,11 @@ function lint_deps() {
             break
         fi
     done
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_ppa() {
+    trap stacktrace ERR
     local ret=0 el_ppa idx=0
     if [[ -n ${ppa[*]} ]]; then
         for el_ppa in "${ppa[@]}"; do
@@ -297,7 +312,7 @@ function lint_ppa() {
             ((idx++))
         done
         if ((ret != 0)); then
-            return 1
+            { ignore_stack=true && return 1; }
         fi
         idx=0
         for el_ppa in "${ppa[@]}"; do
@@ -316,10 +331,11 @@ function lint_ppa() {
             ((idx++))
         done
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_relations() {
+    trap stacktrace ERR
     local rel_type rel_array ret=0 rela idx rdarch rdistro rddarch
     for rel_type in "conflicts" "breaks" "replaces" "provides" "enhances" "recommends" "makeconflicts" "checkconflicts"; do
         local -n rel_array="test_${rel_type}"
@@ -350,10 +366,11 @@ function lint_relations() {
             break
         fi
     done
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_capital_check() {
+    trap stacktrace ERR
     local str="${1}" i=0 c x z split_chars=()
     while printf -v c "%s%n" "${str:i++:1}" x; do
         if ((x)); then
@@ -366,17 +383,18 @@ function lint_capital_check() {
         if [[ ${split_chars[$z]} == '-' ]]; then
             # Is the next letter a capital?
             if [[ ${split_chars[z + 1]} != "${split_chars[z + 1]^}" ]]; then
-                return 1
+                { ignore_stack=true && return 1; }
             fi
         fi
     done
 }
 
 function lint_field_fmt() {
+    trap stacktrace ERR
     local infield="${1}"
     # Ensure no spaces
     if [[ ${infield} =~ [[:space:]] ]]; then
-        return 1
+        { ignore_stack=true && return 1; }
     # Ensure no numbers
     elif [[ ${infield} =~ [0-9] ]]; then
         return 2
@@ -395,6 +413,7 @@ function lint_field_fmt() {
 }
 
 function lint_fields() {
+    trap stacktrace ERR
     # shellcheck disable=SC2034
     local ret=0 idx=0 tfield tlogvar deblog_used=("Suggests" "Depends" "Package" "Version" "Architecture" "Section" "Priority"
         "Essential" "Vcs-Git" "Build-Depends" "Build-Depends-Arch" "Build-Conflicts" "Build-Conflicts-Arch"
@@ -433,11 +452,12 @@ function lint_fields() {
             fi
             ((idx++))
         done
-        return "${ret}"
+        { ignore_stack=true && return "${ret}"; }
     fi
 }
 
 function lint_hash() {
+    trap stacktrace ERR
     local ret=0 test_hash harch test_hashsum_type test_hashsum_style test_hash_arch test_hashsum_method test_hashsum_value \
         hash_distro_archs
     for hash_distro in "${PACSTALL_KNOWN_DISTROS[@]}"; do
@@ -523,10 +543,11 @@ function lint_hash() {
             fi
         done
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_incompatible() {
+    trap stacktrace ERR
     local ret=0 incompat compat idx=0 comp_err=0
     if [[ -n ${compatible[*]} ]]; then
         if [[ -n ${incompatible[*]} ]]; then
@@ -575,10 +596,11 @@ function lint_incompatible() {
             ((idx++))
         done
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_arch() {
+    trap stacktrace ERR
     # shellcheck disable=SC2034
     local ret=0 el_arch key idx=0 has_carch=false has_aarch=false known_archs=("any" "all" "${PACSTALL_KNOWN_ARCH[@]}")
     local -A AARCHS_MAP=(
@@ -598,7 +620,7 @@ function lint_arch() {
         done
         # Fail point
         if ((ret != 0)); then
-            return 1
+            { ignore_stack=true && return 1; }
         fi
         for el_arch in "${arch[@]}"; do
             if ! array.contains known_archs "${el_arch}"; then
@@ -619,10 +641,11 @@ function lint_arch() {
             ret=1
         fi
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_mask() {
+    trap stacktrace ERR
     local ret=0 masked idx=0
     if [[ -n ${mask[*]} ]]; then
         for masked in "${mask[@]}"; do
@@ -633,10 +656,11 @@ function lint_mask() {
             ((idx++))
         done
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_priority() {
+    trap stacktrace ERR
     shopt -s extglob
     local ret=0
     if [[ -v priority ]]; then
@@ -649,10 +673,11 @@ function lint_priority() {
         fi
     fi
     shopt -u extglob
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function lint_license() {
+    trap stacktrace ERR
     # shellcheck disable=SC2034
     local ret=0 linlicense idx=0 license_list=("0BSD" "ADSL" "AFL-1.1" "AFL-1.2" "AFL-2.0" "AFL-2.1" "AFL-3.0" "AGPL-1.0-only" "AGPL-1.0-or-later" "AGPL-3.0-only" "AGPL-3.0-or-later" "AMDPLPA" "AML" "AMPAS" "APAFML" "APSL-1.0" "APSL-1.1" "APSL-1.2" "APSL-2.0" "Abstyles" "Adobe-2006" "Adobe-Glyph" "Afmparse" "Aladdin" "Apache-1.0" "Apache-1.1" "Apache-2.0" "Artistic-1.0-Perl" "Artistic-1.0-cl8" "Artistic-1.0" "Artistic-2.0" "BSD-1-Clause" "BSD-2-Clause-FreeBSD" "BSD-2-Clause-NetBSD" "BSD-2-Clause-Patent" "BSD-2-Clause" "BSD-3-Clause-Attribution" "BSD-3-Clause-Clear" "BSD-3-Clause-LBNL" "BSD-3-Clause-No-Nuclear-License-2014" "BSD-3-Clause-No-Nuclear-License" "BSD-3-Clause-No-Nuclear-Warranty" "BSD-3-Clause-Open-MPI" "BSD-3-Clause" "BSD-4-Clause-UC" "BSD-4-Clause" "BSD-Protection" "BSD-Source-Code" "BSL-1.0" "Bahyph" "BitTorrent-1.0" "BitTorrent-1.1" "BlueOak-1.0.0" "Borceux" "CATOSL-1.1" "CC-BY-1.0" "CC-BY-2.0" "CC-BY-2.5" "CC-BY-3.0" "CC-BY-4.0" "CC-BY-NC-1.0" "CC-BY-NC-2.0" "CC-BY-NC-2.5" "CC-BY-NC-3.0" "CC-BY-NC-4.0" "CC-BY-NC-ND-1.0" "CC-BY-NC-ND-2.0" "CC-BY-NC-ND-2.5" "CC-BY-NC-ND-3.0" "CC-BY-NC-ND-4.0" "CC-BY-NC-SA-1.0" "CC-BY-NC-SA-2.0" "CC-BY-NC-SA-2.5" "CC-BY-NC-SA-3.0" "CC-BY-NC-SA-4.0" "CC-BY-ND-1.0" "CC-BY-ND-2.0" "CC-BY-ND-2.5" "CC-BY-ND-3.0" "CC-BY-ND-4.0" "CC-BY-SA-1.0" "CC-BY-SA-2.0" "CC-BY-SA-2.5" "CC-BY-SA-3.0" "CC-BY-SA-4.0" "CC-PDDC" "CC0-1.0" "CDDL-1.0" "CDDL-1.1" "CDLA-Permissive-1.0" "CDLA-Sharing-1.0" "CECILL-1.0" "CECILL-1.1" "CECILL-2.0" "CECILL-2.1" "CECILL-B" "CECILL-C" "CERN-OHL-1.1" "CERN-OHL-1.2" "CNRI-Jython" "CNRI-Python-GPL-Compatible" "CNRI-Python" "CPAL-1.0" "CPL-1.0" "CPOL-1.02" "CUA-OPL-1.0" "Caldera" "ClArtistic" "Condor-1.1" "Cube" "D-FSL-1.0" "DSDP" "Dotseqn" "ECL-1.0" "ECL-2.0" "EFL-1.0" "EFL-2.0" "EPL-1.0" "EPL-2.0" "EUDatagrid" "EUPL-1.0" "EUPL-1.1" "EUPL-1.2" "Entessa" "Eurosym" "FSFAP" "FSFUL" "FSFULLR" "FTL" "Frameworx-1.0" "GFDL-1.1-only" "GFDL-1.1-or-later" "GFDL-1.2-only" "GFDL-1.2-or-later" "GFDL-1.3-only" "GFDL-1.3-or-later" "GL2PS" "GPL-1.0-only" "GPL-1.0-or-later" "GPL-2.0-only" "GPL-2.0-or-later" "GPL-3.0-linking-exception" "GPL-3.0-linking-source-exception" "GPL-3.0-only" "GPL-3.0-or-later" "GPL-CC-1.0" "Giftware" "Glulxe" "HPND-sell-variant" "HPND" "HaskellReport" "IBM-pibs" "ICU" "IJG" "IPA" "IPL-1.0" "ISC" "ImageMagick" "Imlib2" "Info-ZIP" "Intel-ACPI" "Intel" "JPNIC" "JSON" "JasPer-2.0" "LAL-1.2" "LAL-1.3" "LGPL-2.0-only" "LGPL-2.0-or-later" "LGPL-2.1-only" "LGPL-2.1-or-later" "LGPL-3.0-only" "LGPL-3.0-or-later" "LGPLLR" "LPL-1.0" "LPL-1.02" "LPPL-1.0" "LPPL-1.1" "LPPL-1.2" "LPPL-1.3a" "LPPL-1.3c" "Latex2e" "Leptonica" "LiLiQ-P-1.1" "LiLiQ-R-1.1" "LiLiQ-Rplus-1.1" "Libpng" "Linux-OpenIB" "Linux-syscall-note" "MIT-0" "MIT-CMU" "MIT-advertising" "MIT-enna" "MIT-feh" "MIT" "MITNFA" "MPL-1.0" "MPL-1.1" "MPL-2.0" "MS-PL" "MS-RL" "MTLL" "MakeIndex" "MirOS" "MulanPSL-1.0" "Multics" "Mup" "NASA-1.3" "NBPL-1.0" "NCSA" "NGPL" "NLOD-1.0" "NLPL" "NPL-1.0" "NPL-1.1" "NPOSL-3.0" "NRL" "NTP-0" "NTP" "Naumen" "Net-SNMP" "NetCDF" "Newsletr" "Nokia" "Noweb" "OCCT-PL" "OCLC-2.0" "ODC-By-1.0" "ODbL-1.0" "OFL-1.0-RFN" "OFL-1.0-no-RFN" "OFL-1.0" "OFL-1.1-RFN" "OFL-1.1-no-RFN" "OFL-1.1" "OGL-Canada-2.0" "OGL-UK-1.0" "OGL-UK-2.0" "OGL-UK-3.0" "OGTSL" "OLDAP-1.1" "OLDAP-1.2" "OLDAP-1.3" "OLDAP-1.4" "OLDAP-2.0.1" "OLDAP-2.0" "OLDAP-2.1" "OLDAP-2.2.1" "OLDAP-2.2.2" "OLDAP-2.2" "OLDAP-2.3" "OLDAP-2.4" "OLDAP-2.5" "OLDAP-2.6" "OLDAP-2.7" "OLDAP-2.8" "OML" "OPL-1.0" "OSET-PL-2.1" "OSL-1.0" "OSL-1.1" "OSL-2.0" "OSL-2.1" "OSL-3.0" "OpenSSL" "PDDL-1.0" "PHP-3.0" "PHP-3.01" "PSF-2.0" "Plexus" "PostgreSQL" "Python-2.0" "QPL-1.0" "Qhull" "RHeCos-1.1" "RPL-1.1" "RPL-1.5" "RPSL-1.0" "RSA-MD" "RSCPL" "Rdisc" "Ruby" "SAX-PD" "SCEA" "SGI-B-1.0" "SGI-B-1.1" "SGI-B-2.0" "SHL-0.5" "SHL-0.51" "SISSL-1.2" "SISSL" "SMLNJ" "SMPPL" "SNIA" "SPL-1.0" "SSH-OpenSSH" "SSPL-1.0" "SWL" "Saxpath" "Sendmail-8.23" "Sendmail" "SimPL-2.0" "Sleepycat" "TAPR-OHL-1.0" "TCL" "TCP-wrappers" "TMate" "TORQUE-1.1" "TOSL" "TU-Berlin-1.0" "TU-Berlin-2.0" "UCL-1.0" "UPL-1.0" "Unicode-DFS-2015" "Unicode-DFS-2016" "Unlicense" "VOSTROM" "VSL-1.0" "Vim" "W3C-19980720" "W3C-20150513" "W3C" "WTFPL" "Wsuipa" "X11" "XFree86-1.1" "Xerox" "Xnet" "ZPL-1.1" "ZPL-2.0" "ZPL-2.1" "Zed" "Zend-2.0" "Zlib" "bzip2-1.0.5" "bzip2-1.0.6" "curl" "eGenix" "etalab-2.0" "gSOAP-1.3b" "gnuplot" "iMatix" "libpng-2.0" "libselinux-1.0" "libtiff" "mpich2" "psfrag" "psutils" "xinetd" "xpp")
     if [[ -n ${license[*]} ]]; then
@@ -670,13 +695,14 @@ function lint_license() {
             fi
         done
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function checks() {
+    trap stacktrace ERR
     local ret=0 check linting_checks=(lint_pacname lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_deps lint_ppa lint_relations lint_fields lint_hash lint_incompatible lint_arch lint_mask lint_priority lint_license)
     for check in "${linting_checks[@]}"; do
         "${check}" || ret=1
     done
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -31,7 +31,7 @@ function lint_pacname() {
     local ret=0
     if [[ -z $pacname ]]; then
         fancy_message error "Package does not contain 'pacname'"
-        { ignore_stack=true && return 1; }
+        { ignore_stack=true; return 1; }
     fi
     # https://www.debian.org/doc/debian-policy/ch-controlfields.html#source
     if ((${#pacname} < 2)); then
@@ -51,7 +51,7 @@ function lint_pacname() {
         fancy_message error "pacname: '${pacname}' contains characters that are not lowercase, digits, minus, or periods"
         ret=1
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_gives() {
@@ -81,7 +81,7 @@ function lint_gives() {
             ret=1
         fi
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_pkgrel() {
@@ -96,7 +96,7 @@ function lint_pkgrel() {
             ret=1
         fi
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_epoch() {
@@ -111,7 +111,7 @@ function lint_epoch() {
             ret=1
         fi
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_version() {
@@ -127,7 +127,7 @@ function lint_version() {
         fancy_message error "Package does not contain 'pkgver'"
         ret=1
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_source_deb_test() {
@@ -218,7 +218,7 @@ function lint_source() {
             lint_source_deb_test "${source[@]}"
         fi
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_pkgdesc() {
@@ -228,7 +228,7 @@ function lint_pkgdesc() {
         fancy_message error "Package does not contain 'pkgdesc'"
         ret=1
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_maintainer() {
@@ -290,14 +290,14 @@ function lint_deps() {
                     fancy_message error "'${dep_type}' index '${idx}' is not formatted correctly"
                     ret=1
                 fi
-                { ignore_stack=true && ((idx++)); }
+                { ignore_stack=true; ((idx++)); }
             done
         fi
         if ((ret == 1)); then
             break
         fi
     done
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_ppa() {
@@ -309,10 +309,10 @@ function lint_ppa() {
                 fancy_message error "'ppa' index '${idx}' cannot be empty"
                 ret=1
             fi
-            { ignore_stack=true && ((idx++)); }
+            { ignore_stack=true; ((idx++)); }
         done
         if ((ret != 0)); then
-            { ignore_stack=true && return 1; }
+            { ignore_stack=true; return 1; }
         fi
         idx=0
         for el_ppa in "${ppa[@]}"; do
@@ -320,7 +320,7 @@ function lint_ppa() {
                 fancy_message error "'ppa' index '${idx}' cannot start with 'ppa:'"
                 ret=1
             fi
-            { ignore_stack=true && ((idx++)); }
+            { ignore_stack=true; ((idx++)); }
         done
         idx=0
         for el_ppa in "${ppa[@]}"; do
@@ -328,10 +328,10 @@ function lint_ppa() {
                 fancy_message error "'ppa' index '${idx}' is improperly formatted"
                 ret=1
             fi
-            { ignore_stack=true && ((idx++)); }
+            { ignore_stack=true; ((idx++)); }
         done
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_relations() {
@@ -359,14 +359,14 @@ function lint_relations() {
                     fancy_message error "'${rel_type}' index '${idx}' cannot be empty"
                     ret=1
                 fi
-                { ignore_stack=true && ((idx++)); }
+                { ignore_stack=true; ((idx++)); }
             done
         fi
         if ((ret == 1)); then
             break
         fi
     done
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_capital_check() {
@@ -383,7 +383,7 @@ function lint_capital_check() {
         if [[ ${split_chars[$z]} == '-' ]]; then
             # Is the next letter a capital?
             if [[ ${split_chars[z + 1]} != "${split_chars[z + 1]^}" ]]; then
-                { ignore_stack=true && return 1; }
+                { ignore_stack=true; return 1; }
             fi
         fi
     done
@@ -394,7 +394,7 @@ function lint_field_fmt() {
     local infield="${1}"
     # Ensure no spaces
     if [[ ${infield} =~ [[:space:]] ]]; then
-        { ignore_stack=true && return 1; }
+        { ignore_stack=true; return 1; }
     # Ensure no numbers
     elif [[ ${infield} =~ [0-9] ]]; then
         return 2
@@ -450,9 +450,9 @@ function lint_fields() {
                         ;;
                 esac
             fi
-            { ignore_stack=true && ((idx++)); }
+            { ignore_stack=true; ((idx++)); }
         done
-        { ignore_stack=true && return "${ret}"; }
+        { ignore_stack=true; return "${ret}"; }
     fi
 }
 
@@ -543,7 +543,7 @@ function lint_hash() {
             fi
         done
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_incompatible() {
@@ -562,7 +562,7 @@ function lint_incompatible() {
                 fancy_message error "'compatible' index '${idx}' cannot be empty"
                 ret=1
             fi
-            { ignore_stack=true && ((idx++)); }
+            { ignore_stack=true; ((idx++)); }
         done
         idx=0
         for compat in "${compatible[@]}"; do
@@ -570,7 +570,7 @@ function lint_incompatible() {
                 fancy_message error "'compatible' index '${idx}' is improperly formatted"
                 ret=1
             fi
-            { ignore_stack=true && ((idx++)); }
+            { ignore_stack=true; ((idx++)); }
         done
     elif [[ -n ${incompatible[*]} ]]; then
         if [[ -n ${compatible[*]} ]]; then
@@ -585,7 +585,7 @@ function lint_incompatible() {
                 fancy_message error "'incompatible' index '${idx}' cannot be empty"
                 ret=1
             fi
-            { ignore_stack=true && ((idx++)); }
+            { ignore_stack=true; ((idx++)); }
         done
         idx=0
         for incompat in "${incompatible[@]}"; do
@@ -593,10 +593,10 @@ function lint_incompatible() {
                 fancy_message error "'incompatible' index '${idx}' is improperly formatted"
                 ret=1
             fi
-            { ignore_stack=true && ((idx++)); }
+            { ignore_stack=true; ((idx++)); }
         done
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_arch() {
@@ -616,11 +616,11 @@ function lint_arch() {
                 fancy_message error "'arch' index '${idx}' cannot be empty"
                 ret=1
             fi
-            { ignore_stack=true && ((idx++)); }
+            { ignore_stack=true; ((idx++)); }
         done
         # Fail point
         if ((ret != 0)); then
-            { ignore_stack=true && return 1; }
+            { ignore_stack=true; return 1; }
         fi
         for el_arch in "${arch[@]}"; do
             if ! array.contains known_archs "${el_arch}"; then
@@ -641,7 +641,7 @@ function lint_arch() {
             ret=1
         fi
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_mask() {
@@ -653,10 +653,10 @@ function lint_mask() {
                 fancy_message error "'mask' index '${idx}' cannot be empty"
                 ret=1
             fi
-            { ignore_stack=true && ((idx++)); }
+            { ignore_stack=true; ((idx++)); }
         done
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_priority() {
@@ -673,7 +673,7 @@ function lint_priority() {
         fi
     fi
     shopt -u extglob
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function lint_license() {
@@ -686,7 +686,7 @@ function lint_license() {
                 fancy_message error "'license' index '${idx}' cannot be empty"
                 ret=1
             fi
-            { ignore_stack=true && ((idx++)); }
+            { ignore_stack=true; ((idx++)); }
             if ! array.contains license_list "${linlicense}"; then
                 if [[ ${linlicense} != "custom:"* ]]; then
                     fancy_message error "'${linlicense}' is not a valid license"
@@ -695,7 +695,7 @@ function lint_license() {
             fi
         done
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function checks() {
@@ -705,5 +705,5 @@ function checks() {
         "${check}" || ret=1
     done
     # shellcheck disable=SC2034
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }

--- a/misc/scripts/dep-tree.sh
+++ b/misc/scripts/dep-tree.sh
@@ -47,6 +47,7 @@ function dep_tree.has_deps() {
     if [[ -n $(dpkg-query '--showformat=${Depends}\n' --show "${le_pkg}") ]]; then
         return 0
     else
+        # shellcheck disable=SC2034
         { ignore_stack=true && return 1; }
     fi
 }

--- a/misc/scripts/dep-tree.sh
+++ b/misc/scripts/dep-tree.sh
@@ -22,10 +22,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 function array.remove() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local array_name to_remove i
     declare -n array_name="${1:?No array given to array.remove}"
     to_remove="${2:?No element given to array.remove}"
@@ -42,7 +42,7 @@ function array.remove() {
 }
 
 function dep_tree.has_deps() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local le_pkg="${1:?No pkg given to dep_tree.has_deps}"
     if [[ -n $(dpkg-query '--showformat=${Depends}\n' --show "${le_pkg}") ]]; then
         return 0
@@ -53,7 +53,7 @@ function dep_tree.has_deps() {
 }
 
 function dep_tree.load_traits() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local pkg
     local -n out_arr
     pkg="${1:?No pkg given to dep_tree.load_traits}"
@@ -86,7 +86,7 @@ function dep_tree.load_traits() {
 }
 
 function dep_tree.sort_traits_into_array() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local pkg="${1:?No pkg given to dep_tree.sort_traits_into_array}"
     local -n trait c_one c_two c_three c_four c_five c_six
     local trait="${2:?No trait array given to dep_tree.sort_traits_into_array}"
@@ -136,7 +136,7 @@ function dep_tree.sort_traits_into_array() {
 }
 
 function dep_tree.loop_traits() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local -n merged_array="${1:?No array given to dep_tree.loop_traits}"
     shift
     local class_one=() class_two=() class_three=() class_four=() class_five=() class_six=() i
@@ -152,7 +152,7 @@ function dep_tree.loop_traits() {
 }
 
 function dep_tree.trim_pacdeps() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # shellcheck disable=SC2178
     local -n merged_array="${1:?Pass array to dep_tree.trim_pacdeps}"
     local i z

--- a/misc/scripts/dep-tree.sh
+++ b/misc/scripts/dep-tree.sh
@@ -22,10 +22,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 function array.remove() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local array_name to_remove i
     declare -n array_name="${1:?No array given to array.remove}"
     to_remove="${2:?No element given to array.remove}"
@@ -42,7 +42,7 @@ function array.remove() {
 }
 
 function dep_tree.has_deps() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local le_pkg="${1:?No pkg given to dep_tree.has_deps}"
     if [[ -n $(dpkg-query '--showformat=${Depends}\n' --show "${le_pkg}") ]]; then
         return 0
@@ -53,7 +53,7 @@ function dep_tree.has_deps() {
 }
 
 function dep_tree.load_traits() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local pkg
     local -n out_arr
     pkg="${1:?No pkg given to dep_tree.load_traits}"
@@ -86,7 +86,7 @@ function dep_tree.load_traits() {
 }
 
 function dep_tree.sort_traits_into_array() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local pkg="${1:?No pkg given to dep_tree.sort_traits_into_array}"
     local -n trait c_one c_two c_three c_four c_five c_six
     local trait="${2:?No trait array given to dep_tree.sort_traits_into_array}"
@@ -136,7 +136,7 @@ function dep_tree.sort_traits_into_array() {
 }
 
 function dep_tree.loop_traits() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local -n merged_array="${1:?No array given to dep_tree.loop_traits}"
     shift
     local class_one=() class_two=() class_three=() class_four=() class_five=() class_six=() i
@@ -153,7 +153,7 @@ function dep_tree.loop_traits() {
 
 function dep_tree.trim_pacdeps() {
     # shellcheck disable=SC2034
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # shellcheck disable=SC2178
     local -n merged_array="${1:?Pass array to dep_tree.trim_pacdeps}"
     local i z

--- a/misc/scripts/dep-tree.sh
+++ b/misc/scripts/dep-tree.sh
@@ -152,6 +152,7 @@ function dep_tree.loop_traits() {
 }
 
 function dep_tree.trim_pacdeps() {
+    # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # shellcheck disable=SC2178
     local -n merged_array="${1:?Pass array to dep_tree.trim_pacdeps}"

--- a/misc/scripts/dep-tree.sh
+++ b/misc/scripts/dep-tree.sh
@@ -22,16 +22,17 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-# The order we prefer is pkgs with only pacdeps (class 1), pacdeps+deps (class 2), everything else (class 3), and just pacdeps (class 4)
+trap stacktrace ERR
 
 function array.remove() {
+    trap stacktrace ERR
     local array_name to_remove i
     declare -n array_name="${1:?No array given to array.remove}"
     to_remove="${2:?No element given to array.remove}"
 
     for i in "${!array_name[@]}"; do
         if [[ ${array_name[i]} == "${to_remove}" ]]; then
-            unset "array_name[${i}]" || return 1
+            unset "array_name[${i}]" || { ignore_stack=true && return 1; }
             # Adjust the indices so there are none are jumped
             array_name=("${array_name[@]}")
             break 2
@@ -41,15 +42,17 @@ function array.remove() {
 }
 
 function dep_tree.has_deps() {
+    trap stacktrace ERR
     local le_pkg="${1:?No pkg given to dep_tree.has_deps}"
     if [[ -n $(dpkg-query '--showformat=${Depends}\n' --show "${le_pkg}") ]]; then
         return 0
     else
-        return 1
+        { ignore_stack=true && return 1; }
     fi
 }
 
 function dep_tree.load_traits() {
+    trap stacktrace ERR
     local pkg
     local -n out_arr
     pkg="${1:?No pkg given to dep_tree.load_traits}"
@@ -82,6 +85,7 @@ function dep_tree.load_traits() {
 }
 
 function dep_tree.sort_traits_into_array() {
+    trap stacktrace ERR
     local pkg="${1:?No pkg given to dep_tree.sort_traits_into_array}"
     local -n trait c_one c_two c_three c_four c_five c_six
     local trait="${2:?No trait array given to dep_tree.sort_traits_into_array}"
@@ -131,6 +135,7 @@ function dep_tree.sort_traits_into_array() {
 }
 
 function dep_tree.loop_traits() {
+    trap stacktrace ERR
     local -n merged_array="${1:?No array given to dep_tree.loop_traits}"
     shift
     local class_one=() class_two=() class_three=() class_four=() class_five=() class_six=() i
@@ -146,6 +151,7 @@ function dep_tree.loop_traits() {
 }
 
 function dep_tree.trim_pacdeps() {
+    trap stacktrace ERR
     # shellcheck disable=SC2178
     local -n merged_array="${1:?Pass array to dep_tree.trim_pacdeps}"
     local i z

--- a/misc/scripts/dep-tree.sh
+++ b/misc/scripts/dep-tree.sh
@@ -32,7 +32,7 @@ function array.remove() {
 
     for i in "${!array_name[@]}"; do
         if [[ ${array_name[i]} == "${to_remove}" ]]; then
-            unset "array_name[${i}]" || { ignore_stack=true && return 1; }
+            unset "array_name[${i}]" || { ignore_stack=true; return 1; }
             # Adjust the indices so there are none are jumped
             array_name=("${array_name[@]}")
             break 2
@@ -48,7 +48,7 @@ function dep_tree.has_deps() {
         return 0
     else
         # shellcheck disable=SC2034
-        { ignore_stack=true && return 1; }
+        { ignore_stack=true; return 1; }
     fi
 }
 

--- a/misc/scripts/error-log.sh
+++ b/misc/scripts/error-log.sh
@@ -47,6 +47,7 @@ declare -r -A ErrMsg=([1]="Unknown cause of failure."
     [16]="Specified hash does not exist or failed to sign package.")
 
 function error_log() {
+    # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local code="${1}"
     local scope="${2}"

--- a/misc/scripts/error-log.sh
+++ b/misc/scripts/error-log.sh
@@ -22,6 +22,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
+trap stacktrace ERR
+
 if [[ ! -d ${LOGDIR} ]]; then
     sudo mkdir -p "${LOGDIR}"
 fi
@@ -45,6 +47,7 @@ declare -r -A ErrMsg=([1]="Unknown cause of failure."
     [16]="Specified hash does not exist or failed to sign package.")
 
 function error_log() {
+    trap stacktrace ERR
     local code="${1}"
     local scope="${2}"
     local time

--- a/misc/scripts/error-log.sh
+++ b/misc/scripts/error-log.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 if [[ ! -d ${LOGDIR} ]]; then
     sudo mkdir -p "${LOGDIR}"
@@ -48,7 +48,7 @@ declare -r -A ErrMsg=([1]="Unknown cause of failure."
 
 function error_log() {
     # shellcheck disable=SC2034
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local code="${1}"
     local scope="${2}"
     local time

--- a/misc/scripts/error-log.sh
+++ b/misc/scripts/error-log.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 if [[ ! -d ${LOGDIR} ]]; then
     sudo mkdir -p "${LOGDIR}"
@@ -47,7 +47,7 @@ declare -r -A ErrMsg=([1]="Unknown cause of failure."
     [16]="Specified hash does not exist or failed to sign package.")
 
 function error_log() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local code="${1}"
     local scope="${2}"
     local time

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -27,7 +27,7 @@
 # shellcheck source=./misc/scripts/build.sh
 source "${SCRIPTDIR}/scripts/build.sh" || {
     fancy_message error "Could not find build.sh"
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 }
 
 function parse_source_entry() {
@@ -272,7 +272,7 @@ function hashcheck_down() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     if [[ -n ${expectedHash} && ${expectedHash} != "SKIP" ]]; then
         fancy_message sub "Checking hash ${YELLOW}${expectedHash:0:8}${NC}[${YELLOW}...${NC}]"
-        hashcheck "${dest}" "${expectedHash}" "${hashsum_method}" || { ignore_stack=true && return 1; }
+        hashcheck "${dest}" "${expectedHash}" "${hashsum_method}" || { ignore_stack=true; return 1; }
     fi
 }
 
@@ -554,7 +554,7 @@ function get_compatible_releases() {
     done
     if [[ ${is_compat} == "false" || ${is_compat} != "true" ]]; then
         fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}"
-        { ignore_stack=true && return 1; }
+        { ignore_stack=true; return 1; }
     fi
     return 0
 }
@@ -588,20 +588,20 @@ function get_incompatible_releases() {
             # check for `22.04` or `jammy`
             if [[ ${key#*:} == "${distro_version_number}" || ${key#*:} == "${distro_version_name}" ]]; then
                 fancy_message error "This Pacscript does not work on ${BBlue}${distro_version_name}${NC}/${BBlue}${distro_version_number}${NC}"
-                { ignore_stack=true && return 1; }
+                { ignore_stack=true; return 1; }
             fi
         # check for `ubuntu:*`
         elif [[ $key == *":*" ]]; then
             # check for `ubuntu`
             if [[ ${key%%:*} == "${distro_name}" ]]; then
                 fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}${NC}"
-                { ignore_stack=true && return 1; }
+                { ignore_stack=true; return 1; }
             fi
         else
             # check for `ubuntu:jammy` or `ubuntu:22.04`
             if [[ $key == "${distro_name}:${distro_version_name}" || $key == "${distro_name}:${distro_version_number}" ]]; then
                 fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}"
-                { ignore_stack=true && return 1; }
+                { ignore_stack=true; return 1; }
             fi
         fi
     done
@@ -634,7 +634,7 @@ function is_compatible_arch() {
     if ((ret == 1)); then
         fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}/${AARCH}${NC}"
     fi
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function install_builddepends() {
@@ -702,7 +702,7 @@ function compare_remote_version() {
     local crv_input="${1}" remote_tmp remote_safe remotever localver crv_pkgver crv_pkgrel crv_epoch crv_source remv crv_fetch crv_base
     unset _pkgbase
     # shellcheck source=/dev/null
-    source "$METADIR/$crv_input" || { ignore_stack=true && return 1; }
+    source "$METADIR/$crv_input" || { ignore_stack=true; return 1; }
     [[ ${_remoterepo} == "orphan" ]] && _remoterepo="${REPO}"
     if [[ -z ${_remoterepo} ]]; then
         return 0
@@ -723,7 +723,7 @@ function compare_remote_version() {
         remote_tmp="$(sudo mktemp -p "${PACDIR}" -t "compare-repo-ver-$crv_input.XXXXXX")"
         remote_safe="${remote_tmp}"
         # shellcheck disable=SC2034
-        curl -fsSL "$remoterepo/packages/$crv_fetch/.SRCINFO" | sudo tee "${remote_safe}" > /dev/null || { ignore_stack=true && return 1; }
+        curl -fsSL "$remoterepo/packages/$crv_fetch/.SRCINFO" | sudo tee "${remote_safe}" > /dev/null || { ignore_stack=true; return 1; }
         sudo chown "${PACSTALL_USER}" "${remote_safe}"
         crv_base="$(srcinfo.match_pkg "${remote_safe}" pkgbase)"
         for remv in "pkgver" "pkgrel" "epoch"; do

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -701,6 +701,7 @@ function compare_remote_version() {
     trap stacktrace ERR
     local crv_input="${1}" remote_tmp remote_safe remotever localver crv_pkgver crv_pkgrel crv_epoch crv_source remv crv_fetch crv_base
     unset _pkgbase
+    # shellcheck source=/dev/null
     source "$METADIR/$crv_input" || { ignore_stack=true && return 1; }
     [[ ${_remoterepo} == "orphan" ]] && _remoterepo="${REPO}"
     if [[ -z ${_remoterepo} ]]; then
@@ -721,6 +722,7 @@ function compare_remote_version() {
         unset pkgrel
         remote_tmp="$(sudo mktemp -p "${PACDIR}" -t "compare-repo-ver-$crv_input.XXXXXX")"
         remote_safe="${remote_tmp}"
+        # shellcheck disable=SC2034
         curl -fsSL "$remoterepo/packages/$crv_fetch/.SRCINFO" | sudo tee "${remote_safe}" > /dev/null || { ignore_stack=true && return 1; }
         sudo chown "${PACSTALL_USER}" "${remote_safe}"
         crv_base="$(srcinfo.match_pkg "${remote_safe}" pkgbase)"

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 # shellcheck source=./misc/scripts/build.sh
 source "${SCRIPTDIR}/scripts/build.sh" || {
@@ -31,7 +31,7 @@ source "${SCRIPTDIR}/scripts/build.sh" || {
 }
 
 function parse_source_entry() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     unset source_url dest git_branch git_tag git_commit
     local entry="$1"
     source_url="${entry#*::}"
@@ -67,7 +67,7 @@ function parse_source_entry() {
 }
 
 function calc_git_pkgver() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     unset comp_git_pkgver
     local calc_commit
     if [[ $source_url == git+* ]]; then
@@ -86,7 +86,7 @@ function calc_git_pkgver() {
 }
 
 function genextr_declare() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     unset ext_method ext_deps
     # shellcheck disable=SC2031,SC2034
     case "${source_url,,}" in
@@ -154,14 +154,14 @@ function genextr_declare() {
 }
 
 function clean_fail_down() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     fancy_message info "Cleaning up"
     cleanup
     exit 1
 }
 
 function hashcheck() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local inputFile="${1}" inputHash="${2}" hashMethod="${3}sum" fileHash
     # Get hash of file
     fileHash="$(${hashMethod} "${inputFile}")"
@@ -179,14 +179,14 @@ function hashcheck() {
 }
 
 function fail_down() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     error_log 1 "download ${pacname}"
     fancy_message error "Failed to download package"
     clean_fail_down
 }
 
 function gather_down() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     export srcdir="${PACDIR}/${pacname}~${pkgver}"
     mkdir -p "${srcdir}"
     cd "${srcdir}" || {
@@ -197,7 +197,7 @@ function gather_down() {
 }
 
 function git_down() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local revision gitopts submodules=true no_submodule silence quiet
     ${PACSTALL_VERBOSE} || silence=("&>" "/dev/null") quiet="--quiet"
     dest="${dest%.git}"
@@ -262,14 +262,14 @@ function git_down() {
 }
 
 function net_down() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     fancy_message info "Downloading ${BPurple}${dest}${NC}"
     # shellcheck disable=SC2031
     download "$source_url" "$dest" || fail_down
 }
 
 function hashcheck_down() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     if [[ -n ${expectedHash} && ${expectedHash} != "SKIP" ]]; then
         fancy_message sub "Checking hash ${YELLOW}${expectedHash:0:8}${NC}[${YELLOW}...${NC}]"
         hashcheck "${dest}" "${expectedHash}" "${hashsum_method}" || { ignore_stack=true && return 1; }
@@ -277,7 +277,7 @@ function hashcheck_down() {
 }
 
 function genextr_down() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     hashcheck_down
     local extract=true keep_archive
     for keep_archive in "${noextract[@]}"; do
@@ -310,7 +310,7 @@ function genextr_down() {
 }
 
 function deb_down() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     hashcheck_down
     local upgrade=false
     if is_package_installed "${pacname}" && type -t pre_upgrade &> /dev/null; then
@@ -375,7 +375,7 @@ function deb_down() {
 }
 
 function file_down() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     fancy_message info "Copying local archive ${BPurple}${dest}${NC}"
     # shellcheck disable=SC2031
     cp -r "${source_url}" "${dest}" || fail_down
@@ -407,7 +407,7 @@ function file_down() {
 
 # currently expecting: 1=hash 2=PACSTALL_KNOWN_SUMS 3=hashum_method 4=${CARCH}/${DISTRO} 5=${CARCH}
 function append_hash_entry() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local -n append="${1}" sums="${2}" exp_method="${3}"
     local hash_arch hash_arr extend="${4}${5:+_$5}"
     for type in "${sums[@]}"; do
@@ -432,7 +432,7 @@ function append_hash_entry() {
 }
 
 function append_var_arch() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local inp inputvar="${1}" inputvar_arch="${1}_${2}${3:+_$3}[*]"
     declare -n ref_inputvar="${inputvar}"
     if [[ -n ${!inputvar_arch} ]]; then
@@ -447,7 +447,7 @@ function append_var_arch() {
 }
 
 function append_modifier_entries() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     unset hashsum_method
     # shellcheck disable=SC2034
     local APPARCH="${1}" APPDISTRO="${2}"
@@ -479,7 +479,7 @@ function append_modifier_entries() {
 }
 
 function calc_distro() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local distro_pretty_name key value
     while IFS='=' read -r key value; do
         case "${key}" in
@@ -510,7 +510,7 @@ function calc_distro() {
 }
 
 function set_distro() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number
     calc_distro
     if [[ ${1} == "parent" ]]; then
@@ -521,7 +521,7 @@ function set_distro() {
 }
 
 function get_compatible_releases() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # example for this function is "ubuntu:jammy"
     local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number is_compat=false comp_list=("${@,,}")
     calc_distro
@@ -560,7 +560,7 @@ function get_compatible_releases() {
 }
 
 function get_incompatible_releases() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # example for this function is "ubuntu:jammy"
     local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number incomp_list=("${@,,}")
     calc_distro
@@ -608,7 +608,7 @@ function get_incompatible_releases() {
 }
 
 function is_compatible_arch() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local inarch=("${@}") ret=1 pacarch farch
     # shellcheck disable=SC2076,SC2153
     if array.contains inarch "any" \
@@ -638,7 +638,7 @@ function is_compatible_arch() {
 }
 
 function install_builddepends() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # shellcheck disable=SC2034
     local build_dep not_installed_yet_builddepends bdeps_array bdeps_str check_dep not_installed_yet_checkdepends cdeps_array bcons_array bcons_str
     if [[ -n ${makedepends[*]} ]]; then
@@ -698,7 +698,7 @@ function install_builddepends() {
 }
 
 function compare_remote_version() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local crv_input="${1}" remote_tmp remote_safe remotever localver crv_pkgver crv_pkgrel crv_epoch crv_source remv crv_fetch crv_base
     unset _pkgbase
     # shellcheck source=/dev/null

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 # shellcheck source=./misc/scripts/build.sh
 source "${SCRIPTDIR}/scripts/build.sh" || {
@@ -31,7 +31,7 @@ source "${SCRIPTDIR}/scripts/build.sh" || {
 }
 
 function parse_source_entry() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     unset source_url dest git_branch git_tag git_commit
     local entry="$1"
     source_url="${entry#*::}"
@@ -67,7 +67,7 @@ function parse_source_entry() {
 }
 
 function calc_git_pkgver() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     unset comp_git_pkgver
     local calc_commit
     if [[ $source_url == git+* ]]; then
@@ -86,7 +86,7 @@ function calc_git_pkgver() {
 }
 
 function genextr_declare() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     unset ext_method ext_deps
     # shellcheck disable=SC2031,SC2034
     case "${source_url,,}" in
@@ -154,14 +154,14 @@ function genextr_declare() {
 }
 
 function clean_fail_down() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     fancy_message info "Cleaning up"
     cleanup
     exit 1
 }
 
 function hashcheck() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local inputFile="${1}" inputHash="${2}" hashMethod="${3}sum" fileHash
     # Get hash of file
     fileHash="$(${hashMethod} "${inputFile}")"
@@ -179,14 +179,14 @@ function hashcheck() {
 }
 
 function fail_down() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     error_log 1 "download ${pacname}"
     fancy_message error "Failed to download package"
     clean_fail_down
 }
 
 function gather_down() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     export srcdir="${PACDIR}/${pacname}~${pkgver}"
     mkdir -p "${srcdir}"
     cd "${srcdir}" || {
@@ -197,7 +197,7 @@ function gather_down() {
 }
 
 function git_down() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local revision gitopts submodules=true no_submodule silence quiet
     ${PACSTALL_VERBOSE} || silence=("&>" "/dev/null") quiet="--quiet"
     dest="${dest%.git}"
@@ -262,14 +262,14 @@ function git_down() {
 }
 
 function net_down() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     fancy_message info "Downloading ${BPurple}${dest}${NC}"
     # shellcheck disable=SC2031
     download "$source_url" "$dest" || fail_down
 }
 
 function hashcheck_down() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     if [[ -n ${expectedHash} && ${expectedHash} != "SKIP" ]]; then
         fancy_message sub "Checking hash ${YELLOW}${expectedHash:0:8}${NC}[${YELLOW}...${NC}]"
         hashcheck "${dest}" "${expectedHash}" "${hashsum_method}" || { ignore_stack=true && return 1; }
@@ -277,7 +277,7 @@ function hashcheck_down() {
 }
 
 function genextr_down() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     hashcheck_down
     local extract=true keep_archive
     for keep_archive in "${noextract[@]}"; do
@@ -310,7 +310,7 @@ function genextr_down() {
 }
 
 function deb_down() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     hashcheck_down
     local upgrade=false
     if is_package_installed "${pacname}" && type -t pre_upgrade &> /dev/null; then
@@ -375,7 +375,7 @@ function deb_down() {
 }
 
 function file_down() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     fancy_message info "Copying local archive ${BPurple}${dest}${NC}"
     # shellcheck disable=SC2031
     cp -r "${source_url}" "${dest}" || fail_down
@@ -407,7 +407,7 @@ function file_down() {
 
 # currently expecting: 1=hash 2=PACSTALL_KNOWN_SUMS 3=hashum_method 4=${CARCH}/${DISTRO} 5=${CARCH}
 function append_hash_entry() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local -n append="${1}" sums="${2}" exp_method="${3}"
     local hash_arch hash_arr extend="${4}${5:+_$5}"
     for type in "${sums[@]}"; do
@@ -432,7 +432,7 @@ function append_hash_entry() {
 }
 
 function append_var_arch() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local inp inputvar="${1}" inputvar_arch="${1}_${2}${3:+_$3}[*]"
     declare -n ref_inputvar="${inputvar}"
     if [[ -n ${!inputvar_arch} ]]; then
@@ -447,7 +447,7 @@ function append_var_arch() {
 }
 
 function append_modifier_entries() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     unset hashsum_method
     # shellcheck disable=SC2034
     local APPARCH="${1}" APPDISTRO="${2}"
@@ -479,7 +479,7 @@ function append_modifier_entries() {
 }
 
 function calc_distro() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local distro_pretty_name key value
     while IFS='=' read -r key value; do
         case "${key}" in
@@ -510,7 +510,7 @@ function calc_distro() {
 }
 
 function set_distro() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number
     calc_distro
     if [[ ${1} == "parent" ]]; then
@@ -521,7 +521,7 @@ function set_distro() {
 }
 
 function get_compatible_releases() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # example for this function is "ubuntu:jammy"
     local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number is_compat=false comp_list=("${@,,}")
     calc_distro
@@ -560,7 +560,7 @@ function get_compatible_releases() {
 }
 
 function get_incompatible_releases() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # example for this function is "ubuntu:jammy"
     local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number incomp_list=("${@,,}")
     calc_distro
@@ -608,7 +608,7 @@ function get_incompatible_releases() {
 }
 
 function is_compatible_arch() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local inarch=("${@}") ret=1 pacarch farch
     # shellcheck disable=SC2076,SC2153
     if array.contains inarch "any" \
@@ -638,7 +638,7 @@ function is_compatible_arch() {
 }
 
 function install_builddepends() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # shellcheck disable=SC2034
     local build_dep not_installed_yet_builddepends bdeps_array bdeps_str check_dep not_installed_yet_checkdepends cdeps_array bcons_array bcons_str
     if [[ -n ${makedepends[*]} ]]; then
@@ -698,7 +698,7 @@ function install_builddepends() {
 }
 
 function compare_remote_version() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local crv_input="${1}" remote_tmp remote_safe remotever localver crv_pkgver crv_pkgrel crv_epoch crv_source remv crv_fetch crv_base
     unset _pkgbase
     # shellcheck source=/dev/null

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -22,13 +22,16 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
+trap stacktrace ERR
+
 # shellcheck source=./misc/scripts/build.sh
 source "${SCRIPTDIR}/scripts/build.sh" || {
     fancy_message error "Could not find build.sh"
-    return 1
+    { ignore_stack=true && return 1; }
 }
 
 function parse_source_entry() {
+    trap stacktrace ERR
     unset source_url dest git_branch git_tag git_commit
     local entry="$1"
     source_url="${entry#*::}"
@@ -64,6 +67,7 @@ function parse_source_entry() {
 }
 
 function calc_git_pkgver() {
+    trap stacktrace ERR
     unset comp_git_pkgver
     local calc_commit
     if [[ $source_url == git+* ]]; then
@@ -82,6 +86,7 @@ function calc_git_pkgver() {
 }
 
 function genextr_declare() {
+    trap stacktrace ERR
     unset ext_method ext_deps
     # shellcheck disable=SC2031,SC2034
     case "${source_url,,}" in
@@ -149,12 +154,14 @@ function genextr_declare() {
 }
 
 function clean_fail_down() {
+    trap stacktrace ERR
     fancy_message info "Cleaning up"
     cleanup
     exit 1
 }
 
 function hashcheck() {
+    trap stacktrace ERR
     local inputFile="${1}" inputHash="${2}" hashMethod="${3}sum" fileHash
     # Get hash of file
     fileHash="$(${hashMethod} "${inputFile}")"
@@ -172,12 +179,14 @@ function hashcheck() {
 }
 
 function fail_down() {
+    trap stacktrace ERR
     error_log 1 "download ${pacname}"
     fancy_message error "Failed to download package"
     clean_fail_down
 }
 
 function gather_down() {
+    trap stacktrace ERR
     export srcdir="${PACDIR}/${pacname}~${pkgver}"
     mkdir -p "${srcdir}"
     cd "${srcdir}" || {
@@ -188,6 +197,7 @@ function gather_down() {
 }
 
 function git_down() {
+    trap stacktrace ERR
     local revision gitopts submodules=true no_submodule silence quiet
     ${PACSTALL_VERBOSE} || silence=("&>" "/dev/null") quiet="--quiet"
     dest="${dest%.git}"
@@ -252,19 +262,22 @@ function git_down() {
 }
 
 function net_down() {
+    trap stacktrace ERR
     fancy_message info "Downloading ${BPurple}${dest}${NC}"
     # shellcheck disable=SC2031
     download "$source_url" "$dest" || fail_down
 }
 
 function hashcheck_down() {
+    trap stacktrace ERR
     if [[ -n ${expectedHash} && ${expectedHash} != "SKIP" ]]; then
         fancy_message sub "Checking hash ${YELLOW}${expectedHash:0:8}${NC}[${YELLOW}...${NC}]"
-        hashcheck "${dest}" "${expectedHash}" "${hashsum_method}" || return 1
+        hashcheck "${dest}" "${expectedHash}" "${hashsum_method}" || { ignore_stack=true && return 1; }
     fi
 }
 
 function genextr_down() {
+    trap stacktrace ERR
     hashcheck_down
     local extract=true keep_archive
     for keep_archive in "${noextract[@]}"; do
@@ -277,7 +290,7 @@ function genextr_down() {
         fancy_message sub "Extracting ${CYAN}${dest}${NC}"
         ${ext_method} "${dest}" 1>&1 2> /dev/null
         if [[ -f ${dest} ]]; then
-            rm -f "${dest}"
+            rm -f "${dest:?}"
         fi
     fi
     # if first source and extract is true, enter it for archive check
@@ -297,6 +310,7 @@ function genextr_down() {
 }
 
 function deb_down() {
+    trap stacktrace ERR
     hashcheck_down
     local upgrade=false
     if is_package_installed "${pacname}" && type -t pre_upgrade &> /dev/null; then
@@ -361,6 +375,7 @@ function deb_down() {
 }
 
 function file_down() {
+    trap stacktrace ERR
     fancy_message info "Copying local archive ${BPurple}${dest}${NC}"
     # shellcheck disable=SC2031
     cp -r "${source_url}" "${dest}" || fail_down
@@ -392,6 +407,7 @@ function file_down() {
 
 # currently expecting: 1=hash 2=PACSTALL_KNOWN_SUMS 3=hashum_method 4=${CARCH}/${DISTRO} 5=${CARCH}
 function append_hash_entry() {
+    trap stacktrace ERR
     local -n append="${1}" sums="${2}" exp_method="${3}"
     local hash_arch hash_arr extend="${4}${5:+_$5}"
     for type in "${sums[@]}"; do
@@ -416,6 +432,7 @@ function append_hash_entry() {
 }
 
 function append_var_arch() {
+    trap stacktrace ERR
     local inp inputvar="${1}" inputvar_arch="${1}_${2}${3:+_$3}[*]"
     declare -n ref_inputvar="${inputvar}"
     if [[ -n ${!inputvar_arch} ]]; then
@@ -430,6 +447,7 @@ function append_var_arch() {
 }
 
 function append_modifier_entries() {
+    trap stacktrace ERR
     unset hashsum_method
     # shellcheck disable=SC2034
     local APPARCH="${1}" APPDISTRO="${2}"
@@ -461,6 +479,7 @@ function append_modifier_entries() {
 }
 
 function calc_distro() {
+    trap stacktrace ERR
     local distro_pretty_name key value
     while IFS='=' read -r key value; do
         case "${key}" in
@@ -491,6 +510,7 @@ function calc_distro() {
 }
 
 function set_distro() {
+    trap stacktrace ERR
     local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number
     calc_distro
     if [[ ${1} == "parent" ]]; then
@@ -501,6 +521,7 @@ function set_distro() {
 }
 
 function get_compatible_releases() {
+    trap stacktrace ERR
     # example for this function is "ubuntu:jammy"
     local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number is_compat=false comp_list=("${@,,}")
     calc_distro
@@ -533,12 +554,13 @@ function get_compatible_releases() {
     done
     if [[ ${is_compat} == "false" || ${is_compat} != "true" ]]; then
         fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}"
-        return 1
+        { ignore_stack=true && return 1; }
     fi
     return 0
 }
 
 function get_incompatible_releases() {
+    trap stacktrace ERR
     # example for this function is "ubuntu:jammy"
     local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number incomp_list=("${@,,}")
     calc_distro
@@ -566,26 +588,27 @@ function get_incompatible_releases() {
             # check for `22.04` or `jammy`
             if [[ ${key#*:} == "${distro_version_number}" || ${key#*:} == "${distro_version_name}" ]]; then
                 fancy_message error "This Pacscript does not work on ${BBlue}${distro_version_name}${NC}/${BBlue}${distro_version_number}${NC}"
-                return 1
+                { ignore_stack=true && return 1; }
             fi
         # check for `ubuntu:*`
         elif [[ $key == *":*" ]]; then
             # check for `ubuntu`
             if [[ ${key%%:*} == "${distro_name}" ]]; then
                 fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}${NC}"
-                return 1
+                { ignore_stack=true && return 1; }
             fi
         else
             # check for `ubuntu:jammy` or `ubuntu:22.04`
             if [[ $key == "${distro_name}:${distro_version_name}" || $key == "${distro_name}:${distro_version_number}" ]]; then
                 fancy_message error "This Pacscript does not work on ${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}"
-                return 1
+                { ignore_stack=true && return 1; }
             fi
         fi
     done
 }
 
 function is_compatible_arch() {
+    trap stacktrace ERR
     local inarch=("${@}") ret=1 pacarch farch
     # shellcheck disable=SC2076,SC2153
     if array.contains inarch "any" \
@@ -611,10 +634,11 @@ function is_compatible_arch() {
     if ((ret == 1)); then
         fancy_message error "This Pacscript does not work on ${BBlue}${CARCH}/${AARCH}${NC}"
     fi
-    return "${ret}"
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function install_builddepends() {
+    trap stacktrace ERR
     # shellcheck disable=SC2034
     local build_dep not_installed_yet_builddepends bdeps_array bdeps_str check_dep not_installed_yet_checkdepends cdeps_array bcons_array bcons_str
     if [[ -n ${makedepends[*]} ]]; then
@@ -674,9 +698,10 @@ function install_builddepends() {
 }
 
 function compare_remote_version() {
+    trap stacktrace ERR
     local crv_input="${1}" remote_tmp remote_safe remotever localver crv_pkgver crv_pkgrel crv_epoch crv_source remv crv_fetch crv_base
     unset _pkgbase
-    source "$METADIR/$crv_input" || return 1
+    source "$METADIR/$crv_input" || { ignore_stack=true && return 1; }
     [[ ${_remoterepo} == "orphan" ]] && _remoterepo="${REPO}"
     if [[ -z ${_remoterepo} ]]; then
         return 0
@@ -696,7 +721,7 @@ function compare_remote_version() {
         unset pkgrel
         remote_tmp="$(sudo mktemp -p "${PACDIR}" -t "compare-repo-ver-$crv_input.XXXXXX")"
         remote_safe="${remote_tmp}"
-        curl -fsSL "$remoterepo/packages/$crv_fetch/.SRCINFO" | sudo tee "${remote_safe}" > /dev/null || return 1
+        curl -fsSL "$remoterepo/packages/$crv_fetch/.SRCINFO" | sudo tee "${remote_safe}" > /dev/null || { ignore_stack=true && return 1; }
         sudo chown "${PACSTALL_USER}" "${remote_safe}"
         crv_base="$(srcinfo.match_pkg "${remote_safe}" pkgbase)"
         for remv in "pkgver" "pkgrel" "epoch"; do
@@ -712,7 +737,7 @@ function compare_remote_version() {
         else
             echo "${crv_epoch:+$crv_epoch:}${crv_pkgver}-pacstall${crv_pkgrel:-1}"
         fi
-        sudo rm -rf "${remote_safe}"
+        sudo rm -rf "${remote_safe:?}"
     )" > /dev/null
     localver=$(source "${METADIR}/${crv_input}" && echo "${_version}")
     if [[ $crv_input == *"-git" ]]; then

--- a/misc/scripts/get-pacscript.sh
+++ b/misc/scripts/get-pacscript.sh
@@ -63,6 +63,6 @@ if check_url "${URL}"; then
 else
     error_log 1 "get $PACKAGE pacscript"
     # shellcheck disable=SC2034
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 fi
 # vim:set ft=sh ts=4 sw=4 et:

--- a/misc/scripts/get-pacscript.sh
+++ b/misc/scripts/get-pacscript.sh
@@ -24,6 +24,8 @@
 
 # This script downloads pacscripts from the interwebs
 
+trap stacktrace ERR
+
 if check_url "${URL}"; then
     if [[ $type == "install" ]]; then
         mkdir -p "$PACDIR" || {
@@ -60,6 +62,6 @@ if check_url "${URL}"; then
     return 0
 else
     error_log 1 "get $PACKAGE pacscript"
-    return 1
+    { ignore_stack=true && return 1; }
 fi
 # vim:set ft=sh ts=4 sw=4 et:

--- a/misc/scripts/get-pacscript.sh
+++ b/misc/scripts/get-pacscript.sh
@@ -62,6 +62,7 @@ if check_url "${URL}"; then
     return 0
 else
     error_log 1 "get $PACKAGE pacscript"
+    # shellcheck disable=SC2034
     { ignore_stack=true && return 1; }
 fi
 # vim:set ft=sh ts=4 sw=4 et:

--- a/misc/scripts/get-pacscript.sh
+++ b/misc/scripts/get-pacscript.sh
@@ -24,7 +24,7 @@
 
 # This script downloads pacscripts from the interwebs
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 if check_url "${URL}"; then
     if [[ $type == "install" ]]; then

--- a/misc/scripts/get-pacscript.sh
+++ b/misc/scripts/get-pacscript.sh
@@ -24,7 +24,7 @@
 
 # This script downloads pacscripts from the interwebs
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 if check_url "${URL}"; then
     if [[ $type == "install" ]]; then

--- a/misc/scripts/package-base.sh
+++ b/misc/scripts/package-base.sh
@@ -27,13 +27,13 @@
 # shellcheck source=./misc/scripts/checks.sh
 source "${SCRIPTDIR}/scripts/checks.sh" || {
     fancy_message error "Could not find checks.sh"
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 }
 
 # shellcheck source=./misc/scripts/fetch-sources.sh
 source "${SCRIPTDIR}/scripts/fetch-sources.sh" || {
     fancy_message error "Could not find fetch-sources.sh"
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 }
 
 function trap_ctrlc() {
@@ -97,7 +97,7 @@ function package_pkg() {
                 for i in "${pkgname[@]}"; do
                     # print optdepends with bold package name
                     echo -e "\t\t[${BICyan}$z${NC}] ${BOLD}${i%%:\ *}${NC}"
-                    { ignore_stack=true && ((z++)); }
+                    { ignore_stack=true; ((z++)); }
                 done
                 unset z
                 # tab over the next line
@@ -111,7 +111,7 @@ function package_pkg() {
                         local skip_pkg+=("$i")
                         unset 'choices[$choice_inc]'
                     fi
-                    { ignore_stack=true && ((choice_inc++)); }
+                    { ignore_stack=true; ((choice_inc++)); }
                 done
                 if [[ -n ${skip_pkg[*]} ]]; then
                     fancy_message warn "${BGreen}${skip_pkg[*]}${NC} has exceeded the maximum number of packages to build. Skipping"

--- a/misc/scripts/package-base.sh
+++ b/misc/scripts/package-base.sh
@@ -22,19 +22,22 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
+trap stacktrace ERR
+
 # shellcheck source=./misc/scripts/checks.sh
 source "${SCRIPTDIR}/scripts/checks.sh" || {
     fancy_message error "Could not find checks.sh"
-    return 1
+    { ignore_stack=true && return 1; }
 }
 
 # shellcheck source=./misc/scripts/fetch-sources.sh
 source "${SCRIPTDIR}/scripts/fetch-sources.sh" || {
     fancy_message error "Could not find fetch-sources.sh"
-    return 1
+    { ignore_stack=true && return 1; }
 }
 
 function trap_ctrlc() {
+    trap stacktrace ERR
     fancy_message warn "\nInterrupted, cleaning up"
     # shellcheck disable=SC2031
     if is_apt_package_installed "${pacname}"; then
@@ -48,6 +51,7 @@ function trap_ctrlc() {
 }
 
 function package_override() {
+    trap stacktrace ERR
     # shellcheck disable=SC2031
     local o all_ovars opac="${pacname}" obase="${pkgbase}" ovars=("gives" "pkgdesc" "url" "priority")
     all_ovars=("${ovars[@]}" "arch" "license" "checkdepends" "optdepends" "pacdeps" "provides" "conflicts" "breaks" "replaces" "enhances" "recommends" "backup" "repology")
@@ -80,6 +84,7 @@ function package_override() {
 }
 
 function package_pkg() {
+    trap stacktrace ERR
     # shellcheck disable=SC2031
     if [[ -n ${pkgbase} ]]; then
         # shellcheck disable=SC2031

--- a/misc/scripts/package-base.sh
+++ b/misc/scripts/package-base.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 # shellcheck source=./misc/scripts/checks.sh
 source "${SCRIPTDIR}/scripts/checks.sh" || {
@@ -37,7 +37,7 @@ source "${SCRIPTDIR}/scripts/fetch-sources.sh" || {
 }
 
 function trap_ctrlc() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     fancy_message warn "\nInterrupted, cleaning up"
     # shellcheck disable=SC2031
     if is_apt_package_installed "${pacname}"; then
@@ -51,7 +51,7 @@ function trap_ctrlc() {
 }
 
 function package_override() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # shellcheck disable=SC2031
     local o all_ovars opac="${pacname}" obase="${pkgbase}" ovars=("gives" "pkgdesc" "url" "priority")
     all_ovars=("${ovars[@]}" "arch" "license" "checkdepends" "optdepends" "pacdeps" "provides" "conflicts" "breaks" "replaces" "enhances" "recommends" "backup" "repology")
@@ -84,7 +84,7 @@ function package_override() {
 }
 
 function package_pkg() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # shellcheck disable=SC2031
     if [[ -n ${pkgbase} ]]; then
         # shellcheck disable=SC2031
@@ -97,7 +97,7 @@ function package_pkg() {
                 for i in "${pkgname[@]}"; do
                     # print optdepends with bold package name
                     echo -e "\t\t[${BICyan}$z${NC}] ${BOLD}${i%%:\ *}${NC}"
-                    ((z++))
+                    { ignore_stack=true && ((z++)); }
                 done
                 unset z
                 # tab over the next line
@@ -111,7 +111,7 @@ function package_pkg() {
                         local skip_pkg+=("$i")
                         unset 'choices[$choice_inc]'
                     fi
-                    ((choice_inc++))
+                    { ignore_stack=true && ((choice_inc++)); }
                 done
                 if [[ -n ${skip_pkg[*]} ]]; then
                     fancy_message warn "${BGreen}${skip_pkg[*]}${NC} has exceeded the maximum number of packages to build. Skipping"

--- a/misc/scripts/package-base.sh
+++ b/misc/scripts/package-base.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 # shellcheck source=./misc/scripts/checks.sh
 source "${SCRIPTDIR}/scripts/checks.sh" || {
@@ -37,7 +37,7 @@ source "${SCRIPTDIR}/scripts/fetch-sources.sh" || {
 }
 
 function trap_ctrlc() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     fancy_message warn "\nInterrupted, cleaning up"
     # shellcheck disable=SC2031
     if is_apt_package_installed "${pacname}"; then
@@ -51,7 +51,7 @@ function trap_ctrlc() {
 }
 
 function package_override() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # shellcheck disable=SC2031
     local o all_ovars opac="${pacname}" obase="${pkgbase}" ovars=("gives" "pkgdesc" "url" "priority")
     all_ovars=("${ovars[@]}" "arch" "license" "checkdepends" "optdepends" "pacdeps" "provides" "conflicts" "breaks" "replaces" "enhances" "recommends" "backup" "repology")
@@ -84,7 +84,7 @@ function package_override() {
 }
 
 function package_pkg() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # shellcheck disable=SC2031
     if [[ -n ${pkgbase} ]]; then
         # shellcheck disable=SC2031

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -343,7 +343,6 @@ function fail_out_functions() {
     error_log 5 "$func ${pacname}"
     echo -ne "\t"
     fancy_message error "Could not $func ${pacname} properly"
-    sudo dpkg -P "${gives:-$pacname}" > /dev/null
     clean_fail_down
 }
 

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -386,8 +386,6 @@ if [[ -n ${pac_functions[*]} ]]; then
     done
 fi
 
-trap - ERR
-
 cd "$HOME" 2> /dev/null || (
     error_log 1 "install ${pacname}"
     fancy_message warn "Could not enter into ${HOME}"

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -45,7 +45,7 @@ if ((PACSTALL_INSTALL == 0)) && [[ ${pacname} == *-deb ]]; then
     parse_source_entry "${source[0]}"
     if ! download "${source[0]}" "${dest}"; then
         fancy_message error "Failed to download '${source[0]}'"
-        { ignore_stack=true && return 1; }
+        { ignore_stack=true; return 1; }
     else
         fancy_message info "Moving ${BGreen}${PACDIR}/${dest}${NC} to ${BGreen}${PACDEB_DIR}/${dest}${NC}"
         sudo mv ./"${dest}" "${PACDEB_DIR}"
@@ -262,7 +262,7 @@ unset dest_list
 install_builddepends
 
 # shellcheck disable=SC2034
-prompt_optdepends || { ignore_stack=true && return 1; }
+prompt_optdepends || { ignore_stack=true; return 1; }
 
 fancy_message info "Retrieving packages"
 mkdir -p "${PACDIR}"

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -284,12 +284,16 @@ for i in "${!source[@]}"; do
         done
     fi
     if [[ $source_url != *://* ]]; then
-        if [[ -z ${REPO} ]]; then
-            # shellcheck disable=SC2086
-            REPO="$(< ${SCRIPTDIR}/repo/pacstallrepo)"
+        if [[ -f "${PKGPATH}/${dest}" ]]; then
+            source_url="file://${PKGPATH}/${dest}"
+        else
+            if [[ -z ${REPO} ]]; then
+                # shellcheck disable=SC2086
+                REPO="$(< ${SCRIPTDIR}/repo/pacstallrepo)"
+            fi
+            # shellcheck disable=SC2031
+            source_url="${REPO}/packages/${pacname}/${source_url}"
         fi
-        # shellcheck disable=SC2031
-        source_url="${REPO}/packages/${pacname}/${source_url}"
     fi
     case "${source_url}" in
         *file://*)

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -288,8 +288,8 @@ for i in "${!source[@]}"; do
             source_url="file://${PKGPATH}/${dest}"
         else
             if [[ -z ${REPO} ]]; then
-                # shellcheck disable=SC2086
-                REPO="$(< ${SCRIPTDIR}/repo/pacstallrepo)"
+                mapfile -t REPO < <(< "${SCRIPTDIR}/repo/pacstallrepo")
+                REPO="${REPO[0]}"
             fi
             # shellcheck disable=SC2031
             source_url="${REPO}/packages/${pacname}/${source_url}"

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 if [[ ${external_connection} == "true" ]]; then
     fancy_message warn "This package will connect to the internet during its build process."
@@ -336,7 +336,7 @@ trap - SIGINT
 clean_logdir
 
 function fail_out_functions() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local func="$1"
     trap - ERR
     eval "$restoreshopt"
@@ -347,7 +347,7 @@ function fail_out_functions() {
 }
 
 function safe_run() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local func="$1"
     export restoreshopt="$(shopt -p)
 $(shopt -p -o)"

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -288,8 +288,7 @@ for i in "${!source[@]}"; do
             source_url="file://${PKGPATH}/${dest}"
         else
             if [[ -z ${REPO} ]]; then
-                mapfile -t REPO < <(< "${SCRIPTDIR}/repo/pacstallrepo")
-                REPO="${REPO[0]}"
+                REPO="$(head -n1 "${SCRIPTDIR}/repo/pacstallrepo")"
             fi
             # shellcheck disable=SC2031
             source_url="${REPO}/packages/${pacname}/${source_url}"

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 if [[ ${external_connection} == "true" ]]; then
     fancy_message warn "This package will connect to the internet during its build process."

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -377,7 +377,7 @@ sudo mkdir -p "/var/cache/pacstall/${pacname}/${full_version}"
 if ! cd "$DIR" 2> /dev/null; then
     error_log 1 "install ${pacname}"
     fancy_message error "Could not enter into ${DIR}"
-    sudo dpkg -r "${gives:-$pacname}" > /dev/null
+    sudo dpkg -r "${gives:-$pacname}" 2> /dev/null
     clean_fail_down
 fi
 

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -153,7 +153,7 @@ if [[ -n $pacdeps ]]; then
                     clean_fail_down
                 fi
             else
-                fancy_message info "The pacstall dependency ${i} is already installed and at latest version"
+                fancy_message sub "The pacstall dependency ${PURPLE}${i}${NC} is already installed and at latest version"
                 if ! awk '/_pacstall_depends="true"/ {found=1; exit} END {if (found != 1) exit 1}' "${METADIR}/${i}"; then
                     echo '_pacstall_depends="true"' | sudo tee -a "${METADIR}/${i}" > /dev/null
                 fi

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -261,6 +261,7 @@ done
 unset dest_list
 install_builddepends
 
+# shellcheck disable=SC2034
 prompt_optdepends || { ignore_stack=true && return 1; }
 
 fancy_message info "Retrieving packages"

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -343,7 +343,7 @@ function fail_out_functions() {
     error_log 5 "$func ${pacname}"
     echo -ne "\t"
     fancy_message error "Could not $func ${pacname} properly"
-    sudo dpkg -r "${gives:-$pacname}" > /dev/null
+    sudo dpkg -P "${gives:-$pacname}" > /dev/null
     clean_fail_down
 }
 

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -347,6 +347,7 @@ function fail_out_functions() {
 }
 
 function safe_run() {
+    # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local func="$1"
     export restoreshopt="$(shopt -p)

--- a/misc/scripts/quality-assurance.sh
+++ b/misc/scripts/quality-assurance.sh
@@ -52,6 +52,7 @@ function parse_link() {
 }
 
 function cleanup_qa() {
+    # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     if [[ -f "$SCRIPTDIR/repo/pacstallrepo.pacstall-qa.bak" ]]; then
         fancy_message info "Returning ${CYAN}$SCRIPTDIR/repo/pacstallrepo${NC} backup"

--- a/misc/scripts/quality-assurance.sh
+++ b/misc/scripts/quality-assurance.sh
@@ -22,7 +22,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-parse_pr() {
+trap stacktrace ERR
+
+function parse_pr() {
+    trap stacktrace ERR
     IFS=':' read -ra ADDR <<< "$1"
     local provider user repo pr
     provider="${ADDR[0]}"
@@ -32,7 +35,8 @@ parse_pr() {
     echo "$provider" "$user" "$repo" "$pr"
 }
 
-parse_link() {
+function parse_link() {
+    trap stacktrace ERR
     unset login
     local provider="$1" user="$2" repo="$3" pr="$4"
     if [[ $provider == "github" ]]; then
@@ -47,10 +51,11 @@ parse_link() {
     fi
 }
 
-cleanup_qa() {
+function cleanup_qa() {
+    trap stacktrace ERR
     if [[ -f "$SCRIPTDIR/repo/pacstallrepo.pacstall-qa.bak" ]]; then
         fancy_message info "Returning ${CYAN}$SCRIPTDIR/repo/pacstallrepo${NC} backup"
-        sudo rm -f "${SCRIPTDIR:-/usr/share/pacstall}/repo/pacstallrepo"
+        sudo rm -f "${SCRIPTDIR:?}/repo/pacstallrepo"
         sudo mv "$SCRIPTDIR/repo/pacstallrepo.pacstall-qa.bak" "$SCRIPTDIR/repo/pacstallrepo"
     fi
 }

--- a/misc/scripts/quality-assurance.sh
+++ b/misc/scripts/quality-assurance.sh
@@ -22,10 +22,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 function parse_pr() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     IFS=':' read -ra ADDR <<< "$1"
     local provider user repo pr
     provider="${ADDR[0]}"
@@ -36,7 +36,7 @@ function parse_pr() {
 }
 
 function parse_link() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     unset login
     local provider="$1" user="$2" repo="$3" pr="$4"
     if [[ $provider == "github" ]]; then
@@ -53,7 +53,7 @@ function parse_link() {
 
 function cleanup_qa() {
     # shellcheck disable=SC2034
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     if [[ -f "$SCRIPTDIR/repo/pacstallrepo.pacstall-qa.bak" ]]; then
         fancy_message info "Returning ${CYAN}$SCRIPTDIR/repo/pacstallrepo${NC} backup"
         sudo rm -f "${SCRIPTDIR:?}/repo/pacstallrepo"

--- a/misc/scripts/quality-assurance.sh
+++ b/misc/scripts/quality-assurance.sh
@@ -22,10 +22,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 function parse_pr() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     IFS=':' read -ra ADDR <<< "$1"
     local provider user repo pr
     provider="${ADDR[0]}"
@@ -36,7 +36,7 @@ function parse_pr() {
 }
 
 function parse_link() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     unset login
     local provider="$1" user="$2" repo="$3" pr="$4"
     if [[ $provider == "github" ]]; then
@@ -52,7 +52,7 @@ function parse_link() {
 }
 
 function cleanup_qa() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     if [[ -f "$SCRIPTDIR/repo/pacstallrepo.pacstall-qa.bak" ]]; then
         fancy_message info "Returning ${CYAN}$SCRIPTDIR/repo/pacstallrepo${NC} backup"
         sudo rm -f "${SCRIPTDIR:?}/repo/pacstallrepo"

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -22,6 +22,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
+trap stacktrace ERR
+
 if [[ -z $PACKAGE ]]; then
     fancy_message error "You failed to specify a package"
     exit 1
@@ -35,6 +37,7 @@ fi
 source "$METADIR/$PACKAGE"
 
 function get_field() {
+    trap stacktrace ERR
     # input 1: package
     # input 2: field
     # input 3: out_var

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 if [[ -z $PACKAGE ]]; then
     fancy_message error "You failed to specify a package"
@@ -37,7 +37,7 @@ fi
 source "$METADIR/$PACKAGE"
 
 function get_field() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # input 1: package
     # input 2: field
     # input 3: out_var

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 if [[ -z $PACKAGE ]]; then
     fancy_message error "You failed to specify a package"
@@ -38,7 +38,7 @@ source "$METADIR/$PACKAGE"
 
 function get_field() {
     # shellcheck disable=SC2034
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # input 1: package
     # input 2: field
     # input 3: out_var

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -37,6 +37,7 @@ fi
 source "$METADIR/$PACKAGE"
 
 function get_field() {
+    # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # input 1: package
     # input 2: field

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -23,7 +23,7 @@
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
 # shellcheck disable=SC2034
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 source "$METADIR/$PACKAGE" 2> /dev/null || {
     fancy_message error "$PACKAGE is not installed"

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -22,6 +22,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
+trap stacktrace ERR
+
 source "$METADIR/$PACKAGE" 2> /dev/null || {
     fancy_message error "$PACKAGE is not installed"
     exit 1

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -22,6 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
+# shellcheck disable=SC2034
 { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 source "$METADIR/$PACKAGE" 2> /dev/null || {

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 source "$METADIR/$PACKAGE" 2> /dev/null || {
     fancy_message error "$PACKAGE is not installed"

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -24,7 +24,7 @@
 
 # This script searches for packages in all repos saved on pacstallrepo
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 if [[ -n $UPGRADE ]]; then
     [[ ! -f /tmp/pacstall-pacdeps-${PACKAGE%@*} ]] && PACKAGE="${i}"
@@ -32,7 +32,7 @@ if [[ -n $UPGRADE ]]; then
 fi
 
 function getPath() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local path="${1}"
     local var="${2}"
     path="${path/"file://"/}"
@@ -43,7 +43,7 @@ function getPath() {
 }
 
 function specifyRepo() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local SPLIT
     mapfile -t SPLIT <<< "${1//[\/]/$'\n'}"
 
@@ -67,7 +67,7 @@ function specifyRepo() {
 # Also adds hyperlink for the
 # terminals that support them
 function parseRepo() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local REPO="${1}"
     local SPLIT REPODIR
     mapfile -t SPLIT <<< "${REPO//[\/]/$'\n'}"
@@ -85,7 +85,7 @@ function parseRepo() {
 }
 
 function formatRepo() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     ! [[ $1 =~ ^\ *# ]] \
         && [[ $1 =~ ^([^[:space:]]+)([[:space:]]+#.*)?$ ]] \
         && echo "${BASH_REMATCH[1]}"

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -46,20 +46,26 @@ function specifyRepo() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local SPLIT
     mapfile -t SPLIT <<< "${1//[\/]/$'\n'}"
-
     if [[ $1 == "file://"* ]] || [[ $1 == "/"* ]] || [[ $1 == "~"* ]] || [[ $1 == "."* ]]; then
         export URLNAME
         getPath "${1}" URLNAME
     elif [[ $1 == "github:"* ]] || [[ $1 == "gitlab:"* ]]; then
         export URLNAME="${1}"
     elif [[ $1 == *"github"* ]]; then
-        export URLNAME="github:${SPLIT[-3]}/${SPLIT[-2]}"
+        if [[ ${SPLIT[-1]} == "master" || ${SPLIT[-1]} == "main" ]]; then
+            export URLNAME="github:${SPLIT[-3]}/${SPLIT[-2]}"
+        else
+            export URLNAME="github:${SPLIT[-3]}/${SPLIT[-2]}#${SPLIT[-1]}"
+        fi
     elif [[ $1 == *"gitlab"* ]]; then
-        export URLNAME="gitlab:${SPLIT[-4]}/${SPLIT[-3]}"
+        if [[ ${SPLIT[-1]} == "master" || ${SPLIT[-1]} == "main" ]]; then
+            export URLNAME="github:${SPLIT[-4]}/${SPLIT[-3]}"
+        else
+            export URLNAME="github:${SPLIT[-4]}/${SPLIT[-3]}#${SPLIT[-1]}"
+        fi
     else
         export URLNAME="$REPO"
     fi
-
 }
 
 # Parses github and gitlab URL's

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -24,7 +24,7 @@
 
 # This script searches for packages in all repos saved on pacstallrepo
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 if [[ -n $UPGRADE ]]; then
     [[ ! -f /tmp/pacstall-pacdeps-${PACKAGE%@*} ]] && PACKAGE="${i}"
@@ -32,7 +32,7 @@ if [[ -n $UPGRADE ]]; then
 fi
 
 function getPath() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local path="${1}"
     local var="${2}"
     path="${path/"file://"/}"
@@ -43,7 +43,7 @@ function getPath() {
 }
 
 function specifyRepo() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local SPLIT
     mapfile -t SPLIT <<< "${1//[\/]/$'\n'}"
 
@@ -67,7 +67,7 @@ function specifyRepo() {
 # Also adds hyperlink for the
 # terminals that support them
 function parseRepo() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local REPO="${1}"
     local SPLIT REPODIR
     mapfile -t SPLIT <<< "${REPO//[\/]/$'\n'}"
@@ -85,7 +85,7 @@ function parseRepo() {
 }
 
 function formatRepo() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     ! [[ $1 =~ ^\ *# ]] \
         && [[ $1 =~ ^([^[:space:]]+)([[:space:]]+#.*)?$ ]] \
         && echo "${BASH_REMATCH[1]}"
@@ -187,7 +187,7 @@ if ((${#any_masks[@]} != 0)); then
         if array.contains any_masks "${pkg}"; then
             unset "PACKAGELIST[$mask_itr]"
         fi
-        ((mask_itr++))
+        { ignore_stack=true && ((mask_itr++)); }
     done
     PACKAGELIST=("${PACKAGELIST[@]}")
     unset mask_itr

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -220,6 +220,7 @@ if ((LEN == 0)); then
         exit 1
     fi
 
+    # shellcheck disable=SC2034
     { ignore_stack=true && return 1; }
 # Check if it's upgrading packages
 elif [[ -n $UPGRADE ]]; then

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -187,7 +187,7 @@ if ((${#any_masks[@]} != 0)); then
         if array.contains any_masks "${pkg}"; then
             unset "PACKAGELIST[$mask_itr]"
         fi
-        { ignore_stack=true && ((mask_itr++)); }
+        { ignore_stack=true; ((mask_itr++)); }
     done
     PACKAGELIST=("${PACKAGELIST[@]}")
     unset mask_itr
@@ -221,7 +221,7 @@ if ((LEN == 0)); then
     fi
 
     # shellcheck disable=SC2034
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 # Check if it's upgrading packages
 elif [[ -n $UPGRADE ]]; then
     REPOS=()

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -24,12 +24,15 @@
 
 # This script searches for packages in all repos saved on pacstallrepo
 
+trap stacktrace ERR
+
 if [[ -n $UPGRADE ]]; then
     [[ ! -f /tmp/pacstall-pacdeps-${PACKAGE%@*} ]] && PACKAGE="${i}"
     [[ -n ${_pkgbase} ]] && PACKAGE="${_pkgbase}:${PACKAGE}"
 fi
 
 function getPath() {
+    trap stacktrace ERR
     local path="${1}"
     local var="${2}"
     path="${path/"file://"/}"
@@ -40,6 +43,7 @@ function getPath() {
 }
 
 function specifyRepo() {
+    trap stacktrace ERR
     local SPLIT
     mapfile -t SPLIT <<< "${1//[\/]/$'\n'}"
 
@@ -63,6 +67,7 @@ function specifyRepo() {
 # Also adds hyperlink for the
 # terminals that support them
 function parseRepo() {
+    trap stacktrace ERR
     local REPO="${1}"
     local SPLIT REPODIR
     mapfile -t SPLIT <<< "${REPO//[\/]/$'\n'}"
@@ -80,6 +85,7 @@ function parseRepo() {
 }
 
 function formatRepo() {
+    trap stacktrace ERR
     ! [[ $1 =~ ^\ *# ]] \
         && [[ $1 =~ ^([^[:space:]]+)([[:space:]]+#.*)?$ ]] \
         && echo "${BASH_REMATCH[1]}"
@@ -214,7 +220,7 @@ if ((LEN == 0)); then
         exit 1
     fi
 
-    return 1
+    { ignore_stack=true && return 1; }
 # Check if it's upgrading packages
 elif [[ -n $UPGRADE ]]; then
     REPOS=()

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -42,7 +42,7 @@
 function srcinfo.array_build() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local dest="${1}" src="${2}" i keys values
-    declare -p "$2" &> /dev/null || { ignore_stack=true && return 1; }
+    declare -p "$2" &> /dev/null || { ignore_stack=true; return 1; }
     eval "keys=(\"\${!$2[@]}\")"
     eval "${dest}=()"
     for i in "${keys[@]}"; do
@@ -73,7 +73,7 @@ function srcinfo.extr_fnvar() {
     fi
     local func_body
     func_body=$(declare -f "${funcname}" 2> /dev/null)
-    [[ -z ${func_body} ]] && { ignore_stack=true && return 1; }
+    [[ -z ${func_body} ]] && { ignore_stack=true; return 1; }
     IFS=$'\n' read -r -d '' -a lines <<< "${func_body}"
     for line in "${lines[@]}"; do
         [[ ${line} =~ ${attr_regex} ]] || continue
@@ -81,7 +81,7 @@ function srcinfo.extr_fnvar() {
         eval "${decl/#${attr}/${outputvar}}"
         r=0
     done
-    { ignore_stack=true && return "${r}"; }
+    { ignore_stack=true; return "${r}"; }
 }
 
 function srcinfo.get_attr() {
@@ -280,7 +280,7 @@ function srcinfo._contains() {
         fi
     done
     # shellcheck disable=SC2034
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 }
 
 # @description Create array based on input

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -280,6 +280,7 @@ function srcinfo._contains() {
             return 0
         fi
     done
+    # shellcheck disable=SC2034
     { ignore_stack=true && return 1; }
 }
 

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -37,10 +37,10 @@
 #     Copyright (C) 2009-2024 Pacman Development Team
 #     <pacman-dev@lists.archlinux.org>
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 function srcinfo.array_build() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local dest="${1}" src="${2}" i keys values
     declare -p "$2" &> /dev/null || { ignore_stack=true && return 1; }
     eval "keys=(\"\${!$2[@]}\")"
@@ -52,7 +52,7 @@ function srcinfo.array_build() {
 }
 
 function srcinfo.extr_globvar() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local attr="${1}" isarray="${2}" outputvar="${3}" ref
     if ((isarray)); then
         srcinfo.array_build ref "${attr}"
@@ -63,7 +63,7 @@ function srcinfo.extr_globvar() {
 }
 
 function srcinfo.extr_fnvar() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local funcname="${1}" attr="${2}" isarray="${3}" outputvar="${4}"
     local attr_regex decl r=1
     if ((isarray)); then
@@ -85,7 +85,7 @@ function srcinfo.extr_fnvar() {
 }
 
 function srcinfo.get_attr() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local pkgname="${1}" attrname="${2}" isarray="${3}" outputvar="${4}"
     if ((isarray)); then
         eval "${outputvar}=()"
@@ -101,7 +101,7 @@ function srcinfo.get_attr() {
 }
 
 function srcinfo.write_attr() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local attrname="${1}" attrvalues=("${@:2}")
     attrvalues=("${attrvalues[@]//+([[:space:]])/ }")
     attrvalues=("${attrvalues[@]#[[:space:]]}")
@@ -110,7 +110,7 @@ function srcinfo.write_attr() {
 }
 
 function srcinfo.extract() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local pkgname="${1}" attrname="${2}" isarray="${3}" outvalue
     if srcinfo.get_attr "${pkgname}" "${attrname}" "${isarray}" 'outvalue'; then
         srcinfo.write_attr "${attrname}" "${outvalue[@]}"
@@ -118,7 +118,7 @@ function srcinfo.extract() {
 }
 
 function srcinfo.write_details() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local attr package_arch a
     for attr in "${singlevalued[@]}"; do
         srcinfo.extract "$1" "${attr}" 0
@@ -139,7 +139,7 @@ function srcinfo.write_details() {
 }
 
 function srcinfo.vars() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local _distros _vars _archs _sums distros \
         vars="depends makedepends optdepends pacdeps checkdepends provides conflicts breaks replaces enhances recommends makeconflicts checkconflicts source" \
         sums="b2 sha512 sha384 sha256 sha224 sha1 md5"
@@ -154,7 +154,7 @@ function srcinfo.vars() {
 }
 
 function srcinfo.write_global() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # shellcheck disable=SC2034
     local CARCH='CARCH_REPLACE' DISTRO="${DISTRO}" CDISTRO="${CDISTRO}" AARCH='AARCH_REPLACE' var ar aars bar ars rar rep seek
     local -A AARCHS_MAP=(
@@ -226,7 +226,7 @@ function srcinfo.write_global() {
 }
 
 function srcinfo.write_package() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local singlevalued=(gives pkgdesc url priority)
     local multivalued=(arch license checkdepends optdepends pacdeps
         provides conflicts breaks replaces enhances recommends backup repology)
@@ -235,7 +235,7 @@ function srcinfo.write_package() {
 }
 
 function srcinfo.gen() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local pkg
     srcinfo.write_global
     for pkg in "${pkgname[@]}"; do
@@ -253,7 +253,7 @@ function srcinfo.gen() {
 # @arg $1 string Key value assignment
 # @arg $2 string Name of associated array
 function srcinfo.parse_key_val() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local key value input="${1}"
     declare -n out_array="${2}"
     key="${input%%=*}"
@@ -267,12 +267,12 @@ function srcinfo.parse_key_val() {
 }
 
 function srcinfo._basic_check() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     [[ ${1} == *"="* ]]
 }
 
 function srcinfo._contains() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local -n arr_name="${1}"
     local key="${2}" z
     for z in "${arr_name[@]}"; do
@@ -295,7 +295,7 @@ function srcinfo._contains() {
 #
 # @stdout Name of array created.
 function srcinfo._create_array() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local pkgbase="${1}" var_name="${2}" var_pref="${3}"
     if [[ -n ${pkgbase} ]]; then
         if ! [[ -v "${var_pref}_${pkgbase}_array_${var_name}" ]]; then
@@ -318,7 +318,7 @@ function srcinfo._create_array() {
 #
 # @arg $1 string Name of array to promote
 function srcinfo._promote_to_variable() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local var_name="${1}" key value
     key="${var_name}"
     value="${!var_name[0]}"
@@ -326,10 +326,9 @@ function srcinfo._promote_to_variable() {
 }
 
 function srcinfo.parse() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # We need this for trimming whitespace without external tools.
-    # shellcheck disable=SC2064
-    trap "$(shopt -p extglob)" RETURN
+    trap "shopt -u extglob" RETURN
     shopt -s extglob
     local srcinfo_file var_prefix locbase temp_array ref total_list loop part i part_two split_up
     srcinfo_file="${1:?No .SRCINFO passed to srcinfo.parse}"
@@ -417,7 +416,7 @@ function srcinfo.parse() {
 }
 
 function srcinfo.cleanup() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local var_prefix="${1:?No var_prefix passed to srcinfo.cleanup}" i z
     local main_loop_template="${var_prefix}_access" compg
     declare -n main_loop="${main_loop_template}"
@@ -449,7 +448,7 @@ function srcinfo.cleanup() {
 # @arg $1 string Associative array to reformat
 # @arg $2 string Ref string of indexed array to append conversion to (can be anything)
 function srcinfo.reformat_assoc_arr() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local pfx base ida new pfs in_name="${1}"
     local -n in_arr="${in_name}" app="${2}"
     IFS='_' read -r -a pfs <<< "${in_name}"
@@ -467,7 +466,7 @@ function srcinfo.reformat_assoc_arr() {
 # @arg $1 string .SRCINFO file path
 # @arg $2 string Variable or Array to print
 function srcinfo.print_var() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local srcinfo_file="${1}" found="${2}" var_prefix="srcinfo" pkgbase output var name idx evil eviler e printed
     local -n bases="${var_prefix}_access"
     srcinfo.parse "${srcinfo_file}" "${var_prefix}"
@@ -537,7 +536,7 @@ function srcinfo.print_var() {
 # @arg $2 string Variable or Array to search
 # @arg $3 string Package name or base to get output for
 function srcinfo.match_pkg() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local declares d bases b guy match out srcfile="${1}" search="${2}" pkg="${3}"
     if [[ ${pkg} == "pkgbase:"* || ${search} == "pkgbase" ]]; then
         pkg="${pkg/pkgbase:/}"
@@ -579,10 +578,9 @@ function srcinfo.match_pkg() {
 }
 
 function srcinfo.print_out() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     (
-        # shellcheck disable=SC2064
-        trap "$(shopt -p extglob)" RETURN
+        trap "shopt -u extglob" RETURN
         shopt -s extglob
         srcinfo.vars
         srcinfo.gen

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -37,9 +37,12 @@
 #     Copyright (C) 2009-2024 Pacman Development Team
 #     <pacman-dev@lists.archlinux.org>
 
+trap stacktrace ERR
+
 function srcinfo.array_build() {
+    # trap stacktrace ERR
     local dest="${1}" src="${2}" i keys values
-    declare -p "$2" &> /dev/null || return 1
+    declare -p "$2" &> /dev/null || { ignore_stack=true && return 1; }
     eval "keys=(\"\${!$2[@]}\")"
     eval "${dest}=()"
     for i in "${keys[@]}"; do
@@ -49,6 +52,7 @@ function srcinfo.array_build() {
 }
 
 function srcinfo.extr_globvar() {
+    # trap stacktrace ERR
     local attr="${1}" isarray="${2}" outputvar="${3}" ref
     if ((isarray)); then
         srcinfo.array_build ref "${attr}"
@@ -59,6 +63,7 @@ function srcinfo.extr_globvar() {
 }
 
 function srcinfo.extr_fnvar() {
+    # trap stacktrace ERR
     local funcname="${1}" attr="${2}" isarray="${3}" outputvar="${4}"
     local attr_regex decl r=1
     if ((isarray)); then
@@ -68,7 +73,7 @@ function srcinfo.extr_fnvar() {
     fi
     local func_body
     func_body=$(declare -f "${funcname}" 2> /dev/null)
-    [[ -z ${func_body} ]] && return 1
+    [[ -z ${func_body} ]] && { ignore_stack=true && return 1; }
     IFS=$'\n' read -r -d '' -a lines <<< "${func_body}"
     for line in "${lines[@]}"; do
         [[ ${line} =~ ${attr_regex} ]] || continue
@@ -76,10 +81,11 @@ function srcinfo.extr_fnvar() {
         eval "${decl/#${attr}/${outputvar}}"
         r=0
     done
-    return "${r}"
+    { ignore_stack=true && return "${r}"; }
 }
 
 function srcinfo.get_attr() {
+    # trap stacktrace ERR
     local pkgname="${1}" attrname="${2}" isarray="${3}" outputvar="${4}"
     if ((isarray)); then
         eval "${outputvar}=()"
@@ -95,6 +101,7 @@ function srcinfo.get_attr() {
 }
 
 function srcinfo.write_attr() {
+    trap stacktrace ERR
     local attrname="${1}" attrvalues=("${@:2}")
     attrvalues=("${attrvalues[@]//+([[:space:]])/ }")
     attrvalues=("${attrvalues[@]#[[:space:]]}")
@@ -103,6 +110,7 @@ function srcinfo.write_attr() {
 }
 
 function srcinfo.extract() {
+    trap stacktrace ERR
     local pkgname="${1}" attrname="${2}" isarray="${3}" outvalue
     if srcinfo.get_attr "${pkgname}" "${attrname}" "${isarray}" 'outvalue'; then
         srcinfo.write_attr "${attrname}" "${outvalue[@]}"
@@ -110,6 +118,7 @@ function srcinfo.extract() {
 }
 
 function srcinfo.write_details() {
+    trap stacktrace ERR
     local attr package_arch a
     for attr in "${singlevalued[@]}"; do
         srcinfo.extract "$1" "${attr}" 0
@@ -130,6 +139,7 @@ function srcinfo.write_details() {
 }
 
 function srcinfo.vars() {
+    trap stacktrace ERR
     local _distros _vars _archs _sums distros \
         vars="depends makedepends optdepends pacdeps checkdepends provides conflicts breaks replaces enhances recommends makeconflicts checkconflicts source" \
         sums="b2 sha512 sha384 sha256 sha224 sha1 md5"
@@ -144,6 +154,7 @@ function srcinfo.vars() {
 }
 
 function srcinfo.write_global() {
+    trap stacktrace ERR
     # shellcheck disable=SC2034
     local CARCH='CARCH_REPLACE' DISTRO="${DISTRO}" CDISTRO="${CDISTRO}" AARCH='AARCH_REPLACE' var ar aars bar ars rar rep seek
     local -A AARCHS_MAP=(
@@ -215,6 +226,7 @@ function srcinfo.write_global() {
 }
 
 function srcinfo.write_package() {
+    trap stacktrace ERR
     local singlevalued=(gives pkgdesc url priority)
     local multivalued=(arch license checkdepends optdepends pacdeps
         provides conflicts breaks replaces enhances recommends backup repology)
@@ -223,6 +235,7 @@ function srcinfo.write_package() {
 }
 
 function srcinfo.gen() {
+    trap stacktrace ERR
     local pkg
     srcinfo.write_global
     for pkg in "${pkgname[@]}"; do
@@ -240,6 +253,7 @@ function srcinfo.gen() {
 # @arg $1 string Key value assignment
 # @arg $2 string Name of associated array
 function srcinfo.parse_key_val() {
+    trap stacktrace ERR
     local key value input="${1}"
     declare -n out_array="${2}"
     key="${input%%=*}"
@@ -253,10 +267,12 @@ function srcinfo.parse_key_val() {
 }
 
 function srcinfo._basic_check() {
+    trap stacktrace ERR
     [[ ${1} == *"="* ]]
 }
 
 function srcinfo._contains() {
+    trap stacktrace ERR
     local -n arr_name="${1}"
     local key="${2}" z
     for z in "${arr_name[@]}"; do
@@ -264,7 +280,7 @@ function srcinfo._contains() {
             return 0
         fi
     done
-    return 1
+    { ignore_stack=true && return 1; }
 }
 
 # @description Create array based on input
@@ -278,6 +294,7 @@ function srcinfo._contains() {
 #
 # @stdout Name of array created.
 function srcinfo._create_array() {
+    trap stacktrace ERR
     local pkgbase="${1}" var_name="${2}" var_pref="${3}"
     if [[ -n ${pkgbase} ]]; then
         if ! [[ -v "${var_pref}_${pkgbase}_array_${var_name}" ]]; then
@@ -300,6 +317,7 @@ function srcinfo._create_array() {
 #
 # @arg $1 string Name of array to promote
 function srcinfo._promote_to_variable() {
+    trap stacktrace ERR
     local var_name="${1}" key value
     key="${var_name}"
     value="${!var_name[0]}"
@@ -307,6 +325,7 @@ function srcinfo._promote_to_variable() {
 }
 
 function srcinfo.parse() {
+    trap stacktrace ERR
     # We need this for trimming whitespace without external tools.
     # shellcheck disable=SC2064
     trap "$(shopt -p extglob)" RETURN
@@ -397,6 +416,7 @@ function srcinfo.parse() {
 }
 
 function srcinfo.cleanup() {
+    trap stacktrace ERR
     local var_prefix="${1:?No var_prefix passed to srcinfo.cleanup}" i z
     local main_loop_template="${var_prefix}_access" compg
     declare -n main_loop="${main_loop_template}"
@@ -428,6 +448,7 @@ function srcinfo.cleanup() {
 # @arg $1 string Associative array to reformat
 # @arg $2 string Ref string of indexed array to append conversion to (can be anything)
 function srcinfo.reformat_assoc_arr() {
+    trap stacktrace ERR
     local pfx base ida new pfs in_name="${1}"
     local -n in_arr="${in_name}" app="${2}"
     IFS='_' read -r -a pfs <<< "${in_name}"
@@ -445,6 +466,7 @@ function srcinfo.reformat_assoc_arr() {
 # @arg $1 string .SRCINFO file path
 # @arg $2 string Variable or Array to print
 function srcinfo.print_var() {
+    trap stacktrace ERR
     local srcinfo_file="${1}" found="${2}" var_prefix="srcinfo" pkgbase output var name idx evil eviler e printed
     local -n bases="${var_prefix}_access"
     srcinfo.parse "${srcinfo_file}" "${var_prefix}"
@@ -514,6 +536,7 @@ function srcinfo.print_var() {
 # @arg $2 string Variable or Array to search
 # @arg $3 string Package name or base to get output for
 function srcinfo.match_pkg() {
+    trap stacktrace ERR
     local declares d bases b guy match out srcfile="${1}" search="${2}" pkg="${3}"
     if [[ ${pkg} == "pkgbase:"* || ${search} == "pkgbase" ]]; then
         pkg="${pkg/pkgbase:/}"
@@ -555,6 +578,7 @@ function srcinfo.match_pkg() {
 }
 
 function srcinfo.print_out() {
+    trap stacktrace ERR
     (
         # shellcheck disable=SC2064
         trap "$(shopt -p extglob)" RETURN

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -578,6 +578,7 @@ function srcinfo.match_pkg() {
 }
 
 function srcinfo.print_out() {
+    # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     (
         trap "shopt -u extglob" RETURN

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -324,9 +324,6 @@ function srcinfo._promote_to_variable() {
 
 function srcinfo.parse() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    # We need this for trimming whitespace without external tools.
-    trap "shopt -u extglob" RETURN
-    shopt -s extglob
     local srcinfo_file var_prefix locbase temp_array ref total_list loop part i part_two split_up
     srcinfo_file="${1:?No .SRCINFO passed to srcinfo.parse}"
     var_prefix="${2:?Variable prefix not passed to srcinfo.parse}"
@@ -576,10 +573,11 @@ function srcinfo.print_out() {
     # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     (
-        trap "shopt -u extglob" RETURN
+        # We need this for trimming whitespace without external tools.
         shopt -s extglob
         srcinfo.vars
         srcinfo.gen
+        shopt -u extglob
     )
 }
 # vim:set ft=sh ts=4 sw=4 et:

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -89,7 +89,9 @@ function srcinfo.get_attr() {
     local pkgname="${1}" attrname="${2}" isarray="${3}" outputvar="${4}"
     if [[ -n ${pkgname} ]]; then
         srcinfo.extr_globvar "${attrname}" "${isarray}" "${outputvar}"
-        is_function "package_${pkgname}" && srcinfo.extr_fnvar "package_${pkgname}" "${attrname}" "${isarray}" "${outputvar}"
+        if is_function "package_${pkgname}"; then
+            srcinfo.extr_fnvar "package_${pkgname}" "${attrname}" "${isarray}" "${outputvar}"
+        fi
     else
         srcinfo.extr_globvar "${attrname}" "${isarray}" "${outputvar}"
     fi

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -40,7 +40,7 @@
 trap stacktrace ERR
 
 function srcinfo.array_build() {
-    # trap stacktrace ERR
+    trap stacktrace ERR
     local dest="${1}" src="${2}" i keys values
     declare -p "$2" &> /dev/null || { ignore_stack=true && return 1; }
     eval "keys=(\"\${!$2[@]}\")"
@@ -52,7 +52,7 @@ function srcinfo.array_build() {
 }
 
 function srcinfo.extr_globvar() {
-    # trap stacktrace ERR
+    trap stacktrace ERR
     local attr="${1}" isarray="${2}" outputvar="${3}" ref
     if ((isarray)); then
         srcinfo.array_build ref "${attr}"
@@ -63,7 +63,7 @@ function srcinfo.extr_globvar() {
 }
 
 function srcinfo.extr_fnvar() {
-    # trap stacktrace ERR
+    trap stacktrace ERR
     local funcname="${1}" attr="${2}" isarray="${3}" outputvar="${4}"
     local attr_regex decl r=1
     if ((isarray)); then
@@ -85,7 +85,7 @@ function srcinfo.extr_fnvar() {
 }
 
 function srcinfo.get_attr() {
-    # trap stacktrace ERR
+    trap stacktrace ERR
     local pkgname="${1}" attrname="${2}" isarray="${3}" outputvar="${4}"
     if ((isarray)); then
         eval "${outputvar}=()"
@@ -128,7 +128,7 @@ function srcinfo.write_details() {
         srcinfo.extract "$1" "${attr}" 1
     done
 
-    srcinfo.get_attr "$1" 'arch' 1 'package_arch'
+    srcinfo.get_attr "$1" 'arch' 1 'package_arch' || package_arch=("all")
     for a in "${package_arch[@]}"; do
         [[ ${a} == any || ${a} == all ]] && continue
 

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -37,10 +37,10 @@
 #     Copyright (C) 2009-2024 Pacman Development Team
 #     <pacman-dev@lists.archlinux.org>
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 function srcinfo.array_build() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local dest="${1}" src="${2}" i keys values
     declare -p "$2" &> /dev/null || { ignore_stack=true && return 1; }
     eval "keys=(\"\${!$2[@]}\")"
@@ -52,21 +52,21 @@ function srcinfo.array_build() {
 }
 
 function srcinfo.extr_globvar() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -eo pipefail; trap stacktrace ERR RETURN; }
     local attr="${1}" isarray="${2}" outputvar="${3}" ref
-    if ((isarray)); then
+    if ((isarray==1)); then
         srcinfo.array_build ref "${attr}"
-        ((${#ref[@]})) && srcinfo.array_build "${outputvar}" "${attr}"
+        if ((${#ref[@]}>=1)); then srcinfo.array_build "${outputvar}" "${attr}"; fi
     else
-        [[ -n ${!attr} ]] && printf -v "${outputvar}" %s "${!attr}"
+        if [[ -n ${!attr} ]]; then printf -v "${outputvar}" %s "${!attr}"; fi
     fi
 }
 
 function srcinfo.extr_fnvar() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local funcname="${1}" attr="${2}" isarray="${3}" outputvar="${4}"
     local attr_regex decl r=1
-    if ((isarray)); then
+    if ((isarray==1)); then
         printf -v attr_regex '^[[:space:]]* %s\+?=\(' "${attr}"
     else
         printf -v attr_regex '^[[:space:]]* %s\+?=[^(]' "${attr}"
@@ -85,23 +85,18 @@ function srcinfo.extr_fnvar() {
 }
 
 function srcinfo.get_attr() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local pkgname="${1}" attrname="${2}" isarray="${3}" outputvar="${4}"
-    if ((isarray)); then
-        eval "${outputvar}=()"
-    else
-        printf -v "${outputvar}" %s ''
-    fi
     if [[ -n ${pkgname} ]]; then
         srcinfo.extr_globvar "${attrname}" "${isarray}" "${outputvar}"
-        srcinfo.extr_fnvar "package_${pkgname}" "${attrname}" "${isarray}" "${outputvar}"
+        is_function "package_${pkgname}" && srcinfo.extr_fnvar "package_${pkgname}" "${attrname}" "${isarray}" "${outputvar}"
     else
         srcinfo.extr_globvar "${attrname}" "${isarray}" "${outputvar}"
     fi
 }
 
 function srcinfo.write_attr() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local attrname="${1}" attrvalues=("${@:2}")
     attrvalues=("${attrvalues[@]//+([[:space:]])/ }")
     attrvalues=("${attrvalues[@]#[[:space:]]}")
@@ -110,7 +105,7 @@ function srcinfo.write_attr() {
 }
 
 function srcinfo.extract() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local pkgname="${1}" attrname="${2}" isarray="${3}" outvalue
     if srcinfo.get_attr "${pkgname}" "${attrname}" "${isarray}" 'outvalue'; then
         srcinfo.write_attr "${attrname}" "${outvalue[@]}"
@@ -118,14 +113,16 @@ function srcinfo.extract() {
 }
 
 function srcinfo.write_details() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local attr package_arch a
     for attr in "${singlevalued[@]}"; do
-        srcinfo.extract "$1" "${attr}" 0
+        local -n at="${attr}"
+        [[ -n ${at} ]] && srcinfo.extract "$1" "${attr}" 0
     done
 
     for attr in "${multivalued[@]}"; do
-        srcinfo.extract "$1" "${attr}" 1
+        local -n at="${attr}"
+        [[ -n ${at[*]} ]] && srcinfo.extract "$1" "${attr}" 1
     done
 
     srcinfo.get_attr "$1" 'arch' 1 'package_arch' || package_arch=("all")
@@ -139,7 +136,7 @@ function srcinfo.write_details() {
 }
 
 function srcinfo.vars() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local _distros _vars _archs _sums distros \
         vars="depends makedepends optdepends pacdeps checkdepends provides conflicts breaks replaces enhances recommends makeconflicts checkconflicts source" \
         sums="b2 sha512 sha384 sha256 sha224 sha1 md5"
@@ -154,7 +151,7 @@ function srcinfo.vars() {
 }
 
 function srcinfo.write_global() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # shellcheck disable=SC2034
     local CARCH='CARCH_REPLACE' DISTRO="${DISTRO}" CDISTRO="${CDISTRO}" AARCH='AARCH_REPLACE' var ar aars bar ars rar rep seek
     local -A AARCHS_MAP=(
@@ -226,7 +223,7 @@ function srcinfo.write_global() {
 }
 
 function srcinfo.write_package() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local singlevalued=(gives pkgdesc url priority)
     local multivalued=(arch license checkdepends optdepends pacdeps
         provides conflicts breaks replaces enhances recommends backup repology)
@@ -235,7 +232,7 @@ function srcinfo.write_package() {
 }
 
 function srcinfo.gen() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local pkg
     srcinfo.write_global
     for pkg in "${pkgname[@]}"; do
@@ -253,7 +250,7 @@ function srcinfo.gen() {
 # @arg $1 string Key value assignment
 # @arg $2 string Name of associated array
 function srcinfo.parse_key_val() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local key value input="${1}"
     declare -n out_array="${2}"
     key="${input%%=*}"
@@ -267,12 +264,12 @@ function srcinfo.parse_key_val() {
 }
 
 function srcinfo._basic_check() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     [[ ${1} == *"="* ]]
 }
 
 function srcinfo._contains() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local -n arr_name="${1}"
     local key="${2}" z
     for z in "${arr_name[@]}"; do
@@ -295,7 +292,7 @@ function srcinfo._contains() {
 #
 # @stdout Name of array created.
 function srcinfo._create_array() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local pkgbase="${1}" var_name="${2}" var_pref="${3}"
     if [[ -n ${pkgbase} ]]; then
         if ! [[ -v "${var_pref}_${pkgbase}_array_${var_name}" ]]; then
@@ -318,7 +315,7 @@ function srcinfo._create_array() {
 #
 # @arg $1 string Name of array to promote
 function srcinfo._promote_to_variable() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local var_name="${1}" key value
     key="${var_name}"
     value="${!var_name[0]}"
@@ -326,7 +323,7 @@ function srcinfo._promote_to_variable() {
 }
 
 function srcinfo.parse() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # We need this for trimming whitespace without external tools.
     trap "shopt -u extglob" RETURN
     shopt -s extglob
@@ -416,7 +413,7 @@ function srcinfo.parse() {
 }
 
 function srcinfo.cleanup() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local var_prefix="${1:?No var_prefix passed to srcinfo.cleanup}" i z
     local main_loop_template="${var_prefix}_access" compg
     declare -n main_loop="${main_loop_template}"
@@ -448,7 +445,7 @@ function srcinfo.cleanup() {
 # @arg $1 string Associative array to reformat
 # @arg $2 string Ref string of indexed array to append conversion to (can be anything)
 function srcinfo.reformat_assoc_arr() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local pfx base ida new pfs in_name="${1}"
     local -n in_arr="${in_name}" app="${2}"
     IFS='_' read -r -a pfs <<< "${in_name}"
@@ -466,7 +463,7 @@ function srcinfo.reformat_assoc_arr() {
 # @arg $1 string .SRCINFO file path
 # @arg $2 string Variable or Array to print
 function srcinfo.print_var() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local srcinfo_file="${1}" found="${2}" var_prefix="srcinfo" pkgbase output var name idx evil eviler e printed
     local -n bases="${var_prefix}_access"
     srcinfo.parse "${srcinfo_file}" "${var_prefix}"
@@ -474,10 +471,8 @@ function srcinfo.print_var() {
         if [[ -n ${globase} && ${globase} != "temporary_pacstall_pkgbase" ]]; then
             pkgbase="${globase}"
             declare -p pkgbase
-            return 0
-        else
-            return 3
         fi
+        return 0
     fi
     for var in "${bases[@]}"; do
         declare -n output="${var}_array_${found}"
@@ -536,7 +531,7 @@ function srcinfo.print_var() {
 # @arg $2 string Variable or Array to search
 # @arg $3 string Package name or base to get output for
 function srcinfo.match_pkg() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local declares d bases b guy match out srcfile="${1}" search="${2}" pkg="${3}"
     if [[ ${pkg} == "pkgbase:"* || ${search} == "pkgbase" ]]; then
         pkg="${pkg/pkgbase:/}"
@@ -579,7 +574,7 @@ function srcinfo.match_pkg() {
 
 function srcinfo.print_out() {
     # shellcheck disable=SC2034
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     (
         trap "shopt -u extglob" RETURN
         shopt -s extglob

--- a/misc/scripts/update.sh
+++ b/misc/scripts/update.sh
@@ -25,7 +25,7 @@
 # Update should be self-contained and should use mutable functions or variables
 # Color variables are ok, while "$USERNAME" and "$BRANCH" are needed
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 export BOLD='\033[1m'
 export NC='\033[0m'
@@ -41,7 +41,7 @@ SCRIPTDIR="/usr/share/pacstall"
 required_packages=(aptitude bubblewrap jq distro-info-data)
 
 function suggested_solution() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     if [[ -z $PACSTALL_SUPPRESS_SOLUTIONS ]]; then
         local inputs=("${@}")
         if ((${#inputs[@]} > 1)); then

--- a/misc/scripts/update.sh
+++ b/misc/scripts/update.sh
@@ -24,6 +24,9 @@
 
 # Update should be self-contained and should use mutable functions or variables
 # Color variables are ok, while "$USERNAME" and "$BRANCH" are needed
+
+trap stacktrace ERR
+
 export BOLD='\033[1m'
 export NC='\033[0m'
 export UCyan='\033[4;36m'
@@ -38,6 +41,7 @@ SCRIPTDIR="/usr/share/pacstall"
 required_packages=(aptitude bubblewrap jq distro-info-data)
 
 function suggested_solution() {
+    trap stacktrace ERR
     if [[ -z $PACSTALL_SUPPRESS_SOLUTIONS ]]; then
         local inputs=("${@}")
         if ((${#inputs[@]} > 1)); then
@@ -96,7 +100,7 @@ for i in {error-log.sh,add-repo.sh,search.sh,dep-tree.sh,version-constraints.sh,
 done
 # Remove renamed files
 for i in {error_log.sh,download.sh,download-local.sh,install-local.sh,build-local.sh}; do
-    sudo rm -f "$SCRIPTDIR/scripts/$i"
+    sudo rm -f "${SCRIPTDIR:?}/scripts/$i"
 done
 
 sudo curl -s -o /bin/pacstall "$REPO/pacstall" &

--- a/misc/scripts/update.sh
+++ b/misc/scripts/update.sh
@@ -25,7 +25,7 @@
 # Update should be self-contained and should use mutable functions or variables
 # Color variables are ok, while "$USERNAME" and "$BRANCH" are needed
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 export BOLD='\033[1m'
 export NC='\033[0m'
@@ -42,7 +42,7 @@ required_packages=(aptitude bubblewrap jq distro-info-data)
 
 function suggested_solution() {
     # shellcheck disable=SC2034
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     if [[ -z $PACSTALL_SUPPRESS_SOLUTIONS ]]; then
         local inputs=("${@}")
         if ((${#inputs[@]} > 1)); then

--- a/misc/scripts/update.sh
+++ b/misc/scripts/update.sh
@@ -41,6 +41,7 @@ SCRIPTDIR="/usr/share/pacstall"
 required_packages=(aptitude bubblewrap jq distro-info-data)
 
 function suggested_solution() {
+    # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     if [[ -z $PACSTALL_SUPPRESS_SOLUTIONS ]]; then
         local inputs=("${@}")

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -51,7 +51,7 @@ function ver_compare() {
         first_git="${first#*~git}"; first="${first%~git*}"
         second_git="${second#*~git}"; second="${second%~git*}"
     fi
-    if [[ -n ${second_git} && ${first_git} != ${second_git} ]]; then
+    if [[ -n ${second_git} && ${first_git} != "${second_git}" ]]; then
         result=0
     else
         { dpkg --compare-versions "${first}" lt "${second}"; result=$?; }

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -22,25 +22,28 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
+trap stacktrace ERR
+
 # shellcheck source=./misc/scripts/dep-tree.sh
 source "${SCRIPTDIR}/scripts/dep-tree.sh" || {
     fancy_message error "Could not load dep-tree.sh"
-    return 1
+    { ignore_stack=true && return 1; }
 }
 
 # shellcheck source=./misc/scripts/fetch-sources.sh
 source "${SCRIPTDIR}/scripts/fetch-sources.sh" || {
     fancy_message error "Could not find fetch-sources.sh"
-    return 1
+    { ignore_stack=true && return 1; }
 }
 
 # shellcheck source=./misc/scripts/srcinfo.sh
 source "${SCRIPTDIR}/scripts/srcinfo.sh" || {
     fancy_message error "Could not find srcinfo.sh"
-    return 1
+    { ignore_stack=true && return 1; }
 }
 
 function ver_compare() {
+    trap stacktrace ERR
     local first second
     first="${1#"${1/[0-9]*/}"}"
     second="${2#"${2/[0-9]*/}"}"
@@ -49,11 +52,12 @@ function ver_compare() {
 }
 
 function calc_repo_ver() {
+    trap stacktrace ERR
     local compare_repo="$1" compare_package="$2" compare_tmp compare_safe compare_pkgver compare_pkgrel compare_epoch compare_source comp compare_base
     unset comp_repo_ver
     compare_tmp="$(sudo mktemp -p "${PACDIR}" -t "calc-repo-ver-$compare_package.XXXXXX")"
     compare_safe="${compare_tmp}"
-    curl -fsSL "$compare_repo/packages/$compare_package/.SRCINFO" | sudo tee "${compare_safe}" > /dev/null || return 1
+    curl -fsSL "$compare_repo/packages/$compare_package/.SRCINFO" | sudo tee "${compare_safe}" > /dev/null || { ignore_stack=true && return 1; }
     sudo chown "${PACSTALL_USER}" "${compare_safe}"
     compare_base="$(srcinfo.match_pkg "${compare_safe}" pkgbase)"
     for comp in "pkgver" "pkgrel" "epoch"; do
@@ -69,7 +73,7 @@ function calc_repo_ver() {
     else
         comp_repo_ver="${compare_epoch:+$compare_epoch:}${compare_pkgver}-pacstall${compare_pkgrel:-1}"
     fi
-    sudo rm -rf "${compare_safe}"
+    sudo rm -rf "${compare_safe:?}"
 }
 
 export UPGRADE="yes"
@@ -264,5 +268,5 @@ ${BOLD}$(cat "${up_print}")${NC}\n"
     done
 fi
 
-rm -f "${up_list}" "${up_print}" "${up_urls}"
+rm -f "${up_list:?}" "${up_print:?}" "${up_urls:?}"
 # vim:set ft=sh ts=4 sw=4 et:

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -27,19 +27,19 @@
 # shellcheck source=./misc/scripts/dep-tree.sh
 source "${SCRIPTDIR}/scripts/dep-tree.sh" || {
     fancy_message error "Could not load dep-tree.sh"
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 }
 
 # shellcheck source=./misc/scripts/fetch-sources.sh
 source "${SCRIPTDIR}/scripts/fetch-sources.sh" || {
     fancy_message error "Could not find fetch-sources.sh"
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 }
 
 # shellcheck source=./misc/scripts/srcinfo.sh
 source "${SCRIPTDIR}/scripts/srcinfo.sh" || {
     fancy_message error "Could not find srcinfo.sh"
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 }
 
 function ver_compare() {
@@ -57,7 +57,7 @@ function calc_repo_ver() {
     unset comp_repo_ver
     compare_tmp="$(sudo mktemp -p "${PACDIR}" -t "calc-repo-ver-$compare_package.XXXXXX")"
     compare_safe="${compare_tmp}"
-    curl -fsSL "$compare_repo/packages/$compare_package/.SRCINFO" | sudo tee "${compare_safe}" > /dev/null || { ignore_stack=true && return 1; }
+    curl -fsSL "$compare_repo/packages/$compare_package/.SRCINFO" | sudo tee "${compare_safe}" > /dev/null || { ignore_stack=true; return 1; }
     sudo chown "${PACSTALL_USER}" "${compare_safe}"
     compare_base="$(srcinfo.match_pkg "${compare_safe}" pkgbase)"
     for comp in "pkgver" "pkgrel" "epoch"; do

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 # shellcheck source=./misc/scripts/dep-tree.sh
 source "${SCRIPTDIR}/scripts/dep-tree.sh" || {
@@ -43,7 +43,7 @@ source "${SCRIPTDIR}/scripts/srcinfo.sh" || {
 }
 
 function ver_compare() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local first second
     first="${1#"${1/[0-9]*/}"}"
     second="${2#"${2/[0-9]*/}"}"
@@ -52,7 +52,7 @@ function ver_compare() {
 }
 
 function calc_repo_ver() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local compare_repo="$1" compare_package="$2" compare_tmp compare_safe compare_pkgver compare_pkgrel compare_epoch compare_source comp compare_base
     unset comp_repo_ver
     compare_tmp="$(sudo mktemp -p "${PACDIR}" -t "calc-repo-ver-$compare_package.XXXXXX")"

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 # shellcheck source=./misc/scripts/dep-tree.sh
 source "${SCRIPTDIR}/scripts/dep-tree.sh" || {
@@ -43,7 +43,7 @@ source "${SCRIPTDIR}/scripts/srcinfo.sh" || {
 }
 
 function ver_compare() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local first second
     first="${1#"${1/[0-9]*/}"}"
     second="${2#"${2/[0-9]*/}"}"
@@ -52,7 +52,7 @@ function ver_compare() {
 }
 
 function calc_repo_ver() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local compare_repo="$1" compare_package="$2" compare_tmp compare_safe compare_pkgver compare_pkgrel compare_epoch compare_source comp compare_base
     unset comp_repo_ver
     compare_tmp="$(sudo mktemp -p "${PACDIR}" -t "calc-repo-ver-$compare_package.XXXXXX")"

--- a/misc/scripts/version-constraints.sh
+++ b/misc/scripts/version-constraints.sh
@@ -33,7 +33,7 @@
 # @arg $1 string A versioned string.
 function dep_const.apt_compare_to_constraints() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local compare_pkg="${1}" split_up=() pkg_version stripped
+    local compare_pkg="${1}" split_up=() pkg_version stripped ret
     dep_const.strip_description "${compare_pkg}" stripped
     dep_const.split_name_and_version "${stripped}" split_up
     if ((${#split_up[@]} == 1)); then
@@ -46,12 +46,13 @@ function dep_const.apt_compare_to_constraints() {
     fi
     case "${compare_pkg}" in
         # Example: foo@1.2.4 where foo<=1.2.5 should return true, because 1.2.4 is less than 1.2.5
-        *"<="*) dpkg --compare-versions "${pkg_version}" le "${split_up[1]}" ;;
-        *">="*) dpkg --compare-versions "${pkg_version}" ge "${split_up[1]}" ;;
-        *"="*) dpkg --compare-versions "${pkg_version}" eq "${split_up[1]}" ;;
-        *"<"*) dpkg --compare-versions "${pkg_version}" lt "${split_up[1]}" ;;
-        *">"*) dpkg --compare-versions "${pkg_version}" gt "${split_up[1]}" ;;
+        *"<="*) dpkg --compare-versions "${pkg_version}" le "${split_up[1]}"; ret=$? ;;
+        *">="*) dpkg --compare-versions "${pkg_version}" ge "${split_up[1]}"; ret=$? ;;
+        *"="*) dpkg --compare-versions "${pkg_version}" eq "${split_up[1]}"; ret=$? ;;
+        *"<"*) dpkg --compare-versions "${pkg_version}" lt "${split_up[1]}"; ret=$? ;;
+        *">"*) dpkg --compare-versions "${pkg_version}" gt "${split_up[1]}"; ret=$? ;;
     esac
+    { ignore_stack=true && return "${ret}"; }
 }
 
 function dep_const.get_arch() {

--- a/misc/scripts/version-constraints.sh
+++ b/misc/scripts/version-constraints.sh
@@ -42,7 +42,7 @@ function dep_const.apt_compare_to_constraints() {
     if is_apt_package_installed "${split_up[0]}"; then
         pkg_version="$(dpkg-query --showformat='${Version}' --show "${split_up[0]}")"
     else
-        pkg_version="$(aptitude search --quiet --disable-columns "?exact-name(${split_up[0]})?architecture($(dep_const.get_arch "${split_up[0]}"))" -F "%V")"
+        pkg_version="$(aptitude search --quiet --disable-columns "?exact-name(${split_up[0]%:*})?architecture($(dep_const.get_arch "${split_up[0]}"))" -F "%V")"
     fi
     case "${compare_pkg}" in
         # Example: foo@1.2.4 where foo<=1.2.5 should return true, because 1.2.4 is less than 1.2.5

--- a/misc/scripts/version-constraints.sh
+++ b/misc/scripts/version-constraints.sh
@@ -52,7 +52,7 @@ function dep_const.apt_compare_to_constraints() {
         *"<"*) dpkg --compare-versions "${pkg_version}" lt "${split_up[1]}"; ret=$? ;;
         *">"*) dpkg --compare-versions "${pkg_version}" gt "${split_up[1]}"; ret=$? ;;
     esac
-    { ignore_stack=true && return "${ret}"; }
+    { ignore_stack=true; return "${ret}"; }
 }
 
 function dep_const.get_arch() {
@@ -230,7 +230,7 @@ function dep_const.is_pipe() {
     if perl -ne 'exit 1 unless /^(?:[^\s|:]+(?::[^\s|:]+)?\s\|\s)+[^\s|:]+(?::[^\s|:]+)?(?::\s[^|:]+)?(?<!\s)$/' <<< "$1"; then
         return 0
     else
-        { ignore_stack=true && return 1; }
+        { ignore_stack=true; return 1; }
     fi
 }
 

--- a/misc/scripts/version-constraints.sh
+++ b/misc/scripts/version-constraints.sh
@@ -151,7 +151,9 @@ function dep_const.get_pipe() {
                 echo "${pkg}"
                 return 0
             else
-                viable_packages+=("${pkg}")
+                if [[ -n "$(aptitude search --quiet --disable-columns "?exact-name(${check_name[0]%:*})?architecture($(dep_const.get_arch "${check_name[0]}"))" -F "%p")" ]]; then
+                    viable_packages+=("${pkg}")
+                fi
             fi
         fi
     done

--- a/misc/scripts/version-constraints.sh
+++ b/misc/scripts/version-constraints.sh
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 # @description Checks if a package is compatible with given constraint
 # @internal
@@ -32,7 +32,7 @@ trap stacktrace ERR
 #
 # @arg $1 string A versioned string.
 function dep_const.apt_compare_to_constraints() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local compare_pkg="${1}" split_up=() pkg_version stripped
     dep_const.strip_description "${compare_pkg}" stripped
     dep_const.split_name_and_version "${stripped}" split_up
@@ -55,7 +55,7 @@ function dep_const.apt_compare_to_constraints() {
 }
 
 function dep_const.get_arch() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     if [[ $1 == *":"* ]]; then
         echo "${1##*:}"
     else
@@ -65,7 +65,7 @@ function dep_const.get_arch() {
 
 # https://stackoverflow.com/a/17841619/13449010
 function dep_const.join_by() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local d="${1-}" f="${2-}"
     if shift 2; then
         printf "%s" "${f}" "${@/#/$d}"
@@ -81,7 +81,7 @@ function dep_const.join_by() {
 # @arg $1 string A pipe delimited string.
 # @arg $2 string An array name to save split into.
 function dep_const.pipe_split() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local pipe_str="${1}"
     local -n out_var_pipe="${2}"
     # shellcheck disable=SC2034
@@ -97,7 +97,7 @@ function dep_const.pipe_split() {
 # @arg $1 string A bash array.
 # @arg $2 string An output string.
 function dep_const.comma_array() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local -n input_arr="${1}"
     local -n output_str="${2}"
     printf -v output_str '%s, ' "${input_arr[@]}"
@@ -113,7 +113,7 @@ function dep_const.comma_array() {
 # @arg $1 string A versioned package.
 # @arg $2 string An array name to save name and version into.
 function dep_const.split_name_and_version() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local string="${1}"
     local -n out_var="${2}"
     # shellcheck disable=SC2034
@@ -140,7 +140,7 @@ function dep_const.split_name_and_version() {
 # How this works is that we loop through the list and check if it is installed, and if so,
 # we use that, if not, we go to the next one, and repeat. If no package is installed, we choose list[0].
 function dep_const.get_pipe() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local string="${1}" pkg the_array=() viable_packages=() check_name=()
     dep_const.pipe_split "${string}" the_array
     for pkg in "${the_array[@]}"; do
@@ -168,7 +168,7 @@ function dep_const.get_pipe() {
 # @arg $1 string A string description.
 # @arg $2 string A variable to output the package to.
 function dep_const.strip_description() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local -n desc_out="${2}"
     # shellcheck disable=SC2034
     printf -v desc_out "%s" "${1%%: *}"
@@ -183,7 +183,7 @@ function dep_const.strip_description() {
 # @arg $1 string A string description.
 # @arg $2 string A variable to output the description to.
 function dep_const.extract_description() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local -n desc_ext="${2}"
     # shellcheck disable=SC2034
     printf -v desc_ext "%s" "${1##*: }"
@@ -199,7 +199,7 @@ function dep_const.extract_description() {
 # @arg $1 string A versioned string.
 # @arg $2 string An array name to append to.
 function dep_const.format_version() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local str="${1}" const relation pkg_stuff=() constraints=('<=' '>=' '=' '<' '>')
     local -n out_arr="${2}"
     for const in "${constraints[@]}"; do
@@ -225,7 +225,7 @@ function dep_const.format_version() {
 }
 
 function dep_const.is_pipe() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     perl -ne 'exit 1 unless /^(?:[^\s|:]+(?::[^\s|:]+)?\s\|\s)+[^\s|:]+(?::[^\s|:]+)?(?::\s[^|:]+)?(?<!\s)$/' <<< "$1"
 }
 
@@ -241,7 +241,7 @@ function dep_const.is_pipe() {
 # @arg $1 string An array name.
 # @arg $2 string An array name to output to.
 function dep_const.format_control() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local i z strip pipes=() formatted_pipes=() dep_arr=()
     local -n deps="${1}"
     local -n out="${2}"

--- a/misc/scripts/version-constraints.sh
+++ b/misc/scripts/version-constraints.sh
@@ -22,6 +22,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Pacstall. If not, see <https://www.gnu.org/licenses/>.
 
+trap stacktrace ERR
+
 # @description Checks if a package is compatible with given constraint
 # @internal
 #
@@ -30,6 +32,7 @@
 #
 # @arg $1 string A versioned string.
 function dep_const.apt_compare_to_constraints() {
+    trap stacktrace ERR
     local compare_pkg="${1}" split_up=() pkg_version stripped
     dep_const.strip_description "${compare_pkg}" stripped
     dep_const.split_name_and_version "${stripped}" split_up
@@ -52,6 +55,7 @@ function dep_const.apt_compare_to_constraints() {
 }
 
 function dep_const.get_arch() {
+    trap stacktrace ERR
     if [[ $1 == *":"* ]]; then
         echo "${1##*:}"
     else
@@ -61,6 +65,7 @@ function dep_const.get_arch() {
 
 # https://stackoverflow.com/a/17841619/13449010
 function dep_const.join_by() {
+    trap stacktrace ERR
     local d="${1-}" f="${2-}"
     if shift 2; then
         printf "%s" "${f}" "${@/#/$d}"
@@ -76,6 +81,7 @@ function dep_const.join_by() {
 # @arg $1 string A pipe delimited string.
 # @arg $2 string An array name to save split into.
 function dep_const.pipe_split() {
+    trap stacktrace ERR
     local pipe_str="${1}"
     local -n out_var_pipe="${2}"
     # shellcheck disable=SC2034
@@ -91,6 +97,7 @@ function dep_const.pipe_split() {
 # @arg $1 string A bash array.
 # @arg $2 string An output string.
 function dep_const.comma_array() {
+    trap stacktrace ERR
     local -n input_arr="${1}"
     local -n output_str="${2}"
     printf -v output_str '%s, ' "${input_arr[@]}"
@@ -106,6 +113,7 @@ function dep_const.comma_array() {
 # @arg $1 string A versioned package.
 # @arg $2 string An array name to save name and version into.
 function dep_const.split_name_and_version() {
+    trap stacktrace ERR
     local string="${1}"
     local -n out_var="${2}"
     # shellcheck disable=SC2034
@@ -132,6 +140,7 @@ function dep_const.split_name_and_version() {
 # How this works is that we loop through the list and check if it is installed, and if so,
 # we use that, if not, we go to the next one, and repeat. If no package is installed, we choose list[0].
 function dep_const.get_pipe() {
+    trap stacktrace ERR
     local string="${1}" pkg the_array=() viable_packages=() check_name=()
     dep_const.pipe_split "${string}" the_array
     for pkg in "${the_array[@]}"; do
@@ -159,6 +168,7 @@ function dep_const.get_pipe() {
 # @arg $1 string A string description.
 # @arg $2 string A variable to output the package to.
 function dep_const.strip_description() {
+    trap stacktrace ERR
     local -n desc_out="${2}"
     # shellcheck disable=SC2034
     printf -v desc_out "%s" "${1%%: *}"
@@ -173,6 +183,7 @@ function dep_const.strip_description() {
 # @arg $1 string A string description.
 # @arg $2 string A variable to output the description to.
 function dep_const.extract_description() {
+    trap stacktrace ERR
     local -n desc_ext="${2}"
     # shellcheck disable=SC2034
     printf -v desc_ext "%s" "${1##*: }"
@@ -188,6 +199,7 @@ function dep_const.extract_description() {
 # @arg $1 string A versioned string.
 # @arg $2 string An array name to append to.
 function dep_const.format_version() {
+    trap stacktrace ERR
     local str="${1}" const relation pkg_stuff=() constraints=('<=' '>=' '=' '<' '>')
     local -n out_arr="${2}"
     for const in "${constraints[@]}"; do
@@ -213,6 +225,7 @@ function dep_const.format_version() {
 }
 
 function dep_const.is_pipe() {
+    trap stacktrace ERR
     perl -ne 'exit 1 unless /^(?:[^\s|:]+(?::[^\s|:]+)?\s\|\s)+[^\s|:]+(?::[^\s|:]+)?(?::\s[^|:]+)?(?<!\s)$/' <<< "$1"
 }
 
@@ -228,6 +241,7 @@ function dep_const.is_pipe() {
 # @arg $1 string An array name.
 # @arg $2 string An array name to output to.
 function dep_const.format_control() {
+    trap stacktrace ERR
     local i z strip pipes=() formatted_pipes=() dep_arr=()
     local -n deps="${1}"
     local -n out="${2}"

--- a/misc/scripts/version-constraints.sh
+++ b/misc/scripts/version-constraints.sh
@@ -241,6 +241,7 @@ function dep_const.is_pipe() {
 # @arg $1 string An array name.
 # @arg $2 string An array name to output to.
 function dep_const.format_control() {
+    # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local i z strip pipes=() formatted_pipes=() dep_arr=()
     local -n deps="${1}"

--- a/pacstall
+++ b/pacstall
@@ -239,7 +239,8 @@ function cleanup() {
 }
 
 function stacktrace() {
-    if ! ${ignore_stack}; then
+    catch=$?
+    if ((catch==1)) && ! ${ignore_stack}; then
         local i stack_size=${#FUNCNAME[@]} func linen src trace content stack_color color_idx \
             colors=(196 197 198 199 200 201 165 129 93 57 21 27 33 39 45 51 50 49 48 47 46 82 118 154 190 226 220 214 208 202)
         echo -e "[${BRed}!${NC}] ${BOLD}ERROR${NC}: Stacktrace (most recent call last)" >&2

--- a/pacstall
+++ b/pacstall
@@ -322,12 +322,10 @@ function ask() {
         case "$reply" in
             Y* | y*)
                 export answer=1
-                return 0
                 break
                 ;;
             N* | n*)
                 export answer=0
-                { ignore_stack=true && return 1; }
                 break
                 ;;
             *)

--- a/pacstall
+++ b/pacstall
@@ -794,7 +794,7 @@ Helpful links:
             ;;
 
         -I | --install)
-            unset CHILD PACKAGE
+            unset CHILD PKGPATH
             if [[ -z $2 ]]; then
                 fancy_message error "You failed to specify a package"
                 exit 1
@@ -830,7 +830,7 @@ Helpful links:
                     elif [[ -d $PKGPATH ]]; then
                         cd "$PKGPATH"
                     fi
-
+                    export PKGPATH="${PWD}"
                     # Check if the file exist
                     if [[ ! -f "$PACKAGE".pacscript ]]; then
                         fancy_message error "$2 does not exist"

--- a/pacstall
+++ b/pacstall
@@ -177,6 +177,93 @@ function fancy_message() {
     esac
 }
 
+function decl_scriptvars() {
+    local _distros _vars _archs _sums distros \
+        vars="source depends makedepends optdepends pacdeps checkdepends provides conflicts breaks replaces enhances recommends makeconflicts checkconflicts" \
+        archs="amd64 x86_64 arm64 aarch64 armel arm armhf armv7h i386 i686 mips64el ppc64el riscv64 s390x" \
+        sums="b2 sha512 sha384 sha256 sha224 sha1 md5"
+    pacstallvars=(pkgbase pkgname repology pkgver git_pkgver epoch source_url source depends makedepends checkdepends conflicts
+        breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps NOBUILDDEP provides incompatible
+        compatible srcdir url backup pkgrel mask pac_functions repo priority noextract nosubmodules _archive license
+        bwrapenv safeenv external_connection enhances recommends custom_fields makeconflicts checkconflicts)
+    mapfile -t distros < <(awk -F ',' -v current_date="$(date +'%Y-%m-%d')" '
+      BEGIN {
+        is_first = 1
+      }
+      $3 == "series" {
+        if (is_first) {
+          print "ubuntu"
+          is_first = 0
+        } else {
+          print "devel\ndebian"
+        }
+        next
+      }
+      NR > 1 && (($6 > current_date) || ($7 > current_date) || ($6 == "")) &&
+      ($4 <= current_date) && $3 != "experimental" {
+        print $3
+      }' /usr/share/distro-info/{ubuntu,debian}.csv)
+    export PACSTALL_KNOWN_DISTROS=("${distros[@]}")
+    eval "PACSTALL_KNOWN_ARCH=(${archs}) PACSTALL_KNOWN_SUMS=(${sums})"
+    distros="${distros[*]}"
+    _distros="{${distros// /,}}" _vars="{${vars// /,}}" _archs="{${archs// /,}}" _sums="{${sums// /,}}"
+    eval "pacstallvars+=(${_vars}_${_distros} ${_vars}_${_archs} ${_vars}_${_distros}_${_archs} ${_sums}sums ${_sums}sums_${_distros} ${_sums}sums_${_archs} ${_sums}sums_${_distros}_${_archs} gives_${_distros} gives_${_archs} gives_${_distros}_${_archs})"
+}
+decl_scriptvars
+
+function cleanup() {
+    if [[ -n ${KEEP} && -n ${pacname} ]]; then
+        sudo rm -rf "/tmp/pacstall-keep/${pacname}"
+        mkdir -p "/tmp/pacstall-keep/${pacname}"
+        #shellcheck disable=SC2153
+        sudo mv "${PACDIR:?}/${PACKAGE}.pacscript" "/tmp/pacstall-keep/${pacname}"
+        sudo mv "${PACDIR:?}/${PACKAGE}.SRCINFO" "/tmp/pacstall-keep/${pacname}/.SRCINFO"
+        sudo mv "${PACDIR:?}/${pacname}~${pkgver}" "/tmp/pacstall-keep/${pacname}"
+    fi
+    if [[ -n ${pacname} && -f "/tmp/pacstall-pacdeps-${pacname}" ]]; then
+        sudo rm -rf "/tmp/pacstall-pacdeps-${pacname}"
+    else
+        [[ -n ${PACDIR} ]] && sudo rm -rf "${PACDIR}"/*
+        if [[ -n ${pacname} ]]; then
+            sudo rm -rf "${STAGEDIR:-/usr/src/pacstall}/${pacname}"
+        fi
+        sudo rm -rf /tmp/pacstall-gives
+    fi
+    #shellcheck disable=SC2153
+    [[ -n ${STAGEDIR} && -n ${PACKAGE} ]] && sudo rm -rf "${STAGEDIR}/${pacname:-$PACKAGE}.deb"
+    sudo rm -f /tmp/pacstall-select-options
+    [[ -n ${PACDIR} ]] && sudo rm -f "${PACDIR}/bwrapenv.*"
+    unset "${pacstallvars[@]}" 2> /dev/null
+    unset -f pre_install pre_upgrade pre_remove post_install post_upgrade post_remove prepare build check package 2> /dev/null
+    [[ -n ${pacfile} ]] && sudo rm -f "${pacfile}"
+}
+
+function stacktrace() {
+    if ! ${ignore_stack}; then
+        local i j stack_size=${#FUNCNAME[@]} func linen src trace content stack_color color_idx \
+            colors=(196 197 198 199 200 201 165 129 93 57 21 27 33 39 45 51 50 49 48 47 46 82 118 154 190 226 220 214 208 202)
+        for ((i = stack_size - 1; i >= 1; i--)); do
+            color_idx=$(( (stack_size - 1 - i) % ${#colors[@]} ))
+            stack_color="\033[38;5;${colors[color_idx]}m"
+            ((i != stack_stack_size - 1)) && func="${FUNCNAME[i - 1]}"
+            [[ -z ${func} ]] && func='MAIN'
+            [[ ${func} == "stacktrace" ]] && { unset func; trace="[${BRed}!${NC}] ${BOLD}ERROR${NC}"; }
+            linen="${BASH_LINENO[i - 1]}"
+            src="${BASH_SOURCE[i]}"
+            [[ -z ${src} ]] && src=non_file_source
+            echo -e "${stack_color}${func:+├}${trace:+╰}───${GREEN}${func}${NC}${trace}${NC}${func:+()}${trace:+:} ${src%/*}/${PURPLE}${src##*/}${NC}:${YELLOW}${linen}${NC}" >&2
+            echo -e "${stack_color}${func:+│}${trace:+ }${NC}   ${CYAN}╰───➤${NC} \033[38;5;242m"$(awk "NR==${linen}" "${src}")"${NC}" >&2
+        done
+        fancy_message info "Cleaning up"
+        cleanup
+        exit 1
+    else
+        ignore_stack=false
+    fi
+}
+ignore_stack=false
+trap stacktrace ERR
+
 # This is the ask function. You can source this code block and then run something like:
 # ask "Do you like the color blue? " Y
 # if ((answer == 1)); then
@@ -188,6 +275,7 @@ function fancy_message() {
 # Y=1 and N=0
 # You can specify {Y,N} or leave it out to prevent entering the default but this is not allowed in pacstall because of the -P flag which gives unattended install
 function ask() {
+    trap stacktrace ERR
     local prompt default reply
 
     if [[ ${2-} == 'Y' ]]; then
@@ -232,12 +320,12 @@ function ask() {
         case "$reply" in
             Y* | y*)
                 export answer=1
-                return 0 #return code for backwards compatibility
+                return 0
                 break
                 ;;
             N* | n*)
                 export answer=0
-                return 1 #return code
+                { ignore_stack=true && return 1; }
                 break
                 ;;
             *)
@@ -255,6 +343,7 @@ function ask() {
 #   UPurple: text
 # Make sure to quote ('') commands and files/URLS
 function suggested_solution() {
+    trap stacktrace ERR
     if [[ -z $PACSTALL_SUPPRESS_SOLUTIONS ]]; then
         local inputs=("${@}")
         if ((${#inputs[@]} > 1)); then
@@ -270,9 +359,10 @@ function suggested_solution() {
 }
 
 function check_url() {
+    trap stacktrace ERR
     if [[ ${1} == "file://"* ]]; then
         if ! [[ -f ${1/"file://"/} ]]; then
-            return 1
+            { ignore_stack=true && return 1; }
         fi
     else
         local http_code="$(curl --location -o /dev/null -s --head --write-out '%{http_code}\n' -- "${1}")"
@@ -285,12 +375,12 @@ function check_url() {
                     fancy_message error "Failed to download file, check your connection"
                 fi
                 error_log 1 "get ${PACKAGE} pacscript"
-                return 1
+                { ignore_stack=true && return 1; }
                 ;;
             404)
                 fancy_message error "The URL cannot be found"
                 suggested_solution "Confirm that '${UGreen}$1${NC}' exists"
-                return 1
+                { ignore_stack=true && return 1; }
                 ;;
             200 | 301 | 302)
                 return 0
@@ -298,7 +388,7 @@ function check_url() {
             *)
                 fancy_message error "Failed with http code ${http_code}"
                 suggested_solution "Confirm that '${UGreen}$1${NC}' is accessible"
-                return 1
+                { ignore_stack=true && return 1; }
                 ;;
         esac
     fi
@@ -307,14 +397,16 @@ function check_url() {
 # Checks if a command is available.
 # Plain "command -v" succeeds if the argument is in PATH, even if not executable.
 function has_command() {
+    trap stacktrace ERR
     [[ -x $(command -v "$1" 2> /dev/null) ]]
 }
 
 # use axel if available
 function download() {
+    trap stacktrace ERR
     local src="$1" out="${2:-${src##*/}}"
     if [[ $PACSTALL_DOWNLOADER != "payload" ]]; then
-        sudo rm -f "$out"
+        sudo rm -f "${out:?}"
     fi
     if [[ -z $PACSTALL_DOWNLOADER || -f "/tmp/pacstall-pacdeps-$PACKAGE" ]]; then
         if has_command axel; then
@@ -329,23 +421,23 @@ function download() {
 
     case "$PACSTALL_DOWNLOADER" in
         verbose-axel)
-            axel -ao "$out" "$src" || return 1
+            axel -ao "$out" "$src" || { ignore_stack=true && return 1; }
             ;;
         axel)
-            axel -a -q -o "$out" "$src" || return 1
+            axel -a -q -o "$out" "$src" || { ignore_stack=true && return 1; }
             ;;
         verbose-curl)
-            curl -L -# -o "$out" "$src" || return 1
+            curl -L -# -o "$out" "$src" || { ignore_stack=true && return 1; }
             ;;
         curl)
-            curl -sSL -o "$out" "$src" || return 1
+            curl -sSL -o "$out" "$src" || { ignore_stack=true && return 1; }
             ;;
         verbose-wget)
-            wget -q --show-progress --progress=bar:force -O "$out" -- "$src" 2>&1 || return 1
+            wget -q --show-progress --progress=bar:force -O "$out" -- "$src" 2>&1 || { ignore_stack=true && return 1; }
             ;;
         payload) ;;
         wget | *)
-            wget -q -O "$out" -- "$src" 2>&1 || return 1
+            wget -q -O "$out" -- "$src" 2>&1 || { ignore_stack=true && return 1; }
             ;;
     esac
 }
@@ -354,6 +446,7 @@ function download() {
 #   $ select_options "My message I want to send" "${#array[@]}"
 # This will then output the options given by the user to /tmp/pacstall-select-options, which you can then turn into another array
 function select_options() {
+    trap stacktrace ERR
     rm -f /tmp/pacstall-select-options
     local message="${1}"
     local length="${2}"
@@ -415,37 +508,42 @@ function select_options() {
 
 # Return 0 if exists, 1 if not
 function is_package_installed() {
+    trap stacktrace ERR
     local input="${1}"
     while read -r line; do
         if [[ ${line} == "${input}" ]]; then
             return 0
         fi
     done < <(pacstall -L)
-    return 1
+    { ignore_stack=true && return 1; }
 }
 
 # Returns 0 if exists, 1 if not
 function is_apt_package_installed() {
+    trap stacktrace ERR
     if [[ $(dpkg-query -W --showformat='${db:Status-Status}' "${1}" 2> /dev/null) == "installed" ]]; then
         return 0
     else
-        return 1
+        { ignore_stack=true && return 1; }
     fi
 }
 
 function is_array() {
+    trap stacktrace ERR
     [[ ${!1@a} == *a* ]]
 }
 
 function is_function() {
+    trap stacktrace ERR
     if [[ $(type -t "${1}") == "function" ]]; then
         return 0
     else
-        return 1
+        { ignore_stack=true && return 1; }
     fi
 }
 
 function array.contains() {
+    trap stacktrace ERR
     local check
     local -n arra="${1:?No array passed to array.contains}"
     local input="${2:?No input given to array.contains}"
@@ -454,10 +552,11 @@ function array.contains() {
             return 0
         fi
     done
-    return 1
+    { ignore_stack=true && return 1; }
 }
 
 function getMasks() {
+    trap stacktrace ERR
     local pkgs pkg
     local -n masks="${1}"
     mapfile -t pkgs < <(pacstall -L 2> /dev/null)
@@ -474,6 +573,7 @@ function getMasks() {
 }
 
 function getMasks_offending_pkg() {
+    trap stacktrace ERR
     local the_name="${1}"
     mapfile -t pkgs < <(pacstall -L)
     if ((${#pkgs[@]} == 0)); then
@@ -489,43 +589,8 @@ function getMasks_offending_pkg() {
         fi
         unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask 2> /dev/null
     done
-    return 1
+    { ignore_stack=true && return 1; }
 }
-
-function decl_scriptvars() {
-    local _distros _vars _archs _sums distros \
-        vars="source depends makedepends optdepends pacdeps checkdepends provides conflicts breaks replaces enhances recommends makeconflicts checkconflicts" \
-        archs="amd64 x86_64 arm64 aarch64 armel arm armhf armv7h i386 i686 mips64el ppc64el riscv64 s390x" \
-        sums="b2 sha512 sha384 sha256 sha224 sha1 md5"
-    pacstallvars=(pkgbase pkgname repology pkgver git_pkgver epoch source_url source depends makedepends checkdepends conflicts
-        breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps NOBUILDDEP provides incompatible
-        compatible srcdir url backup pkgrel mask pac_functions repo priority noextract nosubmodules _archive license
-        bwrapenv safeenv external_connection enhances recommends custom_fields makeconflicts checkconflicts)
-    mapfile -t distros < <(awk -F ',' -v current_date="$(date +'%Y-%m-%d')" '
-      BEGIN {
-        is_first = 1
-      }
-      $3 == "series" {
-        if (is_first) {
-          print "ubuntu"
-          is_first = 0
-        } else {
-          print "devel\ndebian"
-        }
-        next
-      }
-      NR > 1 && (($6 > current_date) || ($7 > current_date) || ($6 == "")) &&
-      ($4 <= current_date) && $3 != "experimental" {
-        print $3
-      }' /usr/share/distro-info/{ubuntu,debian}.csv)
-    export PACSTALL_KNOWN_DISTROS=("${distros[@]}")
-    eval "PACSTALL_KNOWN_ARCH=(${archs}) PACSTALL_KNOWN_SUMS=(${sums})"
-    distros="${distros[*]}"
-    _distros="{${distros// /,}}" _vars="{${vars// /,}}" _archs="{${archs// /,}}" _sums="{${sums// /,}}"
-    eval "pacstallvars+=(${_vars}_${_distros} ${_vars}_${_archs} ${_vars}_${_distros}_${_archs} ${_sums}sums ${_sums}sums_${_distros} ${_sums}sums_${_archs} ${_sums}sums_${_distros}_${_archs} gives_${_distros} gives_${_archs} gives_${_distros}_${_archs})"
-}
-
-decl_scriptvars
 
 # run sudo apt update if it's been more than a week
 [[ -z "$(find -H /var/lib/apt/lists -maxdepth 0 -mtime -7)" ]] && sudo apt-get update -qq --allow-releaseinfo-change
@@ -603,6 +668,7 @@ fi
 unset short_commands long_commands commands matches arguments_list unique_arguments_list hashed_arguments
 
 function lock() {
+    trap stacktrace ERR
     # Total number of options flags, increase when needed
     local option_flags=5
     local ignore_short="-S -D -A -Rr -V -L -Qi -T -h"
@@ -611,23 +677,23 @@ function lock() {
 
     for ((i = 1; i <= option_flags + 1; i++)); do
         if [[ $ignore =~ (^|[[:space:]])"${!i}"($|[[:space:]]) ]]; then
-            return 1
+            { ignore_stack=true && return 1; }
         fi
         j=$((i + 1))
         if [[ -f "/tmp/pacstall-pacdeps-${!j%%@*}" ]]; then
-            return 1
+            { ignore_stack=true && return 1; }
         fi
     done
 
     if [[ -f "$SCRIPTDIR/repo/pacstallrepo.pacstall-qa.bak" ]]; then
         instances=($(pidof -o %PPID -x "$0"))
         if [[ ${#instances[@]} -lt 2 ]]; then
-            return 1
+            { ignore_stack=true && return 1; }
         fi
         return 0
     fi
 
-    pidof -o %PPID -x "$0" > /dev/null && return 0 || return 1
+    pidof -o %PPID -x "$0" > /dev/null && return 0 || { ignore_stack=true && return 1; }
 }
 
 while lock $@; do

--- a/pacstall
+++ b/pacstall
@@ -251,9 +251,9 @@ function stacktrace() {
             linen="${BASH_LINENO[i - 1]}"
             src="${BASH_SOURCE[i]}"
             [[ -z ${src} ]] && src=non_file_source
-            echo -e "${stack_color}${func:+├}${trace:+╰}───${GREEN}${func}${NC}${trace}${NC}${func:+()}${trace:+:} ${src%/*}/${PURPLE}${src##*/}${NC}:${YELLOW}${linen}${NC}" >&2
+            echo -e "${stack_color}${func:+├}${trace:+╰}───➤${GREEN}${func}${NC}${trace}${NC}${func:+()}${trace:+:} ${src%/*}/${PURPLE}${src##*/}${NC}:${YELLOW}${linen}${NC}" >&2
             # shellcheck disable=SC2027
-            echo -e "${stack_color}${func:+│}${trace:+ }${NC}   ${CYAN}╰───➤${NC} \033[38;5;242m"$(awk "NR==${linen}" "${src}")"${NC}" >&2
+            echo -e "${stack_color}${func:+│}${trace:+ }${NC}    ${CYAN}╰───➤${NC} \033[38;5;242m"$(awk "NR==${linen}" "${src}")"${NC}" >&2
         done
         fancy_message info "Cleaning up"
         cleanup

--- a/pacstall
+++ b/pacstall
@@ -252,6 +252,7 @@ function stacktrace() {
             src="${BASH_SOURCE[i]}"
             [[ -z ${src} ]] && src=non_file_source
             echo -e "${stack_color}${func:+├}${trace:+╰}───${GREEN}${func}${NC}${trace}${NC}${func:+()}${trace:+:} ${src%/*}/${PURPLE}${src##*/}${NC}:${YELLOW}${linen}${NC}" >&2
+            # shellcheck disable=SC2027
             echo -e "${stack_color}${func:+│}${trace:+ }${NC}   ${CYAN}╰───➤${NC} \033[38;5;242m"$(awk "NR==${linen}" "${src}")"${NC}" >&2
         done
         fancy_message info "Cleaning up"

--- a/pacstall
+++ b/pacstall
@@ -239,7 +239,7 @@ function cleanup() {
 }
 
 function stacktrace() {
-    catch=$?
+    local catch=$?
     if ((catch==1)) && ! ${ignore_stack}; then
         local i stack_size=${#FUNCNAME[@]} func linen src trace content stack_color color_idx \
             colors=(196 197 198 199 200 201 165 129 93 57 21 27 33 39 45 51 50 49 48 47 46 82 118 154 190 226 220 214 208 202)

--- a/pacstall
+++ b/pacstall
@@ -253,7 +253,7 @@ function stacktrace() {
             [[ -z ${src} ]] && src=non_file_source
             echo -e "${stack_color}${func:+├}${trace:+╰}───➤${GREEN}${func}${NC}${trace}${NC}${func:+()}${trace:+:} ${src%/*}/${PURPLE}${src##*/}${NC}:${YELLOW}${linen}${NC}" >&2
             # shellcheck disable=SC2027
-            echo -e "${stack_color}${func:+│}${trace:+ }${NC}    ${CYAN}╰───➤${NC} \033[38;5;242m"$(awk "NR==${linen}" "${src}")"${NC}" >&2
+            echo -e "${stack_color}${func:+│}${trace:+ }${NC}    ${CYAN}╰───➤${NC} \033[38;5;242m"$(tail -n +"${linen}" "${src}" | head -n1)"${NC}" >&2
         done
         fancy_message info "Cleaning up"
         cleanup

--- a/pacstall
+++ b/pacstall
@@ -242,18 +242,19 @@ function stacktrace() {
     if ! ${ignore_stack}; then
         local i j stack_size=${#FUNCNAME[@]} func linen src trace content stack_color color_idx \
             colors=(196 197 198 199 200 201 165 129 93 57 21 27 33 39 45 51 50 49 48 47 46 82 118 154 190 226 220 214 208 202)
+        echo -e "[${BRed}!${NC}] ${BOLD}ERROR${NC}: Stacktrace (most recent call last)" >&2
         for ((i = stack_size - 1; i >= 1; i--)); do
             color_idx=$(( (stack_size - 1 - i) % ${#colors[@]} ))
             stack_color="\033[38;5;${colors[color_idx]}m"
             ((i != stack_stack_size - 1)) && func="${FUNCNAME[i - 1]}"
             [[ -z ${func} ]] && func='MAIN'
-            [[ ${func} == "stacktrace" ]] && { unset func; trace="[${BRed}!${NC}] ${BOLD}ERROR${NC}"; }
+            [[ ${func} == "stacktrace" ]] && { unset func; trace="${RED}TRACEBACK${NC}"; }
             linen="${BASH_LINENO[i - 1]}"
             src="${BASH_SOURCE[i]}"
             [[ -z ${src} ]] && src=non_file_source
-            echo -e "${stack_color}${func:+├}${trace:+╰}───➤${GREEN}${func}${NC}${trace}${NC}${func:+()}${trace:+:} ${src%/*}/${PURPLE}${src##*/}${NC}:${YELLOW}${linen}${NC}" >&2
+            echo -e " ${stack_color}${func:+├}${trace:+╰}─➤${GREEN}${func}${NC}${trace}${NC}${func:+()}${trace:+:} ${src%/*}/${PURPLE}${src##*/}${NC}:${YELLOW}${linen}${NC}" >&2
             # shellcheck disable=SC2027
-            echo -e "${stack_color}${func:+│}${trace:+ }${NC}    ${CYAN}╰───➤${NC} \033[38;5;242m"$(tail -n +"${linen}" "${src}" | head -n1)"${NC}" >&2
+            echo -e " ${stack_color}${func:+│}${trace:+ }${NC}  ${CYAN}╰───➤${NC} \033[38;5;242m"$(tail -n +"${linen}" "${src}" | head -n1)"${NC}" >&2
         done
         fancy_message info "Cleaning up"
         cleanup

--- a/pacstall
+++ b/pacstall
@@ -233,9 +233,9 @@ function cleanup() {
     [[ -n ${STAGEDIR} && -n ${PACKAGE} ]] && sudo rm -rf "${STAGEDIR}/${pacname:-$PACKAGE}"*".deb"
     sudo rm -f /tmp/pacstall-select-options
     [[ -n ${PACDIR} ]] && sudo rm -f "${PACDIR}/bwrapenv.*"
+    [[ -n ${pacfile} ]] && sudo rm -f "${pacfile}"
     unset "${pacstallvars[@]}" 2> /dev/null
     unset -f pre_install pre_upgrade pre_remove post_install post_upgrade post_remove prepare build check package 2> /dev/null
-    [[ -n ${pacfile} ]] && sudo rm -f "${pacfile}"
 }
 
 function stacktrace() {

--- a/pacstall
+++ b/pacstall
@@ -230,7 +230,7 @@ function cleanup() {
         sudo rm -rf /tmp/pacstall-gives
     fi
     #shellcheck disable=SC2153
-    [[ -n ${STAGEDIR} && -n ${PACKAGE} ]] && sudo rm -rf "${STAGEDIR}/${pacname:-$PACKAGE}*_${pkgver}*.deb"
+    [[ -n ${STAGEDIR} && -n ${PACKAGE} ]] && sudo rm -rf "${STAGEDIR}/${pacname:-$PACKAGE}"*".deb"
     sudo rm -f /tmp/pacstall-select-options
     [[ -n ${PACDIR} ]] && sudo rm -f "${PACDIR}/bwrapenv.*"
     unset "${pacstallvars[@]}" 2> /dev/null

--- a/pacstall
+++ b/pacstall
@@ -44,6 +44,7 @@ export PACSTALL_INSTALL=1
 
 # declare verbose debug output
 declare -gx PS4=$'\E[0;10m\E[1m\033[1;31m\033[1;37m[\033[1;35m${BASH_SOURCE[0]##*/}:\033[1;34m${FUNCNAME[0]:-NOFUNC}():\033[1;33m${LINENO}\033[1;37m] - \033[1;33mDEBUG: \E[0;10m'
+set -o pipefail
 
 function def_colors() {
     # Colors
@@ -240,7 +241,7 @@ function cleanup() {
 
 function stacktrace() {
     if ! ${ignore_stack}; then
-        local i j stack_size=${#FUNCNAME[@]} func linen src trace content stack_color color_idx \
+        local i stack_size=${#FUNCNAME[@]} func linen src trace content stack_color color_idx \
             colors=(196 197 198 199 200 201 165 129 93 57 21 27 33 39 45 51 50 49 48 47 46 82 118 154 190 226 220 214 208 202)
         echo -e "[${BRed}!${NC}] ${BOLD}ERROR${NC}: Stacktrace (most recent call last)" >&2
         for ((i = stack_size - 1; i >= 1; i--)); do

--- a/pacstall
+++ b/pacstall
@@ -895,8 +895,9 @@ Helpful links:
                     fi
                     export PACKAGE="${PACKAGE/:pkgbase/}"
                     specifyRepo "$REPO"
-                    export REPO
-                    export URL="${REPO:-https://raw.githubusercontent.com/pacstall/pacstall-programs/master}/packages/$PACKAGE/$PACKAGE.pacscript"
+                    # sanity write
+                    export REPO="${REPO}"
+                    export URL="${REPO}/packages/$PACKAGE/$PACKAGE.pacscript"
 
                     # shellcheck source=./misc/scripts/get-pacscript.sh
                     if ! source "$SCRIPTDIR/scripts/get-pacscript.sh"; then

--- a/pacstall
+++ b/pacstall
@@ -230,7 +230,7 @@ function cleanup() {
         sudo rm -rf /tmp/pacstall-gives
     fi
     #shellcheck disable=SC2153
-    [[ -n ${STAGEDIR} && -n ${PACKAGE} ]] && sudo rm -rf "${STAGEDIR}/${pacname:-$PACKAGE}.deb"
+    [[ -n ${STAGEDIR} && -n ${PACKAGE} ]] && sudo rm -rf "${STAGEDIR}/${pacname:-$PACKAGE}*_${pkgver}*.deb"
     sudo rm -f /tmp/pacstall-select-options
     [[ -n ${PACDIR} ]] && sudo rm -f "${PACDIR}/bwrapenv.*"
     unset "${pacstallvars[@]}" 2> /dev/null

--- a/pacstall
+++ b/pacstall
@@ -264,7 +264,7 @@ function stacktrace() {
         export ignore_stack=false
     fi
 }
-{ export ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ export ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 # This is the ask function. You can source this code block and then run something like:
 # ask "Do you like the color blue? " Y
@@ -277,7 +277,7 @@ function stacktrace() {
 # Y=1 and N=0
 # You can specify {Y,N} or leave it out to prevent entering the default but this is not allowed in pacstall because of the -P flag which gives unattended install
 function ask() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local prompt default reply
 
     if [[ ${2-} == 'Y' ]]; then
@@ -345,7 +345,7 @@ function ask() {
 #   UPurple: text
 # Make sure to quote ('') commands and files/URLS
 function suggested_solution() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     if [[ -z $PACSTALL_SUPPRESS_SOLUTIONS ]]; then
         local inputs=("${@}")
         if ((${#inputs[@]} > 1)); then
@@ -361,7 +361,7 @@ function suggested_solution() {
 }
 
 function check_url() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     if [[ ${1} == "file://"* ]]; then
         if ! [[ -f ${1/"file://"/} ]]; then
             { ignore_stack=true && return 1; }
@@ -399,13 +399,13 @@ function check_url() {
 # Checks if a command is available.
 # Plain "command -v" succeeds if the argument is in PATH, even if not executable.
 function has_command() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     [[ -x $(command -v "$1" 2> /dev/null) ]]
 }
 
 # use axel if available
 function download() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local src="$1" out="${2:-${src##*/}}"
     if [[ $PACSTALL_DOWNLOADER != "payload" ]]; then
         sudo rm -f "${out:?}"
@@ -448,7 +448,7 @@ function download() {
 #   $ select_options "My message I want to send" "${#array[@]}"
 # This will then output the options given by the user to /tmp/pacstall-select-options, which you can then turn into another array
 function select_options() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     rm -f /tmp/pacstall-select-options
     local message="${1}"
     local length="${2}"
@@ -510,7 +510,7 @@ function select_options() {
 
 # Return 0 if exists, 1 if not
 function is_package_installed() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local input="${1}"
     while read -r line; do
         if [[ ${line} == "${input}" ]]; then
@@ -522,7 +522,7 @@ function is_package_installed() {
 
 # Returns 0 if exists, 1 if not
 function is_apt_package_installed() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     if [[ $(dpkg-query -W --showformat='${db:Status-Status}' "${1}" 2> /dev/null) == "installed" ]]; then
         return 0
     else
@@ -531,7 +531,7 @@ function is_apt_package_installed() {
 }
 
 function is_array() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     if [[ ${!1@a} == *a* ]]; then
         return 0
     else
@@ -540,7 +540,7 @@ function is_array() {
 }
 
 function is_function() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     if [[ $(type -t "${1}") == "function" ]]; then
         return 0
     else
@@ -549,7 +549,7 @@ function is_function() {
 }
 
 function array.contains() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local check
     local -n arra="${1:?No array passed to array.contains}"
     local input="${2:?No input given to array.contains}"
@@ -562,7 +562,7 @@ function array.contains() {
 }
 
 function getMasks() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local pkgs pkg
     local -n masks="${1}"
     mapfile -t pkgs < <(pacstall -L 2> /dev/null)
@@ -579,7 +579,7 @@ function getMasks() {
 }
 
 function getMasks_offending_pkg() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local the_name="${1}"
     mapfile -t pkgs < <(pacstall -L)
     if ((${#pkgs[@]} == 0)); then
@@ -674,7 +674,7 @@ fi
 unset short_commands long_commands commands matches arguments_list unique_arguments_list hashed_arguments
 
 function lock() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # Total number of options flags, increase when needed
     local option_flags=5
     local ignore_short="-S -D -A -Rr -V -L -Qi -T -h"

--- a/pacstall
+++ b/pacstall
@@ -363,7 +363,7 @@ function check_url() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     if [[ ${1} == "file://"* ]]; then
         if ! [[ -f ${1/"file://"/} ]]; then
-            { ignore_stack=true && return 1; }
+            { ignore_stack=true; return 1; }
         fi
     else
         local http_code="$(curl --location -o /dev/null -s --head --write-out '%{http_code}\n' -- "${1}")"
@@ -376,12 +376,12 @@ function check_url() {
                     fancy_message error "Failed to download file, check your connection"
                 fi
                 error_log 1 "get ${PACKAGE} pacscript"
-                { ignore_stack=true && return 1; }
+                { ignore_stack=true; return 1; }
                 ;;
             404)
                 fancy_message error "The URL cannot be found"
                 suggested_solution "Confirm that '${UGreen}$1${NC}' exists"
-                { ignore_stack=true && return 1; }
+                { ignore_stack=true; return 1; }
                 ;;
             200 | 301 | 302)
                 return 0
@@ -389,7 +389,7 @@ function check_url() {
             *)
                 fancy_message error "Failed with http code ${http_code}"
                 suggested_solution "Confirm that '${UGreen}$1${NC}' is accessible"
-                { ignore_stack=true && return 1; }
+                { ignore_stack=true; return 1; }
                 ;;
         esac
     fi
@@ -422,23 +422,23 @@ function download() {
 
     case "$PACSTALL_DOWNLOADER" in
         verbose-axel)
-            axel -ao "$out" "$src" || { ignore_stack=true && return 1; }
+            axel -ao "$out" "$src" || { ignore_stack=true; return 1; }
             ;;
         axel)
-            axel -a -q -o "$out" "$src" || { ignore_stack=true && return 1; }
+            axel -a -q -o "$out" "$src" || { ignore_stack=true; return 1; }
             ;;
         verbose-curl)
-            curl -L -# -o "$out" "$src" || { ignore_stack=true && return 1; }
+            curl -L -# -o "$out" "$src" || { ignore_stack=true; return 1; }
             ;;
         curl)
-            curl -sSL -o "$out" "$src" || { ignore_stack=true && return 1; }
+            curl -sSL -o "$out" "$src" || { ignore_stack=true; return 1; }
             ;;
         verbose-wget)
-            wget -q --show-progress --progress=bar:force -O "$out" -- "$src" 2>&1 || { ignore_stack=true && return 1; }
+            wget -q --show-progress --progress=bar:force -O "$out" -- "$src" 2>&1 || { ignore_stack=true; return 1; }
             ;;
         payload) ;;
         wget | *)
-            wget -q -O "$out" -- "$src" 2>&1 || { ignore_stack=true && return 1; }
+            wget -q -O "$out" -- "$src" 2>&1 || { ignore_stack=true; return 1; }
             ;;
     esac
 }
@@ -516,7 +516,7 @@ function is_package_installed() {
             return 0
         fi
     done < <(pacstall -L)
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 }
 
 # Returns 0 if exists, 1 if not
@@ -525,7 +525,7 @@ function is_apt_package_installed() {
     if [[ $(dpkg-query -W --showformat='${db:Status-Status}' "${1}" 2> /dev/null) == "installed" ]]; then
         return 0
     else
-        { ignore_stack=true && return 1; }
+        { ignore_stack=true; return 1; }
     fi
 }
 
@@ -534,7 +534,7 @@ function is_array() {
     if [[ ${!1@a} == *a* ]]; then
         return 0
     else
-        { ignore_stack=true && return 1; }
+        { ignore_stack=true; return 1; }
     fi
 }
 
@@ -543,7 +543,7 @@ function is_function() {
     if [[ $(type -t "${1}") == "function" ]]; then
         return 0
     else
-        { ignore_stack=true && return 1; }
+        { ignore_stack=true; return 1; }
     fi
 }
 
@@ -557,7 +557,7 @@ function array.contains() {
             return 0
         fi
     done
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 }
 
 function getMasks() {
@@ -594,7 +594,7 @@ function getMasks_offending_pkg() {
         fi
         unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask 2> /dev/null
     done
-    { ignore_stack=true && return 1; }
+    { ignore_stack=true; return 1; }
 }
 
 # run sudo apt update if it's been more than a week
@@ -682,23 +682,23 @@ function lock() {
 
     for ((i = 1; i <= option_flags + 1; i++)); do
         if [[ $ignore =~ (^|[[:space:]])"${!i}"($|[[:space:]]) ]]; then
-            { ignore_stack=true && return 1; }
+            { ignore_stack=true; return 1; }
         fi
         j=$((i + 1))
         if [[ -f "/tmp/pacstall-pacdeps-${!j%%@*}" ]]; then
-            { ignore_stack=true && return 1; }
+            { ignore_stack=true; return 1; }
         fi
     done
 
     if [[ -f "$SCRIPTDIR/repo/pacstallrepo.pacstall-qa.bak" ]]; then
         instances=($(pidof -o %PPID -x "$0"))
         if [[ ${#instances[@]} -lt 2 ]]; then
-            { ignore_stack=true && return 1; }
+            { ignore_stack=true; return 1; }
         fi
         return 0
     fi
 
-    pidof -o %PPID -x "$0" > /dev/null && return 0 || { ignore_stack=true && return 1; }
+    pidof -o %PPID -x "$0" > /dev/null && return 0 || { ignore_stack=true; return 1; }
 }
 
 while lock $@; do

--- a/pacstall
+++ b/pacstall
@@ -44,7 +44,6 @@ export PACSTALL_INSTALL=1
 
 # declare verbose debug output
 declare -gx PS4=$'\E[0;10m\E[1m\033[1;31m\033[1;37m[\033[1;35m${BASH_SOURCE[0]##*/}:\033[1;34m${FUNCNAME[0]:-NOFUNC}():\033[1;33m${LINENO}\033[1;37m] - \033[1;33mDEBUG: \E[0;10m'
-set -o pipefail
 
 function def_colors() {
     # Colors
@@ -264,8 +263,7 @@ function stacktrace() {
         ignore_stack=false
     fi
 }
-ignore_stack=false
-trap stacktrace ERR
+{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 # This is the ask function. You can source this code block and then run something like:
 # ask "Do you like the color blue? " Y
@@ -278,7 +276,7 @@ trap stacktrace ERR
 # Y=1 and N=0
 # You can specify {Y,N} or leave it out to prevent entering the default but this is not allowed in pacstall because of the -P flag which gives unattended install
 function ask() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local prompt default reply
 
     if [[ ${2-} == 'Y' ]]; then
@@ -346,7 +344,7 @@ function ask() {
 #   UPurple: text
 # Make sure to quote ('') commands and files/URLS
 function suggested_solution() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     if [[ -z $PACSTALL_SUPPRESS_SOLUTIONS ]]; then
         local inputs=("${@}")
         if ((${#inputs[@]} > 1)); then
@@ -362,7 +360,7 @@ function suggested_solution() {
 }
 
 function check_url() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     if [[ ${1} == "file://"* ]]; then
         if ! [[ -f ${1/"file://"/} ]]; then
             { ignore_stack=true && return 1; }
@@ -400,13 +398,13 @@ function check_url() {
 # Checks if a command is available.
 # Plain "command -v" succeeds if the argument is in PATH, even if not executable.
 function has_command() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     [[ -x $(command -v "$1" 2> /dev/null) ]]
 }
 
 # use axel if available
 function download() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local src="$1" out="${2:-${src##*/}}"
     if [[ $PACSTALL_DOWNLOADER != "payload" ]]; then
         sudo rm -f "${out:?}"
@@ -449,7 +447,7 @@ function download() {
 #   $ select_options "My message I want to send" "${#array[@]}"
 # This will then output the options given by the user to /tmp/pacstall-select-options, which you can then turn into another array
 function select_options() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     rm -f /tmp/pacstall-select-options
     local message="${1}"
     local length="${2}"
@@ -511,7 +509,7 @@ function select_options() {
 
 # Return 0 if exists, 1 if not
 function is_package_installed() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local input="${1}"
     while read -r line; do
         if [[ ${line} == "${input}" ]]; then
@@ -523,7 +521,7 @@ function is_package_installed() {
 
 # Returns 0 if exists, 1 if not
 function is_apt_package_installed() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     if [[ $(dpkg-query -W --showformat='${db:Status-Status}' "${1}" 2> /dev/null) == "installed" ]]; then
         return 0
     else
@@ -532,12 +530,12 @@ function is_apt_package_installed() {
 }
 
 function is_array() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     [[ ${!1@a} == *a* ]]
 }
 
 function is_function() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     if [[ $(type -t "${1}") == "function" ]]; then
         return 0
     else
@@ -546,7 +544,7 @@ function is_function() {
 }
 
 function array.contains() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local check
     local -n arra="${1:?No array passed to array.contains}"
     local input="${2:?No input given to array.contains}"
@@ -559,7 +557,7 @@ function array.contains() {
 }
 
 function getMasks() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local pkgs pkg
     local -n masks="${1}"
     mapfile -t pkgs < <(pacstall -L 2> /dev/null)
@@ -576,7 +574,7 @@ function getMasks() {
 }
 
 function getMasks_offending_pkg() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     local the_name="${1}"
     mapfile -t pkgs < <(pacstall -L)
     if ((${#pkgs[@]} == 0)); then
@@ -671,7 +669,7 @@ fi
 unset short_commands long_commands commands matches arguments_list unique_arguments_list hashed_arguments
 
 function lock() {
-    trap stacktrace ERR
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
     # Total number of options flags, increase when needed
     local option_flags=5
     local ignore_short="-S -D -A -Rr -V -L -Qi -T -h"

--- a/pacstall
+++ b/pacstall
@@ -530,9 +530,12 @@ function is_apt_package_installed() {
 }
 
 function is_array() {
-    { set -o pipefail; trap stacktrace ERR; }
-    ignore_stack=true
-    [[ ${!1@a} == *a* ]] && return $?
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+    if [[ ${!1@a} == *a* ]]; then
+        return 0
+    else
+        { ignore_stack=true && return 1; }
+    fi
 }
 
 function is_function() {

--- a/pacstall
+++ b/pacstall
@@ -399,7 +399,11 @@ function check_url() {
 # Plain "command -v" succeeds if the argument is in PATH, even if not executable.
 function has_command() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    [[ -x $(command -v "$1" 2> /dev/null) ]]
+    if [[ -x $(command -v "$1" 2> /dev/null) ]]; then
+        return 0
+    else
+        { ignore_stack=true; return 1; }
+    fi
 }
 
 # use axel if available

--- a/pacstall
+++ b/pacstall
@@ -262,6 +262,7 @@ function stacktrace() {
         exit 1
     else
         export ignore_stack=false
+        return "${catch}"
     fi
 }
 { export ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }

--- a/pacstall
+++ b/pacstall
@@ -260,10 +260,10 @@ function stacktrace() {
         cleanup
         exit 1
     else
-        ignore_stack=false
+        export ignore_stack=false
     fi
 }
-{ ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
+{ export ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
 
 # This is the ask function. You can source this code block and then run something like:
 # ask "Do you like the color blue? " Y
@@ -530,8 +530,9 @@ function is_apt_package_installed() {
 }
 
 function is_array() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR; }
-    [[ ${!1@a} == *a* ]]
+    { set -o pipefail; trap stacktrace ERR; }
+    ignore_stack=true
+    [[ ${!1@a} == *a* ]] && return $?
 }
 
 function is_function() {


### PR DESCRIPTION
## Purpose

set -x is so hard to read sometimes

## Approach

trap everything, trace it back
- All files and functions must have `{ ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }` at the top
- Any time `return 1` is provided by an internal function, it should be immediately preceded by `ignore_stack=true`, so that intentional error outs are not caught by the trace
- `stacktrace` will pipe back out the return codes it receives that are not `1`

in fixing this PR, three other changes/fixes happened:
1. if `depends` attributes have no aptitude match (like optdepends), then the script will fail out
    - this also fixed optdepends from checking with apt-cache to checking with aptitude for arch enabled depends
    - this also fixed all of the aptitude checks to properly check for architecture
2. `-git` packages now have a proper version check
    - the git commit is split from the rest of the `pkgver`, and considered separately
    - first, if the git commits of the local and remote version do not match, then an update is triggered regardless of the rest of the version
    - if the git commits are the same, then the normal version is considered (`${pkgver}-pacstall${pkgrel}`)
3. relative files will check if they exist locally relative to the pacscript first, before defaulting to downloading like normal

## Progress

- [x] do it
- [x] test it
- [x] make it stack everything
- [x] make sure things all work normally and don't falsely stacktrace

<img width="678" alt="Screenshot 2024-06-27 at 6 21 39 PM" src="https://github.com/pacstall/pacstall/assets/104327997/3dbc1549-a74e-41a2-ba38-7627c51b9957">

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
