### PR TITLE
fix(search.sh): rm weird stray printf thing

### DIFF
--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -387,7 +387,7 @@ while IFS= read -r URL; do
             REPOMSG=1
             continue
         elif ! check_url "${URL}/packagelist"; then
-            fancy_message error "%s\n" $"Cannot connect to Pacstall repo: %b" "${CYAN}${URL}${NC}"
+            fancy_message error $"Cannot connect to Pacstall repo: %b" "${CYAN}${URL}${NC}"
             fancy_message warn $"You can remove or fix the URL by editing %b" "$CYAN$SCRIPTDIR/repo/pacstallrepo$NC"
             REPOMSG=1
             continue


### PR DESCRIPTION
## Purpose

not supposed to be there and makes the error print wrong (we can see on the debian CIs failing rn)

## Approach

remove

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
