### PR TITLE
feat: add `bugs` variable

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -380,6 +380,36 @@ function is_builddep_arch() {
     fi
 }
 
+# This function is used to undo a raw repo URL into its base components.
+# It is sort of flawed because for self-hosted instances, it might not catch the name that it needs
+# in order to parse, and if that eventually comes up, we'll deal with it then.
+function parse_repo_unraw() {
+    local rep="${1}"
+    case "${rep}" in
+        *"githubusercontent"*)
+            pURL="${rep/'raw.githubusercontent.com'/'github.com'}"
+            pURL="${pURL%/*}"
+            export pURL pBRANCH="${rep##*/}" pISSUES="${pURL}/issues" branch="yes"
+
+            ;;
+        *"gitlab"*)
+            pURL="${rep%/-/raw/*}"
+            export pURL pBRANCH="${rep##*/-/raw/}" pISSUES="${pURL}/-/issues" branch="yes"
+            ;;
+        *"git.sr.ht"*)
+            pURL="${rep%/blob*}"
+            export pURL pBRANCH="${rep##*/}" pISSUES="https://lists.sr.ht/~${pURL#*~}" branch="yes"
+            ;;
+        *"codeberg"*)
+            pURL="${rep%raw/branch/*}"
+            export pURL pBRANCH="${rep##*/}" pISSUES="${pURL}/issues" branch="yes"
+            ;;
+        *)
+            export pURL="$rep" branch="no"
+            ;;
+    esac
+}
+
 function makedeb() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # It looks weird for it to say: `Packaging foo as foo`

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -418,6 +418,15 @@ function makedeb() {
         deblog "Priority" "${priority:-optional}"
     fi
 
+    if [[ -n ${bugs} ]]; then
+        deblog "Bugs" "${bugs}"
+    else
+        parse_repo_unraw "$REPO"
+        if [[ -n ${pISSUES} ]]; then
+            deblog "Bugs" "${pISSUES}"
+        fi
+    fi
+
     if [[ $pacname == *-git ]]; then
         parse_source_entry "${source[0]}"
         # shellcheck disable=SC2031
@@ -871,24 +880,7 @@ function meta_log() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # Origin repo info parsing
     if [[ ${local} == "no" ]]; then
-        # shellcheck disable=SC2153
-        case $REPO in
-            *"github"*)
-                pURL="${REPO/'raw.githubusercontent.com'/'github.com'}"
-                pURL="${pURL%/*}"
-                pBRANCH="${REPO##*/}"
-                branch="yes"
-                ;;
-            *"gitlab"*)
-                pURL="${REPO%/-/raw/*}"
-                pBRANCH="${REPO##*/-/raw/}"
-                branch="yes"
-                ;;
-            *)
-                pURL="$REPO"
-                branch="no"
-                ;;
-        esac
+        parse_repo_unraw "$REPO"
     fi
 
     # Metadata writing

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -384,13 +384,13 @@ function is_builddep_arch() {
 # It is sort of flawed because for self-hosted instances, it might not catch the name that it needs
 # in order to parse, and if that eventually comes up, we'll deal with it then.
 function parse_repo_unraw() {
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local rep="${1}"
     case "${rep}" in
         *"githubusercontent"*)
             pURL="${rep/'raw.githubusercontent.com'/'github.com'}"
             pURL="${pURL%/*}"
             export pURL pBRANCH="${rep##*/}" pISSUES="${pURL}/issues" branch="yes"
-
             ;;
         *"gitlab"*)
             pURL="${rep%/-/raw/*}"

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -659,6 +659,18 @@ function lint_mask() {
     { ignore_stack=true; return "${ret}"; }
 }
 
+function lint_bugs() {
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
+    local ret=0
+    if [[ -n ${bugs} ]]; then
+		if [[ ${bugs} != *"://"* ]]; then
+			fancy_message error "'bugs' is improperly formatted"
+			ret=1
+		fi
+    fi
+    { ignore_stack=true; return "${ret}"; }
+}
+
 function lint_priority() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     shopt -s extglob
@@ -700,7 +712,7 @@ function lint_license() {
 
 function checks() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local ret=0 check linting_checks=(lint_pacname lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_deps lint_ppa lint_relations lint_fields lint_hash lint_incompatible lint_arch lint_mask lint_priority lint_license)
+    local ret=0 check linting_checks=(lint_pacname lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_deps lint_ppa lint_relations lint_fields lint_hash lint_incompatible lint_arch lint_mask lint_priority lint_license lint_bugs)
     for check in "${linting_checks[@]}"; do
         "${check}" || ret=1
     done

--- a/pacstall
+++ b/pacstall
@@ -195,7 +195,7 @@ function parse_repo_unraw() {
             ;;
         *"git.sr.ht"*)
             pURL="${rep%/blob*}"
-            local project="${pURL#*~}" 
+            local project="${pURL#*~}"
             export pURL pBRANCH="${rep##*/}" pISSUES="https://lists.sr.ht/~${project}" branch="yes"
             ;;
         *"codeberg"*)

