### PR TITLE
fix(build.sh): don't mark already installed optdeps as deps in build only mode

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -139,7 +139,7 @@ function check_opt_dep() {
     fi
     # Add to the dependency list if already installed so it doesn't get autoremoved on upgrade
     # If the package is not installed already, add it to the list. It's much easier for a user to choose from a list of uninstalled packages than every single one regardless of it's status
-    if ! is_apt_package_installed "${just_name[0]}"; then
+    if ((PACSTALL_INSTALL == 0)) || ! is_apt_package_installed "${just_name[0]}"; then
         echo "${realopt}: ${optdesc}" >> "${PACDIR}-suggested-optdeps-${pacname}"
     else
         echo "${realopt}" >> "${PACDIR}-already-installed-optdeps-${pacname}"


### PR DESCRIPTION
## Purpose

if I have the optdeps preinstalled, and i go to build the package, it will mark already installed optdeps as deps, counter to how it should work, where in build mode they are supposed to be all auto marked as suggests

## Approach

if pacstall_install is 0 dont mark anything off as already installed

## Progress

- [x] do it
- [x] test it

## Addendum

<!--Link any issues with this PR and/or write something that you want to inform us about (optional)-->

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
