### PR TITLE
fix(package-base.sh): accept child calls for local pacscripts

### DIFF
--- a/misc/scripts/package-base.sh
+++ b/misc/scripts/package-base.sh
@@ -91,7 +91,7 @@ function package_pkg() {
         # shellcheck disable=SC2031
         fancy_message info "Found pkgbase: ${PURPLE}${pkgbase}${NC}"
         if ((${#pkgname[@]} > 1)); then
-            if [[ -z ${CHILD} ]]; then
+            if [[ -z ${CHILD} || ${CHILD} == "pkgbase" ]]; then
                 # We do this so that arrays 'start at' 1 to the user
                 z=1
                 echo -e "\t\t[${BIRed}0${NC}] Exit"
@@ -121,8 +121,14 @@ function package_pkg() {
             # Did we get actual answers?
             if [[ ${choices[0]} != "n" && ${choices[0]} != "0" ]] || [[ -n ${CHILD} ]]; then
                 local pacnames
-                if [[ -n ${CHILD} ]]; then
-                    pacnames=("${CHILD}")
+                if [[ -n ${CHILD} && ${CHILD} != "pkgbase" ]]; then
+                    if array.contains pkgname "${CHILD}"; then
+                        pacnames=("${CHILD}")
+                    else
+                        fancy_message error "${PKGPATH:+${PKGPATH}/}${PACKAGE}${PKGPATH:+.pacscript}:${CHILD} does not exist"
+                        cleanup
+                        exit 1
+                    fi
                 else
                     for i in "${choices[@]}"; do
                         # Set our user array that started at 1 down to 0 based

--- a/pacstall
+++ b/pacstall
@@ -824,9 +824,14 @@ Helpful links:
                 else
                     unset pac_body pac_text
                 fi
-                if [[ ${2##*.} == "pacscript" ]]; then
-                    export PACKAGE="${2%.pacscript}"
-                    PACKAGE="${PACKAGE##*/}"
+                if [[ ${2##*.} == "pacscript" || ${2##*.} == "pacscript:"* ]]; then
+                    if [[ ${2##*.} =~ ^pacscript(:([a-zA-Z0-9_.-]+))$ ]]; then
+                        export CHILD="${BASH_REMATCH[2]/\:/}"
+                        PACKAGE="${2%.pacscript:${CHILD}}"
+                    else
+                        PACKAGE="${2%.pacscript}"
+                    fi
+                    export PACKAGE="${PACKAGE##*/}"
                     export type="install"
                     export local="yes"
                     PKGPATH="${2%/*}"


### PR DESCRIPTION
## Purpose

we can call them like this from parent repo as described in release, so we should be able to do it on local ones too

## Approach

`/path/to/package.pacscript:${child}`
`/path/to/package.pacscript:pkgbase`
fail out if not exist

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
