### PR TITLE
feat(search.sh): keyword and info search

### DIFF
--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -164,7 +164,8 @@ function srclist.search() {
 # Usage: eval "$(srclist.parse SRCLIST PACKAGELIST desc_array <pkgname | pkgbase:pkgname | keyword | "spaced keyword" | "'Case Sensitive Keyword'">)"
 function srclist.parse() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local SRCFILE="${1}" DESCARR="${3}" KWD="${4}" SEARCH CHILD searchlist pkglist foundname founddesc exact=false
+    local SRCFILE="${1}" DESCARR="${3}" KWD="${4}" SEARCH CHILD searchlist foundname founddesc exact=false
+    # shellcheck disable=SC2034
     local -n PKGFILE="${2}" LOCARR="${DESCARR}"
     declare -A LOCARR=()
     SEARCH="${KWD%% *}"
@@ -258,6 +259,7 @@ if [[ $SEARCH == *@* ]] || [[ $PACKAGE == *@* ]]; then
         if [[ $URLNAME == "$REPONAME" ]]; then
             mapfile -t PACKAGELIST < <(curl -s -- "$URL"/packagelist)
             if [[ ${DESCON} ]]; then
+                # shellcheck disable=SC2034
                 mapfile -t SRCLIST < <(curl -s -- "$URL"/srclist)
             fi
             any_masks=()
@@ -276,7 +278,7 @@ if [[ $SEARCH == *@* ]] || [[ $PACKAGE == *@* ]]; then
             if [[ -n $SEARCH ]]; then
                 if [[ ${DESCON} ]]; then
                     eval "$(srclist.parse SRCLIST PACKAGELIST SEARCHDESC "${SEARCH}")"
-                    IDXSEARCH="${!SEARCHDESC[@]}"
+                    IDXSEARCH="${!SEARCHDESC[*]}"
                 else
                     IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /${SEARCH}/ {print NR-1}")
                 fi
@@ -338,6 +340,7 @@ if [[ -n ${SEARCH} ]]; then
     while IFS= read -r URL; do
         mapfile -t PACKAGELIST < <(curl -s -- "$URL"/packagelist)
         if [[ ${DESCON} ]]; then
+            # shellcheck disable=SC2034
             mapfile -t SRCLIST < <(curl -s -- "$URL"/srclist)
         fi
         any_masks=()
@@ -355,7 +358,7 @@ if [[ -n ${SEARCH} ]]; then
         fi
         if [[ ${DESCON} ]]; then
             eval "$(srclist.parse SRCLIST PACKAGELIST SEARCHDESC "${SEARCH}")"
-            IDXSEARCH="${!SEARCHDESC[@]}"
+            IDXSEARCH="${!SEARCHDESC[*]}"
         else
             IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /${SEARCH}/ {print NR-1}")
         fi

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -31,6 +31,10 @@ if [[ -n $UPGRADE ]]; then
     [[ -n ${_pkgbase} ]] && PACKAGE="${_pkgbase}:${PACKAGE}"
 fi
 
+if [[ -z ${SEARCH} ]]; then
+    unset DESCON
+fi
+
 function getPath() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local path="${1}"
@@ -97,6 +101,142 @@ function formatRepo() {
         && echo "${BASH_REMATCH[1]}"
 }
 
+# Usage: see srclist.parse
+function srclist.search() {
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
+    local -n FILE="${1}"
+    printf "%s\n" "${FILE[@]}" | awk -v kw="${2}" '
+    BEGIN {
+        FS = "[[:space:]]*=[[:space:]]*"
+        OFS = " - "
+        found = 0
+        kw = tolower(kw)
+    }
+    function print_pkgbase_and_pkgname() {
+        if (pkgbase != "") {
+            print pkgbase, pkgbase_desc
+            if (pkgname != "") {
+                desc = (pkgname_desc != "" ? pkgname_desc : pkgbase_desc)
+                print pkgbase ":" pkgname, desc
+            }
+        }
+    }
+    /^---$/ {
+        if (pkgbase != "" && (pkgbase ~ kw || tolower(pkgbase_desc) ~ kw)) {
+            print_pkgbase_and_pkgname()
+            found = 1
+        } else if (pkgname != "" && (pkgname ~ kw || tolower(pkgname_desc) ~ kw)) {
+            print_pkgbase_and_pkgname()
+            found = 1
+        }
+        pkgname = ""; pkgbase = ""; pkgbase_desc = ""; pkgname_desc = ""; next
+    }
+    /^[[:space:]]*pkgbase[[:space:]]*=/ {
+        pkgbase = $2
+        pkgbase_desc = ""
+    }
+    /^[[:space:]]*pkgname[[:space:]]*=/ {
+        if (pkgname != "") {
+            desc = (pkgname_desc != "" ? pkgname_desc : pkgbase_desc)
+            if (pkgname ~ kw || tolower(desc) ~ kw) {
+                print pkgbase ":" pkgname, desc
+                found = 1
+            }
+        }
+        pkgname = $2
+        pkgname_desc = ""
+    }
+    /^[[:space:]]*pkgdesc[[:space:]]*=/ {
+        if (pkgname == "") {
+            pkgbase_desc = $2
+        } else {
+            pkgname_desc = $2
+        }
+    }
+    END {
+        if (!found) {
+            print "No matching packages found"
+        }
+    }
+    '
+}
+
+# Usage: eval "$(srclist.parse SRCLIST PACKAGELIST desc_array <pkgname | pkgbase:pkgname | keyword | "spaced keyword" | "'Case Sensitive Keyword'">)"
+function srclist.parse() {
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
+    local SRCFILE="${1}" DESCARR="${3}" KWD="${4}" SEARCH CHILD searchlist pkglist foundname founddesc exact=false
+    local -n PKGFILE="${2}" LOCARR="${DESCARR}"
+    declare -A LOCARR=()
+    SEARCH="${KWD%% *}"
+    if [[ ${KWD} == \'*\' ]]; then
+        exact=true
+        KWD="${KWD%*\'}"
+        KWD="${KWD#\'*}"
+    elif [[ ${KWD} == \"*\" ]]; then
+        exact=true
+        KWD="${KWD%*\"}"
+        KWD="${KWD#\"*}"
+    else
+        KWD="${KWD,,}"
+    fi
+    if [[ ${SEARCH} == *':'* && ${SEARCH} == "${KWD##* }" ]]; then
+        CHILD="${SEARCH#*:}" KWD="${SEARCH%:*}"
+    fi
+    mapfile -t searchlist < <(srclist.search "${SRCFILE}" "${KWD}")
+    for i in "${searchlist[@]}"; do
+        foundname="${i%% -*}"
+        founddesc="${i#* - }"
+        if [[ -n ${CHILD} && ${CHILD} != "pkgbase" && ${foundname} != "${KWD}:${CHILD}" ]] \
+            || [[ ${CHILD} == "pkgbase" && ${foundname} =~ ':' && ${foundname} != *":${CHILD}" ]] \
+            || [[ ${exact} == true && ${i} != *"${KWD}"* ]] \
+            || [[ ${exact} == false && -n ${KWD} && ${i,,} != *"${KWD}"* ]]; then
+            continue
+        fi
+        if array.contains PKGFILE "${foundname}"; then
+            LOCARR["${foundname}"]="${founddesc}"
+        elif array.contains PKGFILE "${foundname}:pkgbase"; then
+            LOCARR["${foundname}:pkgbase"]="${founddesc}"
+        fi
+    done
+    declare -p "${DESCARR}"
+}
+
+# Usage: srclist.info SRCLIST <pkgname | pkgbase:pkgname>
+function srclist.info() {
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
+    local SEARCH="${2}" NAME FIELD
+    local -n FILE="${1}"
+    NAME="${SEARCH#*:}" PARENT="${SEARCH%:*}"
+    if [[ ${SEARCH} != *':'* || ${NAME} == "pkgbase" ]]; then
+        FIELD="pkgbase"
+    else
+        FIELD="pkgname"
+    fi
+    [[ ${NAME} == "pkgbase" ]] && NAME="${PARENT}"
+    printf "%s\n" "${FILE[@]}" | awk -v pkg="${NAME}" -v field="${FIELD}" '
+    BEGIN { print_pkg = 0 }
+    /^[[:space:]]*$/ || /^---$/ {
+        if (print_pkg && field == "pkgname") {
+            exit
+        }
+    }
+    /^---$/ {
+        print_pkg = 0
+    }
+    {
+        if ($1 == "pkgbase" && $3 != pkg && field == "pkgname") {
+            print_pkg = 0
+        }
+        if ($1 == field && $3 == pkg) {
+            print_pkg = 1
+        }
+        if (print_pkg) {
+            print
+        }
+    }
+    '
+}
+
 # Repo specific search
 if [[ $SEARCH == *@* ]] || [[ $PACKAGE == *@* ]]; then
     if [[ -n $SEARCH ]]; then
@@ -117,19 +257,43 @@ if [[ $SEARCH == *@* ]] || [[ $PACKAGE == *@* ]]; then
         specifyRepo "$URL"
         if [[ $URLNAME == "$REPONAME" ]]; then
             mapfile -t PACKAGELIST < <(curl -s -- "$URL"/packagelist)
+            if [[ ${DESCON} ]]; then
+                mapfile -t SRCLIST < <(curl -s -- "$URL"/srclist)
+            fi
+            any_masks=()
+            getMasks any_masks
+            if ((${#any_masks[@]} != 0)); then
+                mask_itr=0
+                for pkg in "${PACKAGELIST[@]}"; do
+                    if array.contains any_masks "${pkg}"; then
+                        unset "PACKAGELIST[$mask_itr]"
+                    fi
+                    { ignore_stack=true; ((mask_itr++)); }
+                done
+                PACKAGELIST=("${PACKAGELIST[@]}")
+                unset mask_itr
+            fi
             if [[ -n $SEARCH ]]; then
-                IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /${SEARCH}/ {print NR-1}")
+                if [[ ${DESCON} ]]; then
+                    eval "$(srclist.parse SRCLIST PACKAGELIST SEARCHDESC "${SEARCH}")"
+                    IDXSEARCH="${!SEARCHDESC[@]}"
+                else
+                    IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /${SEARCH}/ {print NR-1}")
+                fi
             else
                 if [[ -n ${CHILD} ]]; then
                     IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /^${PACKAGE:CHILD}$/ {print NR-1}")
                 else
                     IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /^${PACKAGE}$/ {print NR-1}")
-                    [[ -z $IDXSEARCH ]] && IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /^${PACKAGE}:pkgbase$/ {print NR-1}")
+                    if [[ -z $IDXSEARCH ]]; then
+                        IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /^${PACKAGE}:pkgbase$/ {print NR-1}")
+                    fi
                 fi
             fi
             _LEN=($IDXSEARCH)
+            mapfile -t _LEN < <(printf "%s\n" "${_LEN[@]}" | sort -V)
             LEN=${#_LEN[@]}
-            if ((LEN == 0)); then
+            if ((LEN == 0)) || [[ -z ${_LEN[*]} ]]; then
                 if [[ -n $SEARCH ]]; then
                     fancy_message warn "There is no package with the name $IRed${SEARCH%%@*}$NC in the repo $CYAN$REPONAME$NC"
                 else
@@ -139,7 +303,13 @@ if [[ $SEARCH == *@* ]] || [[ $PACKAGE == *@* ]]; then
                 exit 1
             fi
             if [[ -n $SEARCH ]]; then
-                echo -e "$GREEN${PACKAGELIST[$IDXSEARCH]} $PURPLE@ $CYAN$(parseRepo "$URL") $NC"
+                for ids in "${_LEN[@]}"; do
+                    if [[ ${DESCON} ]]; then
+                        echo -e "$GREEN${ids} ${BLUE}-${NC} ${SEARCHDESC[$ids]} $PURPLE@ $CYAN$(parseRepo "$URL") $NC"
+                    else
+                        echo -e "$GREEN${PACKAGELIST[$ids]} $PURPLE@ $CYAN$(parseRepo "$URL") $NC"
+                    fi
+                done
             else
                 export PACKAGE
                 export REPO="$URL"
@@ -151,6 +321,61 @@ if [[ $SEARCH == *@* ]] || [[ $PACKAGE == *@* ]]; then
     fancy_message warn "$IRed$REPONAME$NC is not on your repo list or does not exist"
     error_log 3 "search $PACKAGE@$REPONAME"
     exit 1
+fi
+
+if [[ -n ${SEARCH} ]]; then
+    searchout=()
+    while IFS= read -r URL; do
+        mapfile -t PACKAGELIST < <(curl -s -- "$URL"/packagelist)
+        if [[ ${DESCON} ]]; then
+            mapfile -t SRCLIST < <(curl -s -- "$URL"/srclist)
+        fi
+        any_masks=()
+        getMasks any_masks
+        if ((${#any_masks[@]} != 0)); then
+            mask_itr=0
+            for pkg in "${PACKAGELIST[@]}"; do
+                if array.contains any_masks "${pkg}"; then
+                    unset "PACKAGELIST[$mask_itr]"
+                fi
+                { ignore_stack=true; ((mask_itr++)); }
+            done
+            PACKAGELIST=("${PACKAGELIST[@]}")
+            unset mask_itr
+        fi
+        if [[ ${DESCON} ]]; then
+            eval "$(srclist.parse SRCLIST PACKAGELIST SEARCHDESC "${SEARCH}")"
+            IDXSEARCH="${!SEARCHDESC[@]}"
+        else
+            IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /${SEARCH}/ {print NR-1}")
+        fi
+        _LEN=($IDXSEARCH)
+        mapfile -t _LEN < <(printf "%s\n" "${_LEN[@]}" | sort -V)
+        LEN=${#_LEN[@]}
+        if ((LEN == 0)) || [[ -z ${_LEN[*]} ]]; then
+            continue
+        fi
+        if [[ -n $SEARCH ]]; then
+            for ids in "${_LEN[@]}"; do
+                if [[ ${DESCON} ]]; then
+                    searchout+=("$GREEN${ids} ${BLUE}-${NC} ${SEARCHDESC[$ids]} $PURPLE@ $CYAN$(parseRepo "$URL") $NC")
+                else
+                    searchout+=("$GREEN${PACKAGELIST[$ids]} $PURPLE@ $CYAN$(parseRepo "$URL") $NC")
+                fi
+            done
+        fi
+    done < "$SCRIPTDIR/repo/pacstallrepo"
+    mapfile -t searchout < <(printf "%s\n" "${searchout[@]}" | sort -V)
+    LEN=${#searchout[@]}
+    if ((LEN == 0)) || [[ -z ${searchout[*]} ]]; then
+        fancy_message warn "There is no package with the name $IRed${SEARCH%%@*}$NC"
+        exit 1
+    fi
+    for s in "${searchout[@]}"; do
+        echo -e "${s}"
+    done
+    unset searchout
+    return 0
 fi
 
 # Makes array of packages and array
@@ -184,7 +409,6 @@ done < "$SCRIPTDIR/repo/pacstallrepo"
 
 REPOMSG=1
 
-# Remove any `mask` from output
 any_masks=()
 getMasks any_masks
 if ((${#any_masks[@]} != 0)); then
@@ -202,56 +426,31 @@ fi
 # Gets index of packages that the search returns
 # Complete name if download, upgrade or install
 # Partial word if search
-if [[ -n $SEARCH ]]; then
-    IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /${SEARCH}/ {print NR-1}")
+if [[ -n ${CHILD} ]]; then
+    IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /^${PACKAGE:CHILD}$/ {print NR-1}")
 else
-    if [[ -n ${CHILD} ]]; then
-        IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /^${PACKAGE:CHILD}$/ {print NR-1}")
-    else
-        IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /^${PACKAGE}$/ {print NR-1}")
-        [[ -z $IDXSEARCH ]] && IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /^${PACKAGE}:pkgbase$/ {print NR-1}")
+    IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /^${PACKAGE}$/ {print NR-1}")
+    if [[ -z $IDXSEARCH ]]; then
+        IDXSEARCH=$(printf "%s\n" "${PACKAGELIST[@]}" | awk "\$1 ~ /^${PACKAGE}:pkgbase$/ {print NR-1}")
     fi
 fi
 _LEN=($IDXSEARCH)
+mapfile -t _LEN < <(printf "%s\n" "${_LEN[@]}" | sort -V)
 LEN=${#_LEN[@]}
 
 # Check if there are results
 if ((LEN == 0)); then
-    if [[ -z $SEARCH ]]; then
-        fancy_message error "There is no package with the name $IRed$PACKAGE$NC"
-        error_log 3 "search $PACKAGE"
-        exit 1
-    else
-        fancy_message error "There is no package with the name $IRed$SEARCH$NC"
-        exit 1
-    fi
-
-    # shellcheck disable=SC2034
-    { ignore_stack=true; return 1; }
+    fancy_message error "There is no package with the name $IRed$PACKAGE$NC"
+    error_log 3 "search $PACKAGE"
+    exit 1
 # Check if it's upgrading packages
 elif [[ -n $UPGRADE ]]; then
     REPOS=()
     # Return list of repos with the package
-    for IDX in $IDXSEARCH; do
+    for IDX in "${_LEN[@]}"; do
         ! array.contains REPOS "${URLLIST[$IDX]}" && mapfile -t -O"${#REPOS[@]}" REPOS <<< "${URLLIST[$IDX]}"
     done
     export REPOS
-    return 0
-# Check if its being used for search
-elif [[ -n $SEARCH ]]; then
-    for IDX in $IDXSEARCH; do
-        searchedrepo="$(parseRepo "${URLLIST[$IDX]}")"
-        if [[ ${URLLIST[$IDX]} == *"github"* ]]; then
-            srBRANCH="${URLLIST[$IDX]##*/}"
-        elif [[ ${URLLIST[$IDX]} == *"gitlab"* ]]; then
-            srBRANCH="${URLLIST[$IDX]##*/-/raw/}"
-        else
-            unset srBRANCH
-        fi
-        [[ -n ${srBRANCH} && ${srBRANCH} != "master" && ${srBRANCH} != "main" ]] && searchedrepo+="${YELLOW}#${srBRANCH}${NC}"
-        echo -e "$GREEN${PACKAGELIST[$IDX]} $PURPLE@ $CYAN${searchedrepo} $NC"
-        unset searchedrepo srBRANCH
-    done
     return 0
 # Options left: install or download
 # Variable $type used for the prompt
@@ -266,7 +465,7 @@ else
         echo -e "There are $LEN package(s) with the name $GREEN$PACKAGE$NC."
         echo
         # Pacstall repo first
-        for IDX in $IDXSEARCH; do
+        for IDX in "${_LEN[@]}"; do
             if [[ ${URLLIST[$IDX]} == 'https://raw.githubusercontent.com/pacstall/pacstall-programs/master' ]]; then
                 PACSTALLREPO=$IDX
                 break
@@ -283,7 +482,7 @@ else
             fi
         fi
         # If other repos, ask, if Pacstall repo, skip
-        for IDX in $IDXSEARCH; do
+        for IDX in "${_LEN[@]}"; do
             if [[ $IDX == "$PACSTALLREPO" ]]; then
                 continue
             fi

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -167,6 +167,7 @@ function srclist.parse() {
     local SRCFILE="${1}" DESCARR="${3}" KWD="${4}" SEARCH CHILD searchlist foundname founddesc exact=false
     # shellcheck disable=SC2034
     local -n PKGFILE="${2}" LOCARR="${DESCARR}"
+    # shellcheck disable=SC2034
     declare -A LOCARR=()
     SEARCH="${KWD%% *}"
     if [[ ${KWD} == \'*\' ]]; then
@@ -194,8 +195,10 @@ function srclist.parse() {
             continue
         fi
         if array.contains PKGFILE "${foundname}"; then
+            # shellcheck disable=SC2034
             LOCARR["${foundname}"]="${founddesc}"
         elif array.contains PKGFILE "${foundname}:pkgbase"; then
+            # shellcheck disable=SC2034
             LOCARR["${foundname}:pkgbase"]="${founddesc}"
         fi
     done

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -35,6 +35,10 @@ if [[ -z ${SEARCH} ]]; then
     unset DESCON
 fi
 
+if [[ -z ${INFOQUERY} ]]; then
+    unset SEARCHINFO
+fi
+
 function getPath() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local path="${1}"
@@ -476,6 +480,14 @@ elif [[ -n $UPGRADE ]]; then
         ! array.contains REPOS "${URLLIST[$IDX]}" && mapfile -t -O"${#REPOS[@]}" REPOS <<< "${URLLIST[$IDX]}"
     done
     export REPOS
+    return 0
+# check if we are looking at info
+elif [[ ${SEARCHINFO} ]]; then
+    while IFS= read -r URL; do
+        # shellcheck disable=SC2034
+        mapfile -t SRCLIST < <(curl -s -- "$URL"/srclist)
+        srclist.info SRCLIST "${INFOQUERY}"
+    done < "$SCRIPTDIR/repo/pacstallrepo"
     return 0
 # Options left: install or download
 # Variable $type used for the prompt

--- a/pacstall
+++ b/pacstall
@@ -653,7 +653,7 @@ done
 declare -A arg_map=(
     ["--install"]="-I" ["--search"]="-S" ["--remove"]="-R" ["--download"]="-D"
     ["--add-repo"]="-A" ["--remove-repo"]="-Rr" ["--update"]="-U" ["--list"]="-L" ["--upgrade"]="-Up"
-    ["--query-info"]="-Qi" ["--tree"]="-T" ["--version"]="-V" ["--help"]="-h"
+    ["--query-info"]="-Qi" ["--tree"]="-T" ["--version"]="-V" ["--info"]="-In" ["--help"]="-h"
     ["--build"]="-B" ["--keep"]="-K" ["--disable-prompts"]="-P" ["--nocheck"]="-Nc"
     ["--quality-assurance"]="-Qa" ["--quiet"]="-Q" ["--nosandbox"]="-Ns" ["--description"]="-Ds"
 )
@@ -668,8 +668,8 @@ for arg in "${argument_list[@]}"; do
 done
 
 # Check if only one command flag is being used
-short_commands=("-I" "-S" "-R" "-D" "-A" "-Rr" "-U" "-L" "-Up" "-Qi" "-Qa" "-T" "-V" "-h")
-long_commands=("--install" "--search" "--remove" "--download" "--add-repo" "--remove-repo" "--update" "--list" "--upgrade" "--query-info" "--quality-assurance" "--tree" "--version" "--help")
+short_commands=("-I" "-S" "-R" "-D" "-A" "-Rr" "-U" "-L" "-Up" "-Qi" "-Qa" "-T" "-V" "-In" "-h")
+long_commands=("--install" "--search" "--remove" "--download" "--add-repo" "--remove-repo" "--update" "--list" "--upgrade" "--query-info" "--quality-assurance" "--tree" "--version" "--info" "--help")
 commands=("${short_commands[@]}" "${long_commands[@]}")
 matches=($(comm -12 <(sort <(printf "%s\n" "${unique_argument_list[@]}")) <(sort <(printf "%s\n" "${commands[@]}"))))
 if ((${#matches[@]} <= 1)); then
@@ -686,8 +686,8 @@ function lock() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # Total number of options flags, increase when needed
     local option_flags=5
-    local ignore_short="-S -D -A -Rr -V -L -Qi -T -h"
-    local ignore_long="--search --download --add-repo --remove-repo --version --query-info --tree --help"
+    local ignore_short="-S -D -A -Rr -V -L -Qi -T -In -h"
+    local ignore_long="--search --download --add-repo --remove-repo --version --query-info --tree --info --help"
     local ignore="$ignore_short $ignore_long"
 
     for ((i = 1; i <= option_flags + 1; i++)); do
@@ -741,7 +741,7 @@ while [[ $1 != "--" ]]; do
             ;;
 
         -h | --help)
-            echo -e "Usage: pacstall [-h] {-I,-S,-R,-D,-A,-Rr,-U,-L,-Up,-Qa,-Qi,-T,-V} [-P] [-K] [-B] [-Nc] [-Q] [-Ns] [-Ds]
+            echo -e "Usage: pacstall [-h] {-I,-S,-R,-D,-A,-Rr,-U,-L,-Up,-Qa,-Qi,-In,-T,-V} [-P] [-K] [-B] [-Nc] [-Q] [-Ns] [-Ds]
 
 An AUR inspired package manager for Ubuntu.
 
@@ -767,7 +767,9 @@ Commands:
     ${BOLD}-Qa${NC}, ${BOLD}--quality-assurance${NC} <package>#<number>
         Test a package PR from downstream. Optional: @[provider]:[owner]/[repo]
     ${BOLD}-Qi${NC}, ${BOLD}--query-info${NC} <package>
-        Query information about a package.
+        Query information about an installed package.
+    ${BOLD}-In${NC}, ${BOLD}--info${NC} <package>
+        Query information about a remote package.
     ${BOLD}-T${NC}, ${BOLD}--tree${NC} <package>
         Display a tree graph of a package.
     ${BOLD}-V${NC}, ${BOLD}--version${NC}
@@ -946,6 +948,46 @@ Helpful links:
                 exit 1
             }
 
+            # shellcheck source=./misc/scripts/search.sh
+            source "$SCRIPTDIR/scripts/search.sh"
+            exit 0
+            ;;
+
+        -In | --info)
+            INFOQUERY="${2}"
+            if [[ $2 =~ ^([a-zA-Z0-9_.-]+)(:([a-zA-Z0-9_.-]+))(@(.+))$ ]]; then
+                PACKAGE="${BASH_REMATCH[1]}:pkgbase"
+                if [[ ${BASH_REMATCH[2]} == ":"* ]]; then
+                    CHILD="${BASH_REMATCH[2]/\:/}"
+                else
+                    CHILD="${BASH_REMATCH[3]}"
+                fi
+                if [[ ${BASH_REMATCH[3]} =~ '@' ]]; then
+                    PACKAGE+="${BASH_REMATCH[3]}"
+                elif [[ -n ${BASH_REMATCH[5]} ]]; then
+                    PACKAGE+="@${BASH_REMATCH[5]}"
+                fi
+            elif [[ $2 =~ ^([a-zA-Z0-9_.-]+)(@(.+))$ ]]; then
+                PACKAGE="${2}"
+            elif [[ ${2} =~ ':' ]]; then
+                PACKAGE="${2%:*}:pkgbase"
+                CHILD="${2#*:}"
+            else
+                PACKAGE="${2}"
+            fi
+            [[ ${CHILD} == "pkgbase" ]] && unset CHILD
+            export PACKAGE CHILD
+            if [[ -z $PACKAGE ]]; then
+                fancy_message error "You failed to specify a package"
+                exit 1
+            fi
+            check_url "https://github.com" 2> /dev/null || check_url "https://gitlab.com" 2> /dev/null || {
+                fancy_message error "Could not connect to the internet"
+                suggested_solution "Confirm that the URLs '${UGreen}https://github.com${NC}' or '${UGreen}https://gitlab.com${NC}' are accessible"
+                exit 1
+            }
+
+            SEARCHINFO=true
             # shellcheck source=./misc/scripts/search.sh
             source "$SCRIPTDIR/scripts/search.sh"
             exit 0

--- a/pacstall
+++ b/pacstall
@@ -627,7 +627,7 @@ for i in "${@}"; do
     # Just add argument if doesn't start with exactly one hyphen.
     if ! [[ ${i} =~ ^-[^-] ]]; then
         # if argument is '-B', '-P', '-K' or '-Nc', add to beginning of argument list.
-        if [[ ${i} == "--build" || ${i} == "--disable-prompts" || ${i} == "--keep" || ${i} == "--nocheck" || ${i} == "--quiet" || ${i} == "--nosandbox"|| ${i} == "--description" ]]; then
+        if [[ ${i} == "--build" || ${i} == "--disable-prompts" || ${i} == "--keep" || ${i} == "--nocheck" || ${i} == "--quiet" || ${i} == "--nosandbox" ]]; then
             argument_list=("${i}" "${argument_list[@]}")
         else
             argument_list+=("${i}")
@@ -640,7 +640,7 @@ for i in "${@}"; do
     # Arguments start with uppercase except 'h'.
     for j in $(sed -E 's/[[:upper:]]|h/ &/g' <<< "${i:1}"); do
         # If current string is 'B', 'P', 'K' or 'Nc', add to beginning of argument list.
-        if [[ ${j} == "B" || ${j} == "P" || ${j} == "K" || ${j} == "Nc" || ${j} == "Q" || ${j} == "Ns" || ${j} == "Ds" ]]; then
+        if [[ ${j} == "B" || ${j} == "P" || ${j} == "K" || ${j} == "Nc" || ${j} == "Q" || ${j} == "Ns" ]]; then
             argument_list=("-${j}" "${argument_list[@]}")
         else
             argument_list+=("-${j}")
@@ -653,9 +653,9 @@ done
 declare -A arg_map=(
     ["--install"]="-I" ["--search"]="-S" ["--remove"]="-R" ["--download"]="-D"
     ["--add-repo"]="-A" ["--remove-repo"]="-Rr" ["--update"]="-U" ["--list"]="-L" ["--upgrade"]="-Up"
-    ["--query-info"]="-Qi" ["--tree"]="-T" ["--version"]="-V" ["--info"]="-In" ["--help"]="-h"
-    ["--build"]="-B" ["--keep"]="-K" ["--disable-prompts"]="-P" ["--nocheck"]="-Nc"
-    ["--quality-assurance"]="-Qa" ["--quiet"]="-Q" ["--nosandbox"]="-Ns" ["--description"]="-Ds"
+    ["--search-description"]="-Sd" ["--search-info"]="-Si" ["--cache-info"]="-Ci"
+    ["--quality-assurance"]="-Qa" ["--tree"]="-T" ["--version"]="-V" ["--help"]="-h" ["--build"]="-B"
+    ["--keep"]="-K" ["--disable-prompts"]="-P" ["--nocheck"]="-Nc" ["--quiet"]="-Q" ["--nosandbox"]="-Ns"
 )
 declare -A hashed_arguments
 unique_argument_list=()
@@ -668,8 +668,8 @@ for arg in "${argument_list[@]}"; do
 done
 
 # Check if only one command flag is being used
-short_commands=("-I" "-S" "-R" "-D" "-A" "-Rr" "-U" "-L" "-Up" "-Qi" "-Qa" "-T" "-V" "-In" "-h")
-long_commands=("--install" "--search" "--remove" "--download" "--add-repo" "--remove-repo" "--update" "--list" "--upgrade" "--query-info" "--quality-assurance" "--tree" "--version" "--info" "--help")
+short_commands=("-I" "-S" "-R" "-D" "-A" "-Rr" "-U" "-L" "-Up" "-Qa" "-Sd" "-Si" "-Ci" "-T" "-V" "-h")
+long_commands=("--install" "--search" "--remove" "--download" "--add-repo" "--remove-repo" "--update" "--list" "--upgrade" "--quality-assurance" "--search-description" "--search-info" "--cache-info" "--tree" "--version" "--help")
 commands=("${short_commands[@]}" "${long_commands[@]}")
 matches=($(comm -12 <(sort <(printf "%s\n" "${unique_argument_list[@]}")) <(sort <(printf "%s\n" "${commands[@]}"))))
 if ((${#matches[@]} <= 1)); then
@@ -686,8 +686,8 @@ function lock() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # Total number of options flags, increase when needed
     local option_flags=5
-    local ignore_short="-S -D -A -Rr -V -L -Qi -T -In -h"
-    local ignore_long="--search --download --add-repo --remove-repo --version --query-info --tree --info --help"
+    local ignore_short="-S -D -A -Rr -V -L -T -Sd -Si -Ci -h"
+    local ignore_long="--search --download --add-repo --remove-repo --version --tree --search-description --search-info --cache-info --help"
     local ignore="$ignore_short $ignore_long"
 
     for ((i = 1; i <= option_flags + 1; i++)); do
@@ -741,7 +741,7 @@ while [[ $1 != "--" ]]; do
             ;;
 
         -h | --help)
-            echo -e "Usage: pacstall [-h] {-I,-S,-R,-D,-A,-Rr,-U,-L,-Up,-Qa,-Qi,-In,-T,-V} [-P] [-K] [-B] [-Nc] [-Q] [-Ns] [-Ds]
+            echo -e "Usage: pacstall [-h] {-I,-S,-R,-D,-A,-Rr,-U,-L,-Up,-Qa,-Sd,-Si,-Ci,-T,-V} [-P] [-K] [-B] [-Nc] [-Q] [-Ns]
 
 An AUR inspired package manager for Ubuntu.
 
@@ -766,12 +766,14 @@ Commands:
         Upgrade all installed packages.
     ${BOLD}-Qa${NC}, ${BOLD}--quality-assurance${NC} <package>#<number>
         Test a package PR from downstream. Optional: @[provider]:[owner]/[repo]
-    ${BOLD}-Qi${NC}, ${BOLD}--query-info${NC} <package>
-        Query information about an installed package.
-    ${BOLD}-In${NC}, ${BOLD}--info${NC} <package>
+    ${BOLD}-Sd${NC}, ${BOLD}--search-description${NC} <package>
+        Search for a package or description keyword.
+    ${BOLD}-Si${NC}, ${BOLD}--search-info${NC} <package>
         Query information about a remote package.
+    ${BOLD}-Ci${NC}, ${BOLD}--cache-info${NC} <package>
+        Query information about an installed package.
     ${BOLD}-T${NC}, ${BOLD}--tree${NC} <package>
-        Display a tree graph of a package.
+        Display a tree graph of an installed package.
     ${BOLD}-V${NC}, ${BOLD}--version${NC}
         Display the version number.
     ${BOLD}-h${NC}, ${BOLD}--help${NC}
@@ -790,8 +792,6 @@ Options:
         Download package entries quietly.
     ${BOLD}-Ns${NC}, ${BOLD}--nosandbox${NC}
         Build the package without bwrap.
-    ${BOLD}-Ds${NC}, ${BOLD}--description${NC}
-        Search with description.
 
 Helpful links:
     ${BOLD}https://github.com/pacstall/pacstall${NC}
@@ -934,7 +934,10 @@ Helpful links:
             exit 0
             ;;
 
-        -S | --search)
+        -S | --search | -Sd | --search-description)
+            if [[ ${1} == "-Sd" || ${1} == --search-description ]]; then
+                DESCON=true
+            fi
 
             export SEARCH=$2
             if [[ -z $SEARCH ]]; then
@@ -953,7 +956,8 @@ Helpful links:
             exit 0
             ;;
 
-        -In | --info)
+        -Si | --search-info)
+            unset CHILD
             INFOQUERY="${2}"
             if [[ $2 =~ ^([a-zA-Z0-9_.-]+)(:([a-zA-Z0-9_.-]+))(@(.+))$ ]]; then
                 PACKAGE="${BASH_REMATCH[1]}:pkgbase"
@@ -1232,7 +1236,7 @@ Helpful links:
             exit 0
             ;;
 
-        -Qi | --query-info)
+        -Ci | --cache-info)
             PACKAGE=$2
             QUERY=$3
             # shellcheck source=./misc/scripts/query-info.sh
@@ -1274,10 +1278,6 @@ Helpful links:
             fancy_message warn "Building package without bwrap sandbox"
             fancy_message sub "Be cautious, this exposes your system to potential harm"
             NOSANDBOX=true
-            ;;
-
-        -Ds | --description)
-            DESCON=true
             ;;
 
         *)

--- a/pacstall
+++ b/pacstall
@@ -627,7 +627,7 @@ for i in "${@}"; do
     # Just add argument if doesn't start with exactly one hyphen.
     if ! [[ ${i} =~ ^-[^-] ]]; then
         # if argument is '-B', '-P', '-K' or '-Nc', add to beginning of argument list.
-        if [[ ${i} == "--build" || ${i} == "--disable-prompts" || ${i} == "--keep" || ${i} == "--nocheck" || ${i} == "--quiet" || ${i} == "--nosandbox" ]]; then
+        if [[ ${i} == "--build" || ${i} == "--disable-prompts" || ${i} == "--keep" || ${i} == "--nocheck" || ${i} == "--quiet" || ${i} == "--nosandbox"|| ${i} == "--description" ]]; then
             argument_list=("${i}" "${argument_list[@]}")
         else
             argument_list+=("${i}")
@@ -640,7 +640,7 @@ for i in "${@}"; do
     # Arguments start with uppercase except 'h'.
     for j in $(sed -E 's/[[:upper:]]|h/ &/g' <<< "${i:1}"); do
         # If current string is 'B', 'P', 'K' or 'Nc', add to beginning of argument list.
-        if [[ ${j} == "B" || ${j} == "P" || ${j} == "K" || ${j} == "Nc" || ${j} == "Q" || ${j} == "Ns" ]]; then
+        if [[ ${j} == "B" || ${j} == "P" || ${j} == "K" || ${j} == "Nc" || ${j} == "Q" || ${j} == "Ns" || ${j} == "Ds" ]]; then
             argument_list=("-${j}" "${argument_list[@]}")
         else
             argument_list+=("-${j}")
@@ -655,7 +655,7 @@ declare -A arg_map=(
     ["--add-repo"]="-A" ["--remove-repo"]="-Rr" ["--update"]="-U" ["--list"]="-L" ["--upgrade"]="-Up"
     ["--query-info"]="-Qi" ["--tree"]="-T" ["--version"]="-V" ["--help"]="-h"
     ["--build"]="-B" ["--keep"]="-K" ["--disable-prompts"]="-P" ["--nocheck"]="-Nc"
-    ["--quality-assurance"]="-Qa" ["--quiet"]="-Q" ["--nosandbox"]="-Ns"
+    ["--quality-assurance"]="-Qa" ["--quiet"]="-Q" ["--nosandbox"]="-Ns" ["--description"]="-Ds"
 )
 declare -A hashed_arguments
 unique_argument_list=()
@@ -741,7 +741,7 @@ while [[ $1 != "--" ]]; do
             ;;
 
         -h | --help)
-            echo -e "Usage: pacstall [-h] {-I,-S,-R,-D,-A,-Rr,-U,-L,-Up,-Qa,-Qi,-T,-V} [-P] [-K] [-B] [-Nc] [-Q] [-Ns]
+            echo -e "Usage: pacstall [-h] {-I,-S,-R,-D,-A,-Rr,-U,-L,-Up,-Qa,-Qi,-T,-V} [-P] [-K] [-B] [-Nc] [-Q] [-Ns] [-Ds]
 
 An AUR inspired package manager for Ubuntu.
 
@@ -788,6 +788,8 @@ Options:
         Download package entries quietly.
     ${BOLD}-Ns${NC}, ${BOLD}--nosandbox${NC}
         Build the package without bwrap.
+    ${BOLD}-Ds${NC}, ${BOLD}--description${NC}
+        Search with description.
 
 Helpful links:
     ${BOLD}https://github.com/pacstall/pacstall${NC}
@@ -1230,6 +1232,10 @@ Helpful links:
             fancy_message warn "Building package without bwrap sandbox"
             fancy_message sub "Be cautious, this exposes your system to potential harm"
             NOSANDBOX=true
+            ;;
+
+        -Ds | --description)
+            DESCON=true
             ;;
 
         *)


### PR DESCRIPTION
## Purpose

integrating srclist

## Approach

* add 2 new thingies
    * `-Si/--search-info` command, searches remote srclist for SRCINFO data
    * `-Sd/--search-description` command, searches both display descriptions and query including descriptions (keyword)
    * `-Qi/--query-info` renamed to `-Ci/--cache-info` for clarity between `-Si`, functionally identical
* fix some inconsistencies when searching by repo (did not take into account masks + did not treat search results as an array)
* regular search now sorts packages from multiple repos alphabetically (i.e. mixed together) rather than separate by repo
## Progress

<!--Make a checklist of your progress-->

- [x] keyword
- [x] info
- [x] make sure no break

<img width="497" alt="Screenshot 2024-07-30 at 7 44 02 PM" src="https://github.com/user-attachments/assets/0b9c4ca6-e9b5-41ff-b522-03d61059e461">
<img width="630" alt="Screenshot_2024-07-30_at_7 21 51_PM" src="https://github.com/user-attachments/assets/549cc7fd-a1c9-4c95-80ab-122eb8a98d28">
<img width="1040" alt="Screenshot_2024-07-30_at_7 23 28_PM" src="https://github.com/user-attachments/assets/555a7852-b7cf-4841-a8b5-fa1a21d713d9">
<img width="519" alt="Screenshot 2024-07-30 at 7 51 05 PM" src="https://github.com/user-attachments/assets/1eefc99f-1b99-4d2e-b4c0-d919f9419c62">


## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
