### PR TITLE
fix(*): cleanup again

### DIFF
--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -361,8 +361,6 @@ function deb_down() {
         sudo chmod o+r "/var/cache/pacstall/${pacname}/${full_version}/${PACKAGE}.pacscript"
         sudo cp -r "${srcinfile}" "/var/cache/pacstall/${pacname}/${full_version}/.SRCINFO"
         sudo chmod o+r "/var/cache/pacstall/${pacname}/${full_version}/.SRCINFO"
-        fancy_message sub "Cleaning up"
-        cleanup
         fancy_message info "Done installing ${BPurple}${pacname}${NC}"
         unset expectedHash dest source_url git_branch git_tag git_commit ext_deps ext_method hashsum_method payload_arr
         return 0

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -129,10 +129,10 @@ if [[ -n $ppa ]]; then
 fi
 
 if [[ -n ${pacdeps[*]} ]]; then
+    fancy_message info "Pacstall dependencies"
     for pdep in "${pacdeps[@]}"; do
         # If "${PACDIR}-pacdeps-$i" is available, it will trigger the logger to log it as a dependency
         touch "${PACDIR}-pacdeps-$pdep"
-        fancy_message info "Pacstall dependencies"
         cmd="-I"
         [[ $KEEP ]] && cmd+="K"
         [[ $DISABLE_PROMPTS == "yes" ]] && cmd+="P"

--- a/pacstall
+++ b/pacstall
@@ -229,7 +229,7 @@ function cleanup() {
             fi
             sudo rm -rf "${STAGEDIR:-/usr/src/pacstall}/${pacname}"
             for i in "deps" "gives" "missing-deps" "not-satisfied-deps" "suggested-optdeps" "missing-optdeps" "not-satisfied-optdeps" "already-installed-optdeps" "selectopts-optdeps"; do
-                if [[ -n ${PACDIR} && -f "${PACDIR}-${i}-${pacname}" ]]; then
+                if [[ -f "${PACDIR}-${i}-${pacname}" ]]; then
                     sudo rm -rf "${PACDIR}-${i}-${pacname}"
                 fi
             done


### PR DESCRIPTION
## Purpose

whoopsie

## Approach

- don't accidentally over clean up on `-deb` installs (it runs after install complete)
- don't throw pacdeps info message more than once
- redundant check

## Progress

- [x] do it
- [x] test it

## Addendum

https://github.com/pacstall/pacstall-programs/pull/6199

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