--- a/pacstall
+++ b/pacstall
@@ -184,17 +184,14 @@ function parse_repo_unraw() {
     local rep="${1}"
     case "${rep}" in
         *"githubusercontent"*)
-            export pURL="${rep/'raw.githubusercontent.com'/'github.com'}"
-            export pURL="${pURL%/*}"
-            export pBRANCH="${rep##*/}"
-            export pISSUES="${pURL}/issues"
-            export branch="yes"
+            pURL="${rep/'raw.githubusercontent.com'/'github.com'}"
+            pURL="${pURL%/*}"
+            export pURL pBRANCH="${rep##*/}" pISSUES="${pURL}/issues" branch="yes"
+             
             ;;
         *"gitlab"*)
-            export pURL="${rep%/-/raw/*}"
-            export pBRANCH="${rep##*/-/raw/}"
-            export pISSUES="${pURL}/-/issues"
-            export branch="yes"
+            pURL="${rep%/-/raw/*}"
+            export pURL pBRANCH="${rep##*/-/raw/}" pISSUES="${pURL}/-/issues" branch="yes"
             ;;
         *"git.sr.ht"*)
             export pURL="${rep%/*}"
@@ -206,14 +203,11 @@ function parse_repo_unraw() {
             export branch="yes"
             ;;
         *"codeberg"*)
-            export pURL="${rep%raw/branch/*}"
-            export pBRANCH="${rep##*/}"
-            export pISSUES="${pURL}/issues"
-            export branch="yes"
+            pURL="${rep%raw/branch/*}"
+            export pURL pBRANCH="${rep##*/}" pISSUES="${pURL}/issues" branch="yes"
             ;;
         *)
-            export pURL="$rep"
-            export branch="no"
+            export pURL="$rep" branch="no"
             ;;
     esac
 }

--- a/pacstall
+++ b/pacstall
@@ -178,10 +178,11 @@ function fancy_message() {
 }
 
 # This function is used to undo a raw repo URL into its base components.
+# It is sort of flawed because for self-hosted instances, it might not catch the name that it needs
+# in order to parse, and if that eventually comes up, we'll deal with it then.
 function parse_repo_unraw() {
     local rep="${1}"
-    # shellcheck disable=SC2153
-    case $rep in
+    case "${rep}" in
         *"githubusercontent"*)
             export pURL="${rep/'raw.githubusercontent.com'/'github.com'}"
             export pURL="${pURL%/*}"
@@ -202,6 +203,12 @@ function parse_repo_unraw() {
             local project_name="${pURL##*/}"
             local project_owner="${pURL%/*}"
             export pISSUES="https://lists.sr.ht/${project_owner##*/}/${project_name}"
+            export branch="yes"
+            ;;
+        *"codeberg"*)
+            export pURL="${rep%raw/branch/*}"
+            export pBRANCH="${rep##*/}"
+            export pISSUES="${pURL}/issues"
             export branch="yes"
             ;;
         *)

--- a/pacstall
+++ b/pacstall
@@ -187,7 +187,7 @@ function parse_repo_unraw() {
             pURL="${rep/'raw.githubusercontent.com'/'github.com'}"
             pURL="${pURL%/*}"
             export pURL pBRANCH="${rep##*/}" pISSUES="${pURL}/issues" branch="yes"
-             
+
             ;;
         *"gitlab"*)
             pURL="${rep%/-/raw/*}"

--- a/pacstall
+++ b/pacstall
@@ -177,36 +177,6 @@ function fancy_message() {
     esac
 }
 
-# This function is used to undo a raw repo URL into its base components.
-# It is sort of flawed because for self-hosted instances, it might not catch the name that it needs
-# in order to parse, and if that eventually comes up, we'll deal with it then.
-function parse_repo_unraw() {
-    local rep="${1}"
-    case "${rep}" in
-        *"githubusercontent"*)
-            pURL="${rep/'raw.githubusercontent.com'/'github.com'}"
-            pURL="${pURL%/*}"
-            export pURL pBRANCH="${rep##*/}" pISSUES="${pURL}/issues" branch="yes"
-
-            ;;
-        *"gitlab"*)
-            pURL="${rep%/-/raw/*}"
-            export pURL pBRANCH="${rep##*/-/raw/}" pISSUES="${pURL}/-/issues" branch="yes"
-            ;;
-        *"git.sr.ht"*)
-            pURL="${rep%/blob*}"
-            export pURL pBRANCH="${rep##*/}" pISSUES="https://lists.sr.ht/~${pURL#*~}" branch="yes"
-            ;;
-        *"codeberg"*)
-            pURL="${rep%raw/branch/*}"
-            export pURL pBRANCH="${rep##*/}" pISSUES="${pURL}/issues" branch="yes"
-            ;;
-        *)
-            export pURL="$rep" branch="no"
-            ;;
-    esac
-}
-
 function decl_scriptvars() {
     local _distros _vars _archs _sums distros \
         vars="source depends makedepends optdepends pacdeps checkdepends provides conflicts breaks replaces enhances recommends makeconflicts checkconflicts" \

--- a/pacstall
+++ b/pacstall
@@ -195,8 +195,7 @@ function parse_repo_unraw() {
             ;;
         *"git.sr.ht"*)
             pURL="${rep%/blob*}"
-            local project="${pURL#*~}"
-            export pURL pBRANCH="${rep##*/}" pISSUES="https://lists.sr.ht/~${project}" branch="yes"
+            export pURL pBRANCH="${rep##*/}" pISSUES="https://lists.sr.ht/~${pURL#*~}" branch="yes"
             ;;
         *"codeberg"*)
             pURL="${rep%raw/branch/*}"

