### PR TITLE
fix({build,fetch-sources,version-constraints}.sh): `all` checks

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -61,19 +61,27 @@ function check_gen_dep() {
     local onlyname="${1}" onlyarch="${2}" onlyreal="${3}" onlywhere="${4}"
     if [[ ${onlyname} == *":${onlyarch}" ]]; then
         if [[ -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname%:*})?architecture(${onlyarch})" -F "%p")" ]]; then
-            if [[ -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname%:*}$)?architecture(${onlyarch})" -F "%p")" ]]; then
-                fancy_message sub $"%b [required]" "${CYAN}${onlyreal}${NC} ${RED}✗${NC}"
-                echo "${onlyreal}" >> "${onlywhere}"
-                return 0
+            if [[ -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname%:*})?architecture(all)" -F "%p")" ]]; then
+                if [[ -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname%:*}$)?architecture(${onlyarch})" -F "%p")" ]]; then
+                    if [[ -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname%:*}$)?architecture(all)" -F "%p")" ]]; then
+                        fancy_message sub $"%b [required]" "${CYAN}${onlyreal}${NC} ${RED}✗${NC}"
+                        echo "${onlyreal}" >> "${onlywhere}"
+                        return 0
+                    fi
+                fi
             fi
         fi
     else
         if [[ -z "$(apt-cache search --no-generate --names-only "^${onlyname}\$" 2> /dev/null || apt-cache search --names-only "^${onlyname}\$")" ]]; then
             if [[ -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname})?architecture(${onlyarch})" -F "%p")" ]]; then
-                if [[ -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname}$)?architecture(${onlyarch})" -F "%p")" ]]; then
-                    fancy_message sub $"%b [required]" "${CYAN}${onlyreal}${NC} ${RED}✗${NC}"
-                    echo "${onlyreal}" >> "${onlywhere}"
-                    return 0
+                if [[ -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname})?architecture(all)" -F "%p")" ]]; then
+                    if [[ -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname}$)?architecture(${onlyarch})" -F "%p")" ]]; then
+                        if [[ -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname}$)?architecture(all)" -F "%p")" ]]; then
+                            fancy_message sub $"%b [required]" "${CYAN}${onlyreal}${NC} ${RED}✗${NC}"
+                            echo "${onlyreal}" >> "${onlywhere}"
+                            return 0
+                        fi
+                    fi
                 fi
             fi
         fi

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -61,10 +61,14 @@ function check_gen_dep() {
     local onlyname="${1}" onlyarch="${2}" onlyreal="${3}" onlywhere="${4}"
     if [[ ${onlyname} == *":${onlyarch}" \
         && -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname%:*})?architecture(${onlyarch})" -F "%p")" \
-        && -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname%:*}$)?architecture(${onlyarch})" -F "%p")" ]] \
+        && -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname%:*})?architecture(all)" -F "%p")" \
+        && -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname%:*}$)?architecture(${onlyarch})" -F "%p")" \
+        && -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname%:*}$)?architecture(all)" -F "%p")" ]] \
         || [[ -z "$(apt-cache search --no-generate --names-only "^${onlyname}\$" 2> /dev/null || apt-cache search --names-only "^${onlyname}\$")" \
             && -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname})?architecture(${onlyarch})" -F "%p")" \
