### PR TITLE
previous command crashes terminal when run under zsh shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@
 You can run the command below to install Pacstall.
 You can also grab the deb file [here](https://github.com/pacstall/pacstall/releases/latest) but it may be a bit older.
 ```bash
-sudo bash -c "$(curl -fsSL https://pacstall.dev/q/install || wget -q https://pacstall.dev/q/install -O -)"
+bash -c "sudo bash -c \"\$(curl -fsSL https://pacstall.dev/q/install || wget -q https://pacstall.dev/q/install -O -)\""
 ```
 
 ### Uninstalling
 
 You can run the command below to uninstall Pacstall.
 ```bash
-bash -c "$(curl -fsSL https://pacstall.dev/q/uninstall || wget -q https://pacstall.dev/q/uninstall -O -)"
+bash -c "sudo bash -c \"\$(curl -fsSL https://pacstall.dev/q/uninstall || wget -q https://pacstall.dev/q/uninstall -O -)\""
 ```
 ---
 


### PR DESCRIPTION
## Purpose

to avoid terminal crash when run under zsh shell

## Approach

it runs current command under a bash shell to avoid zsh shell crash

## Progress

- [x] Make command compatible with zsh shell

## Checklist

- [ ] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
