### PR TITLE
perf: remove some awk instances in favor of variable substitution

### DIFF
--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -271,7 +271,7 @@ if ! [[ -f "${PACDIR}-no-download-${pkgbase}" ]]; then
 
     unset payload_arr
     if [[ -n $PACSTALL_PAYLOAD && ! -f "${PACDIR}-pacdeps-${pacname}" ]]; then
-        mapfile -t payload_arr < <(awk -v RS=';:' '{if (NF) print $0}' <<< "${PACSTALL_PAYLOAD}")
+        mapfile -t payload_arr <<< "${PACSTALL_PAYLOAD//;:/$'\n'}"
     fi
 
     for i in "${!source[@]}"; do


### PR DESCRIPTION
## Purpose

awk slow, bash fast.

## Approach

Replace superfluous instances of awk with pure bash.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