--- a/pacstall
+++ b/pacstall
@@ -194,13 +194,9 @@ function parse_repo_unraw() {
             export pURL pBRANCH="${rep##*/-/raw/}" pISSUES="${pURL}/-/issues" branch="yes"
             ;;
         *"git.sr.ht"*)
-            export pURL="${rep%/*}"
-            export pURL="${pURL%/*}"
-            export pBRANCH="${rep##*/}"
-            local project_name="${pURL##*/}"
-            local project_owner="${pURL%/*}"
-            export pISSUES="https://lists.sr.ht/${project_owner##*/}/${project_name}"
-            export branch="yes"
+            pURL="${rep%/blob*}"
+            local project="${pURL#*~}" 
+            export pURL pBRANCH="${rep##*/}" pISSUES="https://lists.sr.ht/~${project}" branch="yes"
             ;;
         *"codeberg"*)
             pURL="${rep%raw/branch/*}"

--- a/pacstall
+++ b/pacstall
@@ -177,6 +177,40 @@ function fancy_message() {
     esac
 }
 
+# This function is used to undo a raw repo URL into its base components.
+function parse_repo_unraw() {
+    local rep="${1}"
+    # shellcheck disable=SC2153
+    case $rep in
+        *"githubusercontent"*)
+            export pURL="${rep/'raw.githubusercontent.com'/'github.com'}"
+            export pURL="${pURL%/*}"
+            export pBRANCH="${rep##*/}"
+            export pISSUES="${pURL}/issues"
+            export branch="yes"
+            ;;
+        *"gitlab"*)
+            export pURL="${rep%/-/raw/*}"
+            export pBRANCH="${rep##*/-/raw/}"
+            export pISSUES="${pURL}/-/issues"
+            export branch="yes"
+            ;;
+        *"git.sr.ht"*)
+            export pURL="${rep%/*}"
+            export pURL="${pURL%/*}"
+            export pBRANCH="${rep##*/}"
+            local project_name="${pURL##*/}"
+            local project_owner="${pURL%/*}"
+            export pISSUES="https://lists.sr.ht/${project_owner##*/}/${project_name}"
+            export branch="yes"
+            ;;
+        *)
+            export pURL="$rep"
+            export branch="no"
+            ;;
+    esac
+}
+
 function decl_scriptvars() {
     local _distros _vars _archs _sums distros \
         vars="source depends makedepends optdepends pacdeps checkdepends provides conflicts breaks replaces enhances recommends makeconflicts checkconflicts" \
@@ -185,7 +219,7 @@ function decl_scriptvars() {
     pacstallvars=(pkgbase pkgname repology pkgver git_pkgver epoch source_url source depends makedepends checkdepends conflicts
         breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps NOBUILDDEP provides incompatible
         compatible srcdir url backup pkgrel mask pac_functions repo priority noextract nosubmodules _archive license
-        bwrapenv safeenv external_connection enhances recommends custom_fields makeconflicts checkconflicts)
+        bwrapenv safeenv external_connection enhances recommends custom_fields makeconflicts checkconflicts bugs)
     mapfile -t distros < <(awk -F ',' -v current_date="$(date +'%Y-%m-%d')" '
       BEGIN {
         is_first = 1


### PR DESCRIPTION
## Purpose

Adding another useful key that a control file can have.

## Approach

If a script has the `bugs` variable defined, it will log that. If it does not, pacstall will figure out the URL to the repo's bug tracker based off of the repo where the script was downloaded from and log that instead. There is one case where `Bugs` will not be logged, and that is only if it is from a repo system that pacstall does not know about (listed in [Addendum](#Addendum)).

This variable will/should rarely be used manually, and 99% of the time should be left as-is, but for those who want more control over the processed deb, it is available now.

## Progress

<!--Make a checklist of your progress-->

- [x] Example

## Addendum

I have also pulled the system already in place that determines repo URLs and moved that into `/bin/pacstall`. Currently the available repository systems are supported for parsing:

1. GitHub
2. GitLab
3. Sourcehut (git)
4. Codeberg

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.