### PR TITLE
fix(build.sh): always log at least one `provides`

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -472,7 +472,9 @@ function makedeb() {
         fi
     fi
 
-    provides+=("${gives:-${pacname}}")
+    if ! array.contains provides "${gives:-${pacname}}"; then
+        provides+=("${gives:-${pacname}}")
+    fi
     # shellcheck disable=SC2001
     deblog "Provides" "$(sed 's/ /, /g' <<< "${provides[@]}")"
 

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -472,10 +472,9 @@ function makedeb() {
         fi
     fi
 
-    if [[ -n ${provides[*]} ]]; then
-        # shellcheck disable=SC2001
-        deblog "Provides" "$(sed 's/ /, /g' <<< "${provides[@]}")"
-    fi
+    provides+=("${gives:-${pacname}}")
+    # shellcheck disable=SC2001
+    deblog "Provides" "$(sed 's/ /, /g' <<< "${provides[@]}")"
 
     if [[ -n ${conflicts[*]} ]]; then
         # shellcheck disable=SC2001


### PR DESCRIPTION
## Purpose

fixes virtualness for pacstall built packages that exist in apt repos

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
