### PR TITLE
fix(bash): add zsh exception for mapfile

### DIFF
--- a/misc/completion/bash
+++ b/misc/completion/bash
@@ -25,6 +25,8 @@ _pacstall_get_repo_urls() {
     local part split
     while read -r part; do
         if [[ -n $ZSH_NAME ]]; then
+            # shellcheck disable=SC2296
+            # shellcheck disable=SC2116
             split=(${(@f)"$(echo "${part// /$'\n'}")"})
         else
             mapfile -t split <<< "${part// /$'\n'}"

--- a/misc/completion/bash
+++ b/misc/completion/bash
@@ -25,8 +25,7 @@ _pacstall_get_repo_urls() {
     local part split
     while read -r part; do
         if [[ -n $ZSH_NAME ]]; then
-            # shellcheck disable=SC2296
-            # shellcheck disable=SC2116
+            # shellcheck disable=SC2296,SC2116
             split=(${(@f)"$(echo "${part// /$'\n'}")"})
         else
             mapfile -t split <<< "${part// /$'\n'}"

--- a/misc/completion/bash
+++ b/misc/completion/bash
@@ -24,7 +24,11 @@
 _pacstall_get_repo_urls() {
     local part split
     while read -r part; do
-        mapfile -t split <<< "${part// /$'\n'}"
+        if [[ -n $ZSH_NAME ]]; then
+            split=(${(@f)"$(echo "${part// /$'\n'}")"})
+        else
+            mapfile -t split <<< "${part// /$'\n'}"
+        fi
         if ((${#split[@]} == 1)); then
             echo "${split[0]}"
         elif ((${#split[@]} == 2)); then


### PR DESCRIPTION
## Purpose

I goofed on #1189 at the part about getting the urls from `pacstallrepo`. ZSH should no longer scream mapfile errors.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
