### PR TITLE
fix(remove.sh): Enforce removing metadata if package was removed by apt, change remove to purge

### DIFF
--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -26,12 +26,12 @@
 { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
 function clean_rem_pac() {
-if [[ -e "${METADIR:?}/${_name}" ]]; then
-sudo rm -f "${METADIR:?}/${_name}"
-fi
-if [[ -e "/etc/apt/preferences.d/${_name//./-}-pin" ]]; then
-sudo rm -f "/etc/apt/preferences.d/${_name//./-}-pin"
-fi
+    if [[ -e "${METADIR:?}/${_name}" ]]; then
+        sudo rm -f "${METADIR:?}/${_name}"
+    fi
+    if [[ -e "/etc/apt/preferences.d/${_name//./-}-pin" ]]; then
+        sudo rm -f "/etc/apt/preferences.d/${_name//./-}-pin"
+    fi
 }
 
 source "$METADIR/$PACKAGE" 2> /dev/null || {


### PR DESCRIPTION
## Purpose

- If a package is removed with apt or aptitude, metadata still exists in pacstall -L
- Use apt-get purge to remove config files because they are useless
- add function to clean metadata and pin, for more clarity and checks to avoid rm errors

## Approach

```
davius@distrobox-davius-debian ~ $ pacstall -Up
[+] INFO: Checking for updates
    [>] Building dependency tree
dpkg-query: aucun paquet ne correspond à crossbuild32-rust-bin
dpkg-query: aucun paquet ne correspond à lutris
dpkg-query: aucun paquet ne correspond à protonplus
dpkg-query: aucun paquet ne correspond à rustdesk-server-bin
dpkg-query: aucun paquet ne correspond à webcord
```
```
davius@distrobox-davius-debian ~ $ pacstall -L
~ crossbuild32-rust-bin@1.80.1-pacstall1
   gives        : crossbuild32-rust-bin
   maintainer   : xdavius <xdavius@github.com>
   size         : 885 MB
   repository   : local
   install date : jeu. sept.  5 02:09:38  CEST 2024

~ lutris-deb@0.5.17-pacstall1
   gives        : lutris
   maintainer   : Oren Klopfer <oren@taumoda.com>
   size         : 4 592 kB
   repository   : https://github.com/pacstall/pacstall-programs
   install date : mar. sept. 10 10:46:07  CEST 2024

~ protonplus@0.4.11-pacstall1
   gives        : protonplus
   maintainer   : xdavius <xdavus@github.com>
   size         : 4096 B
   repository   : local
   install date : Wed Jul 31 12:03:11 PM CEST 2024

~ rustdesk-server-bin@1.1.11_1-pacstall1
   maintainer   : sukanka <su975853527 [AT] gmail.com>
   size         : 28.3 MB
   repository   : local
   install date : Sat Aug 17 03:08:01 PM CEST 2024

~ webcord-deb@4.10.0-pacstall1
   gives        : webcord
   maintainer   : Oren Klopfer <oren@taumoda.com>
   size         : 282 MB
   repository   : https://github.com/pacstall/pacstall-programs
   install date : Sat Aug 17 02:54:40 PM CEST 2024
```
```
davius@distrobox-davius-debian ~ $ pacstall -R lutris
[!] ERROR: lutris is not installed
davius@distrobox-davius-debian ~ $ pacstall -R lutris-deb
[!] ERROR: lutris-deb is not installed
davius@distrobox-davius-debian ~ $ pacstall -R protonplus 
[!] ERROR: protonplus is not installed
```
### Pacstall -L still show the packages, that doesn't exists anymore in apt.
### Db is not cleaned by pacstall -R

```
davius@distrobox-davius-debian ~ $ sudo ls /var/lib/pacstall/metadata/
crossbuild32-rust-bin  lutris-deb  protonplus  rustdesk-server-bin  webcord-deb
```

### With this PR

```
davius@distrobox-davius-debian ~ $ pacstall -L
~ lutris-deb@0.5.17-pacstall1
   gives        : lutris
   maintainer   : Oren Klopfer <oren@taumoda.com>
   size         : 4 592 kB
   repository   : https://github.com/pacstall/pacstall-programs
   install date : jeu. sept. 19 03:28:26  CEST 2024
davius@distrobox-davius-debian ~ $ pacstall -R lutris-deb 
[!] ERROR: lutris-deb is not installed
[!] ERROR: lutris-deb removed from pacstall db
```

## Progress

Done

## Nota bene

pacstall -Up should be reinforced too if dpkg-query fails too, to clean the db