### PR TITLE
fix(build.sh): mark `prerm` file executable

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -647,7 +647,7 @@ function makedeb() {
     unset pre_inst_upg post_inst_upg
     echo -e "sudo rm -f ${METADIR:?}/$pacname\nsudo rm -f /etc/apt/preferences.d/${pacname//./-}-pin" | sudo tee -a "$STAGEDIR/$pacname/DEBIAN/postrm" > /dev/null
     local postfile
-    for postfile in {postrm,postinst,preinst}; do
+    for postfile in {postrm,postinst,preinst,prerm}; do
         if [[ -f "$STAGEDIR/$pacname/DEBIAN/${postfile}" ]]; then
             sudo chmod -x "$STAGEDIR/$pacname/DEBIAN/${postfile}" &> /dev/null
             sudo chmod 755 "$STAGEDIR/$pacname/DEBIAN/${postfile}" &> /dev/null


### PR DESCRIPTION
## Purpose

the file was not marked like the others (it still runs tho)

## Approach

add it to the list

## Progress

- [x] do it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
