### PR TITLE
fix({fetch-sources,checks}.sh): cleanup namerefs

### DIFF
--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -409,18 +409,18 @@ function append_hash_entry() {
     local -n append="${1}" sums="${2}" exp_method="${3}"
     local hash_arch hash_arr extend="${4}${5:+_$5}"
     for type in "${sums[@]}"; do
-        hash_arr="${type}sums[*]"
-        [[ ${extend} ]] && hash_arch="${type}sums_${extend}[*]"
+        local -n hash_arr="${type}sums"
+        [[ ${extend} ]] && local -n hash_arch="${type}sums_${extend}"
         if [[ ${exp_method} == "${type}" || -z ${exp_method} ]]; then
-            if [[ -n ${!hash_arr} && -z ${extend} ]]; then
+            if [[ -n ${hash_arr[*]} && -z ${extend} ]]; then
                 export exp_method="${type}"
-                for a in ${!hash_arr}; do
+                for a in "${hash_arr[@]}"; do
                     [[ ${pacname} == *"-deb" ]] && append=("${a}") || append+=("${a}")
                 done
                 break
-            elif [[ -n ${!hash_arch} ]]; then
-                [[ -z ${!hash_arr} && -z ${append[*]} ]] && export exp_method="${type}"
-                for a in ${!hash_arch}; do
+            elif [[ -n ${hash_arch[*]} ]]; then
+                [[ -z ${hash_arr[*]} && -z ${append[*]} ]] && export exp_method="${type}"
+                for a in "${hash_arch[@]}"; do
                     [[ ${pacname} == *"-deb" ]] && append=("${a}") || append+=("${a}")
                 done
                 break
@@ -431,10 +431,10 @@ function append_hash_entry() {
 
 function append_var_arch() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local inp inputvar="${1}" inputvar_arch="${1}_${2}${3:+_$3}[*]"
-    declare -n ref_inputvar="${inputvar}"
-    if [[ -n ${!inputvar_arch} ]]; then
-        for inp in "${!inputvar_arch}"; do
+    local inp inputvar="${1}"
+    local -n ref_inputvar="${inputvar}" inputvar_arch="${inputvar}_${2}${3:+_$3}"
+    if [[ -n ${inputvar_arch[*]} ]]; then
+        for inp in "${inputvar_arch[@]}"; do
             if [[ ${pacname} == *"-deb" && ${inputvar} == "source" ]]; then
                 ref_inputvar=("${inp}")
             elif ! array.contains ref_inputvar "${inp}" || [[ ${inputvar} == "source" ]]; then


### PR DESCRIPTION
## Purpose

when I wrote these originally I did not know enough about namerefs, and as a result I wrote bad and eventually buggy code

## Approach

treat them correctly as arrays now

## Progress

- [x] do it
- [x] test it

## Addendum

Fixing bug found in https://github.com/pacstall/pacstall-programs/pull/6270

```bash
pkgname="pacstall-qa-git"
source=("git+https://github.com/pacstall/pacstall-qa")
pkgver="0.0.1"
gives="pacstall-qa"
makedepends=("make")
pacdeps=("nushell-bin")
pacdeps_debian=("rhino-pkg-git" "rhino-neofetch-git")
pkgdesc="A tool to easily test pacscripts from PRs locally"
maintainer=("Oren Klopfer <oren@taumoda.com>")

build() {
  cd "${_archive}"
  mkdir -p "${pkgdir}/usr/bin"
  mkdir -p "${pkgdir}/usr/share/pacstall-qa"
}

package() {
  cd "${_archive}"
  DESTDIR="${pkgdir}" make install
}
```
before:
<img width="501" alt="Screenshot 2024-08-10 at 5 27 20 PM" src="https://github.com/user-attachments/assets/5d7207d5-c297-498e-b808-98af62fec749">

after:
<img width="505" alt="Screenshot 2024-08-10 at 5 34 12 PM" src="https://github.com/user-attachments/assets/589e73ce-450e-40a3-b520-704e90ae0adc">


## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
