### PR TITLE
fix(*)!: `pkgbase` download and function overkill

### DIFF
--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -187,7 +187,7 @@ function fail_down() {
 
 function gather_down() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    export srcdir="${PACDIR}/${pacname}~${pkgver}"
+    export srcdir="${PACDIR}/${pkgbase}~${pkgver}"
     mkdir -p "${srcdir}"
     cd "${srcdir}" || {
         error_log 1 "gather-main ${pacname}"

--- a/misc/scripts/package-base.sh
+++ b/misc/scripts/package-base.sh
@@ -139,6 +139,11 @@ function package_pkg() {
                 if [[ -n ${pacnames[*]} ]]; then
                     fancy_message info $"Selecting packages %b" "${BCyan}${pacnames[*]%%:\ *}${NC}"
                     for pacname in "${pacnames[@]}"; do
+                        if [[ ${pacname} == "${pacnames[0]}" ]]; then
+                            rm -rf "${PACDIR}-no-download-${pkgbase}"
+                        else
+                            touch "${PACDIR}-no-download-${pkgbase}"
+                        fi
                         package_override
                         # shellcheck disable=SC2031
                         fancy_message info $"Packaging %b" "${GREEN}${pacname}${NC}"
@@ -156,6 +161,7 @@ function package_pkg() {
                 fi
             fi
             fancy_message info $"Cleaning up"
+            rm -rf "${PACDIR}-no-download-${pkgbase}"
             if is_apt_package_installed "${PACKAGE}-dummy-builddeps"; then
                 sudo apt-get purge "${PACKAGE}-dummy-builddeps" -y > /dev/null
             fi
@@ -164,6 +170,7 @@ function package_pkg() {
         fi
     else
         pacname="${pkgname}"
+        rm -rf "${PACDIR}-no-download-${pkgbase}"
         # shellcheck source=./misc/scripts/package.sh
         if ! source "$SCRIPTDIR/scripts/package.sh"; then
             # shellcheck disable=SC2031

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -261,66 +261,69 @@ install_builddepends
 # shellcheck disable=SC2034
 prompt_depends || { ignore_stack=true; return 1; }
 
-fancy_message info $"Retrieving packages"
 mkdir -p "${PACDIR}"
 gather_down
 
-unset payload_arr
-if [[ -n $PACSTALL_PAYLOAD && ! -f "${PACDIR}-pacdeps-${pacname}" ]]; then
-    mapfile -t payload_arr < <(awk -v RS=';:' '{if (NF) print $0}' <<< "${PACSTALL_PAYLOAD}")
-fi
+if ! [[ -f "${PACDIR}-no-download-${pkgbase}" ]]; then
+    fancy_message info $"Retrieving packages"
 
-for i in "${!source[@]}"; do
-    parse_source_entry "${source[$i]}"
-    expectedHash="${hash[$i]}"
-    if [[ -n ${payload_arr[*]} ]]; then
-        for p in "${!payload_arr[@]}"; do
-            if [[ ${payload_arr[$p]##*/} == "${dest}" ]]; then
-                source_url="file://${payload_arr[$p]}"
-            fi
-        done
+    unset payload_arr
+    if [[ -n $PACSTALL_PAYLOAD && ! -f "${PACDIR}-pacdeps-${pacname}" ]]; then
+        mapfile -t payload_arr < <(awk -v RS=';:' '{if (NF) print $0}' <<< "${PACSTALL_PAYLOAD}")
     fi
-    if [[ $source_url != *://* ]]; then
-        if [[ -f "${PKGPATH}/${dest}" ]]; then
-            source_url="file://${PKGPATH}/${dest}"
-        else
-            if [[ -z ${REPO} ]]; then
-                REPO="$(head -n1 "${SCRIPTDIR}/repo/pacstallrepo")"
-            fi
-            # shellcheck disable=SC2031
-            source_url="${REPO}/packages/${pacname}/${source_url}"
+
+    for i in "${!source[@]}"; do
+        parse_source_entry "${source[$i]}"
+        expectedHash="${hash[$i]}"
+        if [[ -n ${payload_arr[*]} ]]; then
+            for p in "${!payload_arr[@]}"; do
+                if [[ ${payload_arr[$p]##*/} == "${dest}" ]]; then
+                    source_url="file://${payload_arr[$p]}"
+                fi
+            done
         fi
-    fi
-    case "${source_url}" in
-        *file://*)
-            source_url="${source_url#file://}"
-            source_url="${source_url#git+}"
-            file_down
-            ;;
-        *.git | git+*)
-            if [[ $source_url == git+* ]]; then
-                source_url="${source_url#git+}"
+        if [[ $source_url != *://* ]]; then
+            if [[ -f "${PKGPATH}/${dest}" ]]; then
+                source_url="file://${PKGPATH}/${dest}"
+            else
+                if [[ -z ${REPO} ]]; then
+                    REPO="$(head -n1 "${SCRIPTDIR}/repo/pacstallrepo")"
+                fi
+                # shellcheck disable=SC2031
+                source_url="${REPO}/packages/${pacname}/${source_url}"
             fi
-            git_down
-            ;;
-        *.deb)
-            net_down
-            deb_down && return 0
-            ;;
-        *.zip | *.tar.gz | *.tgz | *.tar.bz2 | *.tbz2 | *.tar.bz | *.tbz | *.tar.xz | *.txz | *.tar.zst | *.tzst | *.gz | *.bz2 | *.xz | *.lz | *.lzma | *.zst | *.7z | *.rar | *.lz4 | *.tar)
-            net_down
-            genextr_declare
-            genextr_down
-            ;;
-        *)
-            net_down
-            hashcheck_down
-            gather_down
-            ;;
-    esac
-    unset expectedHash dest source_url git_branch git_tag git_commit ext_deps ext_method
-done
-unset hashsum_method payload_arr
+        fi
+        case "${source_url}" in
+            *file://*)
+                source_url="${source_url#file://}"
+                source_url="${source_url#git+}"
+                file_down
+                ;;
+            *.git | git+*)
+                if [[ $source_url == git+* ]]; then
+                    source_url="${source_url#git+}"
+                fi
+                git_down
+                ;;
+            *.deb)
+                net_down
+                deb_down && return 0
+                ;;
+            *.zip | *.tar.gz | *.tgz | *.tar.bz2 | *.tbz2 | *.tar.bz | *.tbz | *.tar.xz | *.txz | *.tar.zst | *.tzst | *.gz | *.bz2 | *.xz | *.lz | *.lzma | *.zst | *.7z | *.rar | *.lz4 | *.tar)
+                net_down
+                genextr_declare
+                genextr_down
+                ;;
+            *)
+                net_down
+                hashcheck_down
+                gather_down
+                ;;
+        esac
+        unset expectedHash dest source_url git_branch git_tag git_commit ext_deps ext_method
+    done
+    unset hashsum_method payload_arr
+fi
 
 if [[ -z ${_archive} ]]; then
     export _archive="${srcdir}"
@@ -333,20 +336,26 @@ export -f ask fancy_message select_options
 
 clean_logdir
 
-unset pac_functions
-if [[ $NOCHECK == true ]]; then
-    for i in "prepare" "build" "package${pkgbase:+_$pacname}"; do
-        if is_function "$i"; then
-            pac_functions+=("$i")
-        fi
-    done
+unset pac_functions pac_func_arr
+if ! [[ -f "${PACDIR}-no-download-${pkgbase}" ]]; then
+    if [[ $NOCHECK == true ]]; then
+        pac_func_arr=("prepare" "build" "package${pkgbase:+_$pacname}")
+    else
+        pac_func_arr=("prepare" "build" "check" "package${pkgbase:+_$pacname}")
+    fi
 else
-    for i in "prepare" "build" "check" "package${pkgbase:+_$pacname}"; do
-        if is_function "$i"; then
-            pac_functions+=("$i")
-        fi
-    done
+    if [[ $NOCHECK == true ]]; then
+        pac_func_arr=("package${pkgbase:+_$pacname}")
+    else
+        pac_func_arr=("check" "package${pkgbase:+_$pacname}")
+    fi
 fi
+
+for i in "${pac_func_arr[@]}"; do
+    if is_function "${i}"; then
+        pac_functions+=("${i}")
+    fi
+done
 if [[ -n ${pac_functions[*]} ]]; then
     fancy_message info $"Running functions"
     for function in "${pac_functions[@]}"; do

--- a/pacstall
+++ b/pacstall
@@ -189,7 +189,7 @@ function decl_scriptvars() {
         sums="b2 sha512 sha384 sha256 sha224 sha1 md5"
     pacstallvars=(pkgbase pkgname repology pkgver git_pkgver epoch source_url source depends makedepends checkdepends conflicts
         breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps NOBUILDDEP provides incompatible
-        compatible srcdir url backup pkgrel mask pac_functions repo priority noextract nosubmodules _archive license
+        compatible srcdir url backup pkgrel mask pac_functions pac_func_arr repo priority noextract nosubmodules _archive license
         bwrapenv safeenv external_connection enhances recommends suggests custom_fields makeconflicts checkconflicts bugs)
     mapfile -t distros < <(awk -F ',' -v current_date="$(date +'%Y-%m-%d')" '
       BEGIN {
@@ -239,7 +239,7 @@ function cleanup() {
                 fi
             done
         fi
-        [[ -n ${pkgbase} ]] && sudo rm -rf "${PACDIR}-selectopts-pkgbase-${pkgbase}"
+        [[ -n ${pkgbase} ]] && sudo rm -rf "${PACDIR}-selectopts-pkgbase-${pkgbase}" "${PACDIR}-no-download-${pkgbase}"
         # shellcheck disable=SC2153
         [[ -n ${STAGEDIR} && -n ${PACKAGE} ]] && sudo rm -rf "${STAGEDIR}/${pacname:-$PACKAGE}"
         [[ -n ${pacfile} ]] && sudo rm -f "${pacfile}"


### PR DESCRIPTION
## Purpose

When building split packages, the `prepare` and `build` functions should only be run once, and the download of `source` entries should only be performed once. Pacstall currently does not abide by this, causing: https://github.com/pacstall/pacstall-programs/pull/6339#issue-2469229994

## Approach

- Switch `srcdir` from being based off of `pacname` to `pkgbase`
- If `pacname` is not the first entry in the `pacnames` list, `touch` the file `/tmp/pacstall-no-download-${pkgbase}`
- If this file is present:
    - Do not run the download functions (as they were already run)
    - Do not run `prepare` or `build` (as they were already run), only `check` and `package_${pkgname}`
- Make sure this file is cleaned up both at the end of the package split loop, and in `cleanup` as backup

## Progress

- [x] do it
- [x] test it

<details>
<summary>log showing that it works even with pacdeps</summary>

```
rhino@docker-desktop:~$ pacstall -BI rhino-pkg-git.pacscript 
[+] INFO: Package will be built and not installed
(rhino-pkg-git) Do you want to view/edit the pacscript? [y/N] 
[+] INFO: Sourcing pacscript
[+] INFO: Found pkgbase: rhino-pkg-git
		[0] Exit
		[1] rhino-pkg-git
		[2] rpk-git
	Select packages to be built [1 2 or Y] 
[+] INFO: Selecting packages rhino-pkg-git rpk-git
[+] INFO: Packaging rhino-pkg-git
[+] INFO: Checking build dependencies
	[>] gettext ✓ [installed]
	[>] make ✓ [installed]
[+] INFO: Checking apt dependencies
	[>] gettext ✓ [installed]
[+] INFO: Retrieving packages
[+] INFO: Cloning rhino-pkg from HEAD
Cloning into 'rhino-pkg'...
remote: Enumerating objects: 33, done.
remote: Counting objects: 100% (33/33), done.
remote: Compressing objects: 100% (27/27), done.
remote: Total 33 (delta 17), reused 11 (delta 3), pack-reused 0 (from 0)
Receiving objects: 100% (33/33), 28.48 KiB | 2.19 MiB/s, done.
Resolving deltas: 100% (17/17), done.
	[>] Checking integrity of bf10b08e
[+] INFO: Running functions
	[>] Running package_rhino-pkg-git
mapfile -t linguas <po/LINGUAS && for i in "${linguas[@]}"; do mkdir -p /usr/src/pacstall/rhino-pkg-git/usr/share/locale/"${i}"/LC_MESSAGES/ && msgfmt -o /usr/src/pacstall/rhino-pkg-git/usr/share/locale/"${i}"/LC_MESSAGES/rhino-pkg.mo po/"${i}".po; done
install -Dm755 rhino-pkg -t /usr/src/pacstall/rhino-pkg-git/usr/bin/
[+] INFO: Packaging rhino-pkg-git as rhino-pkg
	[>] Packing control.tar
	[>] Packing data.tar
	[>] Compressing
[+] INFO: Package built at /home/rhino/rhino-pkg-git_0.1.2-pacstall1~gitbf10b08e_all.deb
[+] INFO: Performing post install operations
	[>] Storing pacscript
[+] INFO: Done installing rhino-pkg-git
[+] INFO: Packaging rpk-git
[+] INFO: Checking pacstall dependencies
	[>] pacstall-qa-git ✗ [required]
(pacstall-qa-git) Do you want to view/edit the pacscript? [y/N] 
[+] INFO: Sourcing pacscript
[+] INFO: Checking pacstall dependencies
	[>] nushell-bin ↑↓ [update]
(nushell-bin) Do you want to view/edit the pacscript? [y/N] 
[+] INFO: Sourcing pacscript
[+] INFO: Checking build dependencies
	[>] gzip ✓ [installed]
	[>] tar ✓ [installed]
[+] INFO: Checking apt dependencies
[+] INFO: Retrieving packages
[+] INFO: Downloading nu-0.99.1-aarch64-unknown-linux-gnu.tar.gz
Initializing download: https://github.com/nushell/nushell/releases/download/0.99.1/nu-0.99.1-aarch64-unknown-linux-gnu.tar.gz
File size: 47.025 Megabyte(s) (49309333 bytes)
Opening output file nu-0.99.1-aarch64-unknown-linux-gnu.tar.gz
Starting download

Connection 0 finished
Connection 2 finished
Connection 3 finished
[100%] [.....................................................................................] [  32.5MB/s] [00:00]

Downloaded 47.025 Megabyte(s) in 1 second(s). (33279.55 KB/s)
	[>] Checking hash 5e4437a0[...]
	[>] Extracting nu-0.99.1-aarch64-unknown-linux-gnu.tar.gz
[+] INFO: Running functions
	[>] Running package
install: creating directory '/usr/src/pacstall/nushell-bin/usr'
install: creating directory '/usr/src/pacstall/nushell-bin/usr/bin'
'./nu_plugin_inc' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_inc'
'./nu' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu'
'./nu_plugin_gstat' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_gstat'
'./nu_plugin_formats' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_formats'
'./nu_plugin_custom_values' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_custom_values'
'./nu_plugin_example' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_example'
'./nu_plugin_stress_internals' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_stress_internals'
'./nu_plugin_polars' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_polars'
'./nu_plugin_query' -> '/usr/src/pacstall/nushell-bin/usr/bin/nu_plugin_query'
install: creating directory '/usr/src/pacstall/nushell-bin/usr/share'
install: creating directory '/usr/src/pacstall/nushell-bin/usr/share/doc'
install: creating directory '/usr/src/pacstall/nushell-bin/usr/share/doc/nushell'
'README.txt' -> '/usr/src/pacstall/nushell-bin/usr/share/doc/nushell/README.txt'
install: creating directory '/usr/src/pacstall/nushell-bin/usr/share/licenses'
install: creating directory '/usr/src/pacstall/nushell-bin/usr/share/licenses/nushell'
'LICENSE' -> '/usr/src/pacstall/nushell-bin/usr/share/licenses/nushell/LICENSE'
[+] INFO: Packaging nushell-bin
	[>] Packing control.tar
	[>] Packing data.tar
	[>] Compressing
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'nushell-bin' instead of '/usr/src/pacstall/nushell-bin_0.99.1-pacstall1_arm64.deb'
The following packages were automatically installed and are no longer required:
  gettext gettext-base gtk-update-icon-cache libdeflate0 libgdk-pixbuf-2.0-0 libgdk-pixbuf2.0-bin
  libgdk-pixbuf2.0-common libglib2.0-0t64 libglib2.0-data libicu74 libjbig0 libjpeg-turbo8 libjpeg8 liblerc4
  libperl5.38t64 libpng16-16t64 libsharpyuv0 libtiff6 libwebp7 libxml2 perl-modules-5.38 shared-mime-info unicons
  xdg-user-dirs
Use 'sudo apt autoremove' to remove them.
The following packages will be upgraded:
  nushell-bin
1 upgraded, 0 newly installed, 0 to remove and 54 not upgraded.
Need to get 0 B/55.0 MB of archives.
After this operation, 7776 kB of additional disk space will be used.
Get:1 /usr/src/pacstall/nushell-bin_0.99.1-pacstall1_arm64.deb nushell-bin arm64 0.99.1-pacstall1 [55.0 MB]
(Reading database ... 23880 files and directories currently installed.)
Preparing to unpack .../nushell-bin_0.99.1-pacstall1_arm64.deb ...
Unpacking nushell-bin (0.99.1-pacstall1) over (0.94.2-pacstall1) ...
Setting up nushell-bin (0.99.1-pacstall1) ...
nushell-bin was already set to automatically installed.
[+] INFO: Performing post install operations
	[>] Storing pacscript
[+] INFO: Done installing nushell-bin
[+] INFO: Cleaning up
[+] INFO: Checking build dependencies
	[>] make ✓ [installed]
[+] INFO: Checking apt dependencies
[+] INFO: Retrieving packages
[+] INFO: Cloning pacstall-qa from HEAD
Cloning into 'pacstall-qa'...
remote: Enumerating objects: 7, done.
remote: Counting objects: 100% (7/7), done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 7 (delta 0), reused 3 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (7/7), 14.29 KiB | 1.10 MiB/s, done.
	[>] Checking integrity of d8094640
[+] INFO: Running functions
	[>] Running build
	[>] Running package
cp pacstall-qa.wrapper /usr/src/pacstall/pacstall-qa-git/usr/bin/pacstall-qa
install -Dm755 pacstall-qa -t /usr/src/pacstall/pacstall-qa-git/usr/share/pacstall-qa/
install -Dm644 README.md -t /usr/src/pacstall/pacstall-qa-git/usr/share/pacstall-qa/
[+] INFO: Packaging pacstall-qa-git as pacstall-qa
	[>] Packing control.tar
	[>] Packing data.tar
	[>] Compressing
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Note, selecting 'pacstall-qa' instead of '/usr/src/pacstall/pacstall-qa-git_0.0.1-pacstall1~gitd8094640_all.deb'
The following packages were automatically installed and are no longer required:
  gettext gettext-base gtk-update-icon-cache libdeflate0 libgdk-pixbuf-2.0-0 libgdk-pixbuf2.0-bin
  libgdk-pixbuf2.0-common libglib2.0-0t64 libglib2.0-data libicu74 libjbig0 libjpeg-turbo8 libjpeg8 liblerc4
  libperl5.38t64 libpng16-16t64 libsharpyuv0 libtiff6 libwebp7 libxml2 perl-modules-5.38 shared-mime-info unicons
  xdg-user-dirs
Use 'sudo apt autoremove' to remove them.
The following NEW packages will be installed:
  pacstall-qa
0 upgraded, 1 newly installed, 0 to remove and 54 not upgraded.
Need to get 0 B/2334 B of archives.
After this operation, 4096 B of additional disk space will be used.
Get:1 /usr/src/pacstall/pacstall-qa-git_0.0.1-pacstall1~gitd8094640_all.deb pacstall-qa all 0.0.1-pacstall1~gitd8094640 [2334 B]
Selecting previously unselected package pacstall-qa.
(Reading database ... 23880 files and directories currently installed.)
Preparing to unpack .../pacstall-qa-git_0.0.1-pacstall1~gitd8094640_all.deb ...
Unpacking pacstall-qa (0.0.1-pacstall1~gitd8094640) ...
Setting up pacstall-qa (0.0.1-pacstall1~gitd8094640) ...
pacstall-qa set to automatically installed.
[+] INFO: Performing post install operations
	[>] Storing pacscript
[+] INFO: Done installing pacstall-qa-git
[+] INFO: Cleaning up
[+] INFO: Checking build dependencies
	[>] gettext ✓ [installed]
	[>] make ✓ [installed]
[+] INFO: Checking apt dependencies
	[>] gettext ✓ [installed]
[+] INFO: Running functions
	[>] Running package_rpk-git
mapfile -t linguas <po/LINGUAS && for i in "${linguas[@]}"; do mkdir -p /usr/src/pacstall/rpk-git/usr/share/locale/"${i}"/LC_MESSAGES/ && msgfmt -o /usr/src/pacstall/rpk-git/usr/share/locale/"${i}"/LC_MESSAGES/rhino-pkg.mo po/"${i}".po; done
install -Dm755 rhino-pkg -t /usr/src/pacstall/rpk-git/usr/bin/
[+] INFO: Packaging rpk-git as rpk
	[>] Packing control.tar
	[>] Packing data.tar
	[>] Compressing
[+] INFO: Package built at /home/rhino/rpk-git_0.1.2-pacstall1~gitbf10b08e_all.deb
[+] INFO: Performing post install operations
	[>] Storing pacscript
[+] INFO: Done installing rpk-git
[+] INFO: Cleaning up
```
</details>

## Addendum

Fixes https://github.com/pacstall/pacstall-programs/pull/6339 's issue (though the script will need to be reverted back to its proper state)

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