-            && -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname}$)?architecture(${onlyarch})" -F "%p")" ]]; then
+            && -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname})?architecture(all)" -F "%p")" \
+            && -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname}$)?architecture(${onlyarch})" -F "%p")" \
+            && -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname}$)?architecture(all)" -F "%p")" ]]; then
         fancy_message sub $"%b [required]" "${CYAN}${onlyreal}${NC} ${RED}✗${NC}"
         echo "${onlyreal}" >> "${onlywhere}"
         return 0

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -59,32 +59,15 @@ function clean_builddir() {
 function check_gen_dep() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local onlyname="${1}" onlyarch="${2}" onlyreal="${3}" onlywhere="${4}"
-    if [[ ${onlyname} == *":${onlyarch}" ]]; then
-        if [[ -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname%:*})?architecture(${onlyarch})" -F "%p")" ]]; then
-            if [[ -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname%:*})?architecture(all)" -F "%p")" ]]; then
-                if [[ -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname%:*}$)?architecture(${onlyarch})" -F "%p")" ]]; then
-                    if [[ -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname%:*}$)?architecture(all)" -F "%p")" ]]; then
-                        fancy_message sub $"%b [required]" "${CYAN}${onlyreal}${NC} ${RED}✗${NC}"
-                        echo "${onlyreal}" >> "${onlywhere}"
-                        return 0
-                    fi
-                fi
-            fi
-        fi
-    else
-        if [[ -z "$(apt-cache search --no-generate --names-only "^${onlyname}\$" 2> /dev/null || apt-cache search --names-only "^${onlyname}\$")" ]]; then
-            if [[ -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname})?architecture(${onlyarch})" -F "%p")" ]]; then
-                if [[ -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname})?architecture(all)" -F "%p")" ]]; then
-                    if [[ -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname}$)?architecture(${onlyarch})" -F "%p")" ]]; then
-                        if [[ -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname}$)?architecture(all)" -F "%p")" ]]; then
-                            fancy_message sub $"%b [required]" "${CYAN}${onlyreal}${NC} ${RED}✗${NC}"
-                            echo "${onlyreal}" >> "${onlywhere}"
-                            return 0
-                        fi
-                    fi
-                fi
-            fi
-        fi
+    if [[ ${onlyname} == *":${onlyarch}" \
+        && -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname%:*})?architecture(${onlyarch})" -F "%p")" \
+        && -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname%:*}$)?architecture(${onlyarch})" -F "%p")" ]] \
+        || [[ -z "$(apt-cache search --no-generate --names-only "^${onlyname}\$" 2> /dev/null || apt-cache search --names-only "^${onlyname}\$")" \
+            && -z "$(aptitude search --quiet --disable-columns "?exact-name(${onlyname})?architecture(${onlyarch})" -F "%p")" \
+            && -z "$(aptitude search --quiet --disable-columns "?provides(^${onlyname}$)?architecture(${onlyarch})" -F "%p")" ]]; then
+        fancy_message sub $"%b [required]" "${CYAN}${onlyreal}${NC} ${RED}✗${NC}"
+        echo "${onlyreal}" >> "${onlywhere}"
+        return 0
     fi
 }
 

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -657,25 +657,7 @@ function check_builddepends() {
     fi
     dep_const.split_name_and_version "${build_dep}" just_build
     just_arch="$(dep_const.get_arch "${just_build[0]}")"
-    if [[ ${just_build[0]} == *":${just_arch}" ]]; then
-        if [[ -z "$(aptitude search --quiet --disable-columns "?exact-name(${just_build[0]%:*})?architecture(${just_arch})" -F "%p")" ]]; then
-            if [[ -z "$(aptitude search --quiet --disable-columns "?provides(^${just_build[0]%:*}$)?architecture(${just_arch})" -F "%p")" ]]; then
-                fancy_message sub $"%b [required]" "${CYAN}${realbuild}${NC} ${RED}✗${NC}"
-                echo "${realbuild}" >> "${PACDIR}-missing-${type}-${pacname}"
-                return 0
-            fi
-        fi
-    else
-        if [[ -z "$(apt-cache search --no-generate --names-only "^${just_build[0]}\$" 2> /dev/null || apt-cache search --names-only "^${just_build[0]}\$")" ]]; then
-            if [[ -z "$(aptitude search --quiet --disable-columns "?exact-name(${just_build[0]})?architecture(${just_arch})" -F "%p")" ]]; then
-                if [[ -z "$(aptitude search --quiet --disable-columns "?provides(^${just_build[0]}$)?architecture(${just_arch})" -F "%p")" ]]; then
-                    fancy_message sub $"%b [required]" "${CYAN}${realbuild}${NC} ${RED}✗${NC}"
-                    echo "${realbuild}" >> "${PACDIR}-missing-${type}-${pacname}"
-                    return 0
-                fi
-            fi
-        fi
-    fi
+    check_gen_dep "${just_build[0]}" "${just_arch}" "${realbuild}" "${PACDIR}-missing-${type}-${pacname}"
     if dep_const.apt_compare_to_constraints "${build_dep}"; then
         if ! is_apt_package_installed "${just_build[0]}"; then
             echo "${realbuild}" >> "${PACDIR}-needed-${type}-${pacname}"


### PR DESCRIPTION
## Purpose

if a package has both version constraints and is only available as `all`, it needs that as its architecture upon search

## Approach

do that check and also clean up the other aptitude checks

## Progress

- [x] do it
- [x] test it

## Addendum

https://github.com/pacstall/pacstall-programs/pull/6368

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
