### PR TITLE
fix(package.sh): repair bad cleanup on local pacscripts

### DIFF
--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -200,7 +200,7 @@ if [[ -n ${pacdeps[*]} ]]; then
         [[ $NOSANDBOX ]] && cmd+="Ns"
         ${PACSTALL_VERBOSE} || cmd+="Q"
 
-        if pacstall -S "${pdep}@${REPO}" &> /dev/null; then
+        if [[ -n ${REPO} ]] && pacstall -S "${pdep}@${REPO}" &> /dev/null; then
             repo="@${REPO}"
         fi
         if is_package_installed "${pdep}"; then


### PR DESCRIPTION
## Purpose

when repo search on pacdeps did not have a `$REPO` (aka local install), it was stacktracing & cleaning up secretly, but we could not see it

## Approach

only do the search if `$REPO` exists

## Progress

- [x] do it
- [x] test it
- [x] cry

## Addendum

Fixes issue found in https://github.com/pacstall/pacstall/pull/1209

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
