### PR TITLE
fix(srcinfo.sh): allow read for enhanced arrays

### DIFF
--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -539,9 +539,9 @@ function srcinfo.match_pkg() {
     local declares d bases b guy match out srcfile="${1}" search="${2}" pkg="${3}"
     if [[ ${pkg} == "pkgbase:"* || ${search} == "pkgbase" ]]; then
         pkg="${pkg/pkgbase:/}"
-        match="srcinfo_${search}_${pkg//-/_}_pkgbase"
+        match="srcinfo_${search%%_*}_${pkg//-/_}_pkgbase"
     else
-        match="srcinfo_${search}_${pkg//-/_}"
+        match="srcinfo_${search%%_*}_${pkg//-/_}"
     fi
     mapfile -t declares < <(srcinfo.print_var "${srcfile}" "${search}" | awk '{sub(/^declare -a |^declare -- |^declare -x /, ""); print}')
     [[ ${search} == "pkgbase" && -z ${declares[*]} ]] \


### PR DESCRIPTION
## Purpose

elsie does cooler stuff at a lower level for mapping the enhanced arrays and it was not being passed all the way up correctly

## Approach

fix the matching

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
