### PR TITLE
fix(bwrap.sh): fallback `pkgbase`

### DIFF
--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -122,7 +122,7 @@ EOF
         fi
     fi
     if [[ ${NOSANDBOX} == "true" ]]; then
-        sudo LOGDIR="${LOGDIR}" SCRIPTDIR="${SCRIPTDIR}" STAGEDIR="${STAGEDIR}" pkgdir="${pkgdir}" pacname="${pacname}" pkgbase="${pkgbase}" \
+        sudo LOGDIR="${LOGDIR}" SCRIPTDIR="${SCRIPTDIR}" STAGEDIR="${STAGEDIR}" pkgdir="${pkgdir}" pacname="${pacname}" pkgbase="${pkgbase:-${pacname}}" \
             srcdir="${srcdir}" git_pkgver="${git_pkgver}" homedir="${homedir}" CARCH="${CARCH}" AARCH="${AARCH}" \
             DISTRO="${DISTRO}" CDISTRO="${CDISTRO}" NCPU="${NCPU}" PACSTALL_USER="${PACSTALL_USER}" TAR_OPTIONS='--no-same-owner' \
             "$tmpfile" && sudo rm "$tmpfile"
@@ -133,7 +133,7 @@ EOF
             --dev-bind /dev/null /dev/null --tmpfs /root --tmpfs /home --setenv safeenv "$safeenv" \
             --bind "$STAGEDIR" "$STAGEDIR" --bind "$PACDIR" "$PACDIR" --setenv LOGDIR "$LOGDIR" \
             --setenv SCRIPTDIR "$SCRIPTDIR" --setenv STAGEDIR "$STAGEDIR" --setenv pkgdir "$pkgdir" \
-            --setenv srcdir "$srcdir" --setenv git_pkgver "$git_pkgver" --setenv pacname "$pacname" --setenv pkgbase "$pkgbase" \
+            --setenv srcdir "$srcdir" --setenv git_pkgver "$git_pkgver" --setenv pacname "$pacname" --setenv pkgbase "${pkgbase:-${pacname}}" \
             --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv AARCH "$AARCH" --setenv DISTRO "$DISTRO" \
             --setenv CDISTRO "$CDISTRO"  --setenv NCPU "$NCPU" --setenv PACSTALL_USER "$PACSTALL_USER" --setenv TAR_OPTIONS '--no-same-owner' \
             "$tmpfile" && sudo rm "$tmpfile"


### PR DESCRIPTION
## Purpose

last PR fixed the pacname issue but I realized that pkgbase can be empty if it is a singular package so for functions to access the value it needs to fallback pacname

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
