### PR TITLE
fix(build.sh): repair replaces removal logic

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -469,6 +469,7 @@ function makedeb() {
             if ! array.contains breaks "${i}" && ! array.contains conflicts "${i}"; then
                 conflicts+=("${i}")
             fi
+        done
         deblog_depends replaces "Replaces"
     fi
 


### PR DESCRIPTION
## Purpose

if we run apt remove in most normal contexts, it will also remove all the packages depending on it.

## Approach

If conflicts and breaks array dont contain an item in replaces, add it to conflicts, and let apt do the removing. Essential packages dont work with this (rhino-core stuff), so we still need to have the logic for them.

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
