### PR TITLE
fix(build.sh): cleanup dep files immediately

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -300,6 +300,9 @@ function prompt_optdepends() {
         dep_const.comma_array depends_for_logging out_str
         deblog "Depends" "${out_str}"
     fi
+    for i in "gives" "deps" "missing-deps" "not-satisfied-deps" "suggested-optdeps" "missing-optdeps" "not-satisfied-optdeps" "already-installed-optdeps"; do
+        sudo rm -rf "${PACDIR}-${i}-${pacname}"
+    done
 }
 
 function generate_changelog() {


### PR DESCRIPTION
## Purpose

if building split packages, pacstall waits to run cleanup until the end of the script, but some cleanups are based on `pacname`

## Approach

clean them up inside of the function they're being used in at the end (doesn't work inside of earlier loops because of `wait` shenanigans)

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
