### PR TITLE
fix(build.sh): repair pinning contexts

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -696,10 +696,8 @@ function install_deb() {
         if ! [[ -d /etc/apt/preferences.d/ ]]; then
             sudo mkdir -p /etc/apt/preferences.d
         fi
-        local combined_pinning=("${provides[@]}" "${gives:-${pacname}}")
-        echo "Package: ${combined_pinning[*]}" | sudo tee "/etc/apt/preferences.d/${pacname//./-}-pin" > /dev/null
-        echo "Pin: version *" | sudo tee -a "/etc/apt/preferences.d/${pacname//./-}-pin" > /dev/null
-        echo "Pin-Priority: -1" | sudo tee -a "/etc/apt/preferences.d/${pacname//./-}-pin" > /dev/null
+        echo -e "Package: ${provides[*]}\nPin: release o=*\nPin-Priority: -1\n" | sudo tee "/etc/apt/preferences.d/${pacname//./-}-pin" > /dev/null
+        echo -e "Package: ${provides[*]}\nPin: version ${full_version}\nPin-Priority: 100" | sudo tee -a "/etc/apt/preferences.d/${pacname//./-}-pin" > /dev/null
         return 0
     else
         sudo mv "$STAGEDIR/$debname.deb" "$PACDEB_DIR"


### PR DESCRIPTION
## Purpose

If a package is installed by pacstall, we use negative pinning to ensure it is not updated by apt. This causes issues, though, when setting a depend on a pacstall package, forcing us to use pacdeps.

## Approach

keep everyone negative pinned except for the local installed version

## Progress

- [x] do it
- [x] test it

## Addendum

Fixes https://github.com/pacstall/pacstall/issues/1231.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
