### PR TITLE
fix(*): make srcinfo parsing not resource heavy

### DIFF
--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -838,12 +838,12 @@ function compare_remote_version() {
         # shellcheck disable=SC2034
         curl -fsSL "$remoterepo/packages/$crv_fetch/.SRCINFO" | sudo tee "${remote_safe}" > /dev/null || { ignore_stack=true; return 1; }
         sudo chown "${PACSTALL_USER}" "${remote_safe}"
-        srcinfo.parse "${remote_safe}"
-        srcinfo.match_pkg "crv_base" "pkgbase"
+        srcinfo.parse "${remote_safe}" "${crv_fetch}"
+        srcinfo.match_pkg "crv_base" "${crv_fetch}" "pkgbase"
         for remv in "pkgver" "pkgrel" "epoch"; do
-            srcinfo.match_pkg "crv_${remv}" "${remv}" "${crv_base}"
+            srcinfo.match_pkg "crv_${remv}" "${crv_fetch}" "${remv}" "${crv_base}"
         done
-        srcinfo.match_pkg "crv_source" "source" "${crv_base}"
+        srcinfo.match_pkg "crv_source" "${crv_fetch}" "source" "${crv_base}"
         if [[ ${crv_input} == *-git ]]; then
             parse_source_entry "${crv_source[0]}"
             calc_git_pkgver
@@ -851,7 +851,7 @@ function compare_remote_version() {
         else
             echo "${crv_epoch:+$crv_epoch:}${crv_pkgver}-pacstall${crv_pkgrel:-1}"
         fi
-        srcinfo.cleanup
+        srcinfo.cleanup "${crv_fetch}"
         sudo rm -rf "${remote_safe:?}"
     )" > /dev/null
     localver=$(source "${METADIR}/${crv_input}" && echo "${_version}")

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -838,13 +838,12 @@ function compare_remote_version() {
         # shellcheck disable=SC2034
         curl -fsSL "$remoterepo/packages/$crv_fetch/.SRCINFO" | sudo tee "${remote_safe}" > /dev/null || { ignore_stack=true; return 1; }
         sudo chown "${PACSTALL_USER}" "${remote_safe}"
-        crv_base="$(srcinfo.match_pkg "${remote_safe}" pkgbase)"
+        srcinfo.parse "${remote_safe}"
+        srcinfo.match_pkg "crv_base" "pkgbase"
         for remv in "pkgver" "pkgrel" "epoch"; do
-            local -n deremv="crv_${remv}"
-            # shellcheck disable=SC2034
-            deremv="$(srcinfo.match_pkg "${remote_safe}" "${remv}" "${crv_base}")"
+            srcinfo.match_pkg "crv_${remv}" "${remv}" "${crv_base}"
         done
-        mapfile -t crv_source < <(srcinfo.match_pkg "${remote_safe}" "source" "${crv_base}")
+        srcinfo.match_pkg "crv_source" "source" "${crv_base}"
         if [[ ${crv_input} == *-git ]]; then
             parse_source_entry "${crv_source[0]}"
             calc_git_pkgver
@@ -852,6 +851,7 @@ function compare_remote_version() {
         else
             echo "${crv_epoch:+$crv_epoch:}${crv_pkgver}-pacstall${crv_pkgrel:-1}"
         fi
+        srcinfo.cleanup
         sudo rm -rf "${remote_safe:?}"
     )" > /dev/null
     localver=$(source "${METADIR}/${crv_input}" && echo "${_version}")

--- a/misc/scripts/package-base.sh
+++ b/misc/scripts/package-base.sh
@@ -55,13 +55,14 @@ function trap_ctrlc() {
 function package_override() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # shellcheck disable=SC2031
-    local o all_ovars opac="${pacname}" obase="${pkgbase}" ovars=("gives" "pkgdesc" "url" "priority")
+    local o all_ovars look lbase opac="${pacname}" obase="${pkgbase}" ovars=("gives" "pkgdesc" "url" "priority")
     all_ovars=("${ovars[@]}" "arch" "license" "depends" "checkdepends" "optdepends" "pacdeps" "provides" "checkconflicts" "conflicts" "breaks" "replaces" "enhances" "recommends" "suggests" "backup" "repology")
+    srcinfo.parse "${srcinfile}"
     for o in "${all_ovars[@]}"; do
-        local look lbase
+        unset look lbase
         # shellcheck disable=SC2034
         local -n over="${o}"
-        mapfile -t look < <(unset "${pacstallvars[@]}" && srcinfo.match_pkg "${srcinfile}" "${o}" "${opac}")
+        srcinfo.match_pkg "look" "${o}" "${opac}"
         if [[ -n ${look[*]} ]]; then
             if array.contains ovars "${o}"; then
                 # shellcheck disable=SC2178,SC2034
@@ -71,7 +72,7 @@ function package_override() {
                 over=("${look[@]}")
             fi
         else
-            mapfile -t lbase < <(unset "${pacstallvars[@]}" && srcinfo.match_pkg "${srcinfile}" "${o}" "pkgbase:${obase}")
+            srcinfo.match_pkg "lbase" "${o}" "pkgbase:${obase}"
             if [[ -n ${lbase[*]} ]]; then
                 if array.contains ovars "${o}"; then
                     # shellcheck disable=SC2178,SC2034
@@ -88,6 +89,7 @@ function package_override() {
             declare -p "${o}" | sudo tee -a "${safeenv}" > /dev/null
         fi
     done
+    srcinfo.cleanup
 }
 
 function package_pkg() {

--- a/misc/scripts/package-base.sh
+++ b/misc/scripts/package-base.sh
@@ -72,6 +72,7 @@ function package_override() {
             fi
         else
             mapfile -t lbase < <(unset "${pacstallvars[@]}" && srcinfo.match_pkg "${srcinfile}" "${o}" "pkgbase:${obase}")
+            unset "${o}"
             if [[ -n ${lbase[*]} ]]; then
                 if array.contains ovars "${o}"; then
                     # shellcheck disable=SC2178,SC2034
@@ -81,6 +82,9 @@ function package_override() {
                     over=("${lbase[@]}")
                 fi
             fi
+        fi
+        if [[ -n "${look[*]}" || -n "${lbase[*]}" ]]; then
+            declare -p "${o}" | sudo tee -a "${safeenv}" > /dev/null
         fi
     done
 }

--- a/misc/scripts/package-base.sh
+++ b/misc/scripts/package-base.sh
@@ -72,7 +72,6 @@ function package_override() {
             fi
         else
             mapfile -t lbase < <(unset "${pacstallvars[@]}" && srcinfo.match_pkg "${srcinfile}" "${o}" "pkgbase:${obase}")
-            unset "${o}"
             if [[ -n ${lbase[*]} ]]; then
                 if array.contains ovars "${o}"; then
                     # shellcheck disable=SC2178,SC2034
@@ -83,7 +82,9 @@ function package_override() {
                 fi
             fi
         fi
-        if [[ -n "${look[*]}" || -n "${lbase[*]}" ]]; then
+        if [[ -z ${look[*]} && -z ${lbase[*]} ]]; then
+            echo "unset ${o}" | sudo tee -a "${safeenv}" > /dev/null
+        else
             declare -p "${o}" | sudo tee -a "${safeenv}" > /dev/null
         fi
     done

--- a/misc/scripts/package-base.sh
+++ b/misc/scripts/package-base.sh
@@ -57,12 +57,12 @@ function package_override() {
     # shellcheck disable=SC2031
     local o all_ovars look lbase opac="${pacname}" obase="${pkgbase}" ovars=("gives" "pkgdesc" "url" "priority")
     all_ovars=("${ovars[@]}" "arch" "license" "depends" "checkdepends" "optdepends" "pacdeps" "provides" "checkconflicts" "conflicts" "breaks" "replaces" "enhances" "recommends" "suggests" "backup" "repology")
-    srcinfo.parse "${srcinfile}"
+    srcinfo.parse "${srcinfile}" "${pacname}"
     for o in "${all_ovars[@]}"; do
         unset look lbase
         # shellcheck disable=SC2034
         local -n over="${o}"
-        srcinfo.match_pkg "look" "${o}" "${opac}"
+        srcinfo.match_pkg "look" "${pacname}" "${o}" "${opac}"
         if [[ -n ${look[*]} ]]; then
             if array.contains ovars "${o}"; then
                 # shellcheck disable=SC2178,SC2034
@@ -72,7 +72,7 @@ function package_override() {
                 over=("${look[@]}")
             fi
         else
-            srcinfo.match_pkg "lbase" "${o}" "pkgbase:${obase}"
+            srcinfo.match_pkg "lbase" "${pacname}" "${o}" "pkgbase:${obase}"
             if [[ -n ${lbase[*]} ]]; then
                 if array.contains ovars "${o}"; then
                     # shellcheck disable=SC2178,SC2034
@@ -89,7 +89,7 @@ function package_override() {
             declare -p "${o}" | sudo tee -a "${safeenv}" > /dev/null
         fi
     done
-    srcinfo.cleanup
+    srcinfo.cleanup "${pacname}"
 }
 
 function package_pkg() {

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -485,7 +485,7 @@ function srcinfo.print_var() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local srcinfo_file="${1}" found="${2}" pkgbase output var name idx evil eviler e printed
     local -n bases="srcinfo_access"
-    srcinfo.parse "${srcinfo_file}" srcinfo
+    srcinfo.parse "${srcinfo_file}" "srcinfo"
     if [[ ${found} == "pkgbase" ]]; then
         if [[ -n ${globase} && ${globase} != "temporary_pacstall_pkgbase" ]]; then
             pkgbase="${globase}"
@@ -562,7 +562,7 @@ function srcinfo.match_pkg() {
     fi
     mapfile -t declares < <(srcinfo.print_var "${srcfile}" "${search}" | awk '{sub(/^declare -a |^declare -- |^declare -x /, ""); print}')
     [[ ${search} == "pkgbase" && -z ${declares[*]} ]] \
-        && mapfile -t declares < <(srcinfo.print_var "${srcfile}" pkgname | awk '{sub(/^declare -a |^declare -- |^declare -x /, ""); print}')
+        && mapfile -t declares < <(srcinfo.print_var "${srcfile}" "pkgname" | awk '{sub(/^declare -a |^declare -- |^declare -x /, ""); print}')
     for d in "${declares[@]}"; do
         if [[ ${d%=\(*} =~ = ]]; then
             declare -- "${d}"

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -289,10 +289,12 @@ function srcinfo._basic_check() {
 function srcinfo._contains() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local -n arr_name="${1}"
-    local key="${2}"
-    if [[ " ${arr_name[*]} " == *" ${key} "* ]]; then
-        return 0
-    fi
+    local key="${2}" z
+    for z in "${arr_name[@]}"; do
+        if [[ ${z} == "${key}" ]]; then
+            return 0
+        fi
+    done
     # shellcheck disable=SC2034
     { ignore_stack=true; return 1; }
 }

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -289,12 +289,10 @@ function srcinfo._basic_check() {
 function srcinfo._contains() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local -n arr_name="${1}"
-    local key="${2}" z
-    for z in "${arr_name[@]}"; do
-        if [[ ${z} == "${key}" ]]; then
-            return 0
-        fi
-    done
+    local key="${2}"
+    if [[ " ${arr_name[*]} " == *" ${key} "* ]]; then
+        return 0
+    fi
     # shellcheck disable=SC2034
     { ignore_stack=true; return 1; }
 }
@@ -385,7 +383,7 @@ function srcinfo.parse() {
         temp_array="$(srcinfo._create_array "${locbase}" "${temp_line[key]}" "${var_prefix}")"
         declare -n ref="${temp_array}"
         ref+=("${temp_line[value]}")
-        if [[ ${locbase} == "pkgbase_"* ]] || ! srcinfo._contains total_list "${temp_array}"; then
+        if ! srcinfo._contains total_list "${temp_array}"; then
             total_list+=("${temp_array}")
         fi
     done < "${srcinfo_file}"

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -483,8 +483,9 @@ function srcinfo.reformat_assoc_arr() {
 # @arg $2 string Variable or Array to print
 function srcinfo.print_var() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local found="${1}" pkgbase output var name idx evil eviler e printed
+    local srcinfo_file="${1}" found="${2}" pkgbase output var name idx evil eviler e printed
     local -n bases="srcinfo_access"
+    srcinfo.parse "${srcinfo_file}" srcinfo
     if [[ ${found} == "pkgbase" ]]; then
         if [[ -n ${globase} && ${globase} != "temporary_pacstall_pkgbase" ]]; then
             pkgbase="${globase}"
@@ -559,10 +560,9 @@ function srcinfo.match_pkg() {
     else
         match="srcinfo_${search%%_*}_${pkg//-/_}"
     fi
-    srcinfo.parse "${srcfile}" srcinfo
-    mapfile -t declares < <(srcinfo.print_var "${search}" | awk '{sub(/^declare -a |^declare -- |^declare -x /, ""); print}')
+    mapfile -t declares < <(srcinfo.print_var "${srcfile}" "${search}" | awk '{sub(/^declare -a |^declare -- |^declare -x /, ""); print}')
     [[ ${search} == "pkgbase" && -z ${declares[*]} ]] \
-        && mapfile -t declares < <(srcinfo.print_var pkgname | awk '{sub(/^declare -a |^declare -- |^declare -x /, ""); print}')
+        && mapfile -t declares < <(srcinfo.print_var "${srcfile}" pkgname | awk '{sub(/^declare -a |^declare -- |^declare -x /, ""); print}')
     for d in "${declares[@]}"; do
         if [[ ${d%=\(*} =~ = ]]; then
             declare -- "${d}"

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -321,7 +321,7 @@ function srcinfo._create_array() {
 function srcinfo.parse() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     srcinfo.cleanup
-    local srcfile srcinfo_data var_prefix locbase temp_array ref total_list loop part i suffix
+    local srcfile srcinfo_data locbase temp_array ref total_list loop part i suffix
     srcfile="${1:?No .SRCINFO passed to srcinfo.parse}"
     [[ ! -s ${srcfile} ]] && return 5
     mapfile -t srcinfo_data < "${srcfile}"
@@ -367,20 +367,16 @@ function srcinfo.parse() {
     done
     unset srcinfo_data
     sudo rm -f "${PACDIR}-srcinfo-access"
-    declare -Ag "srcinfo_access"
     for loop in "${total_list[@]}"; do
         declare -n part="${loop}"
         # Are we at a new pkgname (pkgbase)?
         if [[ ${loop} == *@(pkgname|pkgbase) ]]; then
-            declare -n var_name="srcinfo_access"
             [[ ${loop} == "srcinfo_pkgbase"* ]] && global="pkgbase_"
             for i in "${!part[@]}"; do
                 suffix="${global}${part[${i}]//-/_}"
                 suffix="${suffix//./_}"
                 # Create our inner part
                 declare -ga "srcinfo_${suffix}"
-                # Declare that relationship
-                var_name["srcinfo_${suffix}"]="srcinfo_${suffix}"
             done
             unset global
         fi
@@ -427,7 +423,7 @@ function srcinfo.match_pkg() {
                 srcref+=("${output[@]}")
             fi
         else
-            srcref=""
+            srcref=()
         fi
     done
 }

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -302,7 +302,7 @@ function srcinfo._contains() {
 # @description Create array based on input
 #
 # @example
-#   srcinfo._create_array pkgbase var_name var_prefix
+#   srcinfo._create_array base var_name var_prefix
 #
 # @arg $1 string (optional) The pkgbase of the section
 # @arg $2 string The variable name
@@ -311,47 +311,31 @@ function srcinfo._contains() {
 # @stdout Name of array created.
 function srcinfo._create_array() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local pkgbase="${1}" var_name="${2}" var_pref="${3}"
-    if [[ -n ${pkgbase} ]]; then
-        pkgbase="${pkgbase//./_}" var_name="${var_name//./_}"
-        if ! [[ -v "${var_pref}_${pkgbase}_array_${var_name}" ]]; then
-            declare -ag "${var_pref}_${pkgbase}_array_${var_name}"
+    local base="${1}" var_name="${2}"
+    if [[ -n ${base} ]]; then
+        base="${base//./_}" var_name="${var_name//./_}"
+        if ! [[ -v "srcinfo_${base}_array_${var_name}" ]]; then
+            declare -ag "srcinfo_${base}_array_${var_name}"
         fi
-        echo "${var_pref}_${pkgbase}_array_${var_name}"
+        echo "srcinfo_${base}_array_${var_name}"
     else
-        if ! [[ -v "${var_pref}_array_${var_name}" ]]; then
-            declare -ag "${var_pref}_array_${var_name}"
+        if ! [[ -v "srcinfo_array_${var_name}" ]]; then
+            declare -ag "srcinfo_array_${var_name}"
         fi
-        echo "${var_pref}_array_${var_name}"
+        echo "srcinfo_array_${var_name}"
     fi
-}
-
-# @description Promote array to variable
-#
-# @example
-#   foo=('bar')
-#   srcinfo._promote_to_variable foo
-#
-# @arg $1 string Name of array to promote
-function srcinfo._promote_to_variable() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local var_name="${1}" key value
-    key="${var_name}"
-    value="${!var_name[0]}"
-    declare -g "${key}=${value}"
 }
 
 function srcinfo.parse() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local srcinfo_file var_prefix locbase temp_array ref total_list loop part i part_two split_up suffix
-    srcinfo_file="${1:?No .SRCINFO passed to srcinfo.parse}"
-    var_prefix="${2:?Variable prefix not passed to srcinfo.parse}"
-    srcinfo.cleanup "${var_prefix}"
-    [[ ! -s ${srcinfo_file} ]] && return 5
-    while IFS= read -r line; do
+    srcinfo.cleanup
+    local srcfile srcinfo_data var_prefix locbase temp_array ref total_list loop part i suffix
+    srcfile="${1:?No .SRCINFO passed to srcinfo.parse}"
+    [[ ! -s ${srcfile} ]] && return 5
+    mapfile -t srcinfo_data < "${srcfile}"
+    for line in "${srcinfo_data[@]}"; do
         # Skip blank lines
-        [[ -z ${line} ]] && continue
-        [[ ${line} =~ ^\s*#.* ]] && continue
+        [[ -z ${line} || ${line} =~ ^\s*#.* ]] && continue
         # Trim leading whitespace.
         line="${line##+([[:space:]])}"
         declare -A temp_line
@@ -382,215 +366,76 @@ function srcinfo.parse() {
         # So the strategy is to create arrays of every key and at the end,
         # we can promote array.len() == 1 to variables instead. After that we
         # can work back upwards.
-        temp_array="$(srcinfo._create_array "${locbase}" "${temp_line[key]}" "${var_prefix}")"
+        temp_array="$(srcinfo._create_array "${locbase}" "${temp_line[key]}")"
         declare -n ref="${temp_array}"
         ref+=("${temp_line[value]}")
         if ! srcinfo._contains total_list "${temp_array}"; then
             total_list+=("${temp_array}")
         fi
-    done < "${srcinfo_file}"
-    declare -Ag "${var_prefix}_access"
+    done
+    unset srcinfo_data
+    sudo rm -f "${PACDIR}-srcinfo-access"
+    declare -Ag "srcinfo_access"
     for loop in "${total_list[@]}"; do
         declare -n part="${loop}"
         # Are we at a new pkgname (pkgbase)?
         if [[ ${loop} == *@(pkgname|pkgbase) ]]; then
-            declare -n var_name="${var_prefix}_access"
-            [[ ${loop} == "${var_prefix}_pkgbase"* ]] && global="pkgbase_"
+            declare -n var_name="srcinfo_access"
+            [[ ${loop} == "srcinfo_pkgbase"* ]] && global="pkgbase_"
             for i in "${!part[@]}"; do
                 suffix="${global}${part[${i}]//-/_}"
                 suffix="${suffix//./_}"
                 # Create our inner part
-                declare -ga "${var_prefix}_${suffix}"
+                declare -ga "srcinfo_${suffix}"
                 # Declare that relationship
-                var_name["${var_prefix}_${suffix}"]="${var_prefix}_${suffix}"
+                var_name["srcinfo_${suffix}"]="srcinfo_${suffix}"
             done
             unset global
         fi
     done
-    for part_two in "${total_list[@]}"; do
-        # Now we need to go and check every loop over, and parse it out so we get something like ("prefix", "key"), so we can then work with that.
-        # But first actually we should promote single element arrays to variables
-        declare -n referoo="${part_two}"
-        if (("${#referoo[@]}" == 1)); then
-            srcinfo._promote_to_variable "${part_two}"
-        fi
-        mapfile -t split_up <<< "${part_two/_array_/$'\n'}"
-        declare -n addarr="${split_up[0]}"
-        unset "${split_up[1]}"
-        # So now we need to check if the thing we're trying to insert is a variable,
-        # or an array.
-        if is_array "${part_two}"; then
-            declare -ga "${part_two}"
-            # shellcheck disable=SC2004
-            addarr[${split_up[1]}]="${part_two}"
-        else
-            # shellcheck disable=SC2034,SC2004
-            addarr[${split_up[1]}]="${!part_two}"
-        fi
-    done
+    declare -p "${total_list[@]}" | sudo tee -a "${PACDIR}-srcinfo-access" > /dev/null
 }
 
 function srcinfo.cleanup() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local var_prefix="${1:?No var_prefix passed to srcinfo.cleanup}" i z
-    local main_loop_template="${var_prefix}_access" compg
-    declare -n main_loop="${main_loop_template}"
-    for i in "${main_loop[@]}"; do
-        declare -n cleaner="${i}"
-        for z in "${cleaner[@]}"; do
-            unset "${var_prefix}_array_${z}"
-        done
-        unset cleaner
-    done
-    unset "${var_prefix}_access" globase global "${pacstallvars[@]}"
-    # So now lets clean the stragglers that we can't reasonably infer
-    mapfile -t compg < <(compgen -v)
-    for i in "${compg[@]}"; do
-        if [[ ${i} == "${var_prefix}_"* ]]; then
-            unset -v "${i}"
-        fi
-    done
-}
-
-# @description Reformat numbered associative array to indexed
-#
-# @example
-#   srcinfo_depends_vala_panel_appmenu_xfce_git=(["vala-panel-appmenu-valapanel-git-0"]="gtk3")
-#   srcinfo.reformat_assoc_arr "srcinfo_depends_vala_panel_appmenu_xfce_git" "eviler"
-#
-#   converts to `srcinfo_depends_vala_panel_appmenu_valapanel_git=([0]="gtk3")`
-#
-# @arg $1 string Associative array to reformat
-# @arg $2 string Ref string of indexed array to append conversion to (can be anything)
-function srcinfo.reformat_assoc_arr() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local pfx base ida new pfs in_name="${1}"
-    local -n in_arr="${in_name}" app="${2}"
-    IFS='_' read -r -a pfs <<< "${in_name}"
-    for pfx in "${!in_arr[@]}"; do
-        base="${pfx%-*}" ida="${pfx##*-}" new="${base//-/_}"
-        new="${new//./_}"
-        app+=("$(printf "%s[%s]=\"%s\"\n" "${pfs[0]}_${pfs[1]}_${new}" "${ida}" "${in_arr[${pfx}]}")")
-    done
-}
-
-# @description Parse a specific variable from .SRCINFO
-#
-# @example
-#
-#   srcinfo.print_var .SRCINFO source
-# @arg $1 string .SRCINFO file path
-# @arg $2 string Variable or Array to print
-function srcinfo.print_var() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local srcinfo_file="${1}" found="${2}" pkgbase output var name idx evil eviler e printed
-    local -n bases="srcinfo_access"
-    srcinfo.parse "${srcinfo_file}" "srcinfo"
-    if [[ ${found} == "pkgbase" ]]; then
-        if [[ -n ${globase} && ${globase} != "temporary_pacstall_pkgbase" ]]; then
-            pkgbase="${globase}"
-            declare -p pkgbase
-        fi
-        return 0
-    fi
-    for var in "${bases[@]}"; do
-        var="${var//./_}"
-        declare -n output="${var}_array_${found}"
-        declare -n name="${var}_array_pkgname"
-        if [[ -n ${output[*]} ]]; then
-            for idx in "${!output[@]}"; do
-                if ((${#bases[@]} > 1)); then
-                    # shellcheck disable=SC2076
-                    if [[ ${var} =~ "pkgbase_${globase//-/_}" ]]; then
-                        evil+=("$(printf "srcinfo_${found}_${globase//-/_}[\"${globase}-pkgbase-%d\"]=\"%s\"\n" "${idx}" "${output[${idx}]}")")
-                    else
-                        evil+=("$(printf "srcinfo_${found}_${globase//-/_}[\"${name}-%d\"]=\"%s\"\n" "${idx}" "${output[${idx}]}")")
-                    fi
-                else
-                    evil+=("$(printf "srcinfo_${found}_${name//-/_}[\"${name}-%d\"]=\"%s\"\n" "${idx}" "${output[${idx}]}")")
-                fi
-            done
-        fi
-    done
-    if [[ -n ${globase} && ${globase} != "temporary_pacstall_pkgbase" ]]; then
-        unset "srcinfo_${found}_${globase//-/_}"
-        declare -Ag "srcinfo_${found}_${globase//-/_}"
-    else
-        unset "srcinfo_${found}_${name//-/_}"
-        declare -Ag "srcinfo_${found}_${name//-/_}"
-    fi
-    # shellcheck disable=SC2294
-    eval "${evil[@]}"
-    if [[ -n ${globase} && ${globase} != "temporary_pacstall_pkgbase" ]]; then
-        srcinfo.reformat_assoc_arr "srcinfo_${found}_${globase//-/_}" "eviler"
-        unset "srcinfo_${found}_${globase//-/_}"
-        # shellcheck disable=SC2294
-        eval "${eviler[@]}"
-    else
-        srcinfo.reformat_assoc_arr "srcinfo_${found}_${name//-/_}" "eviler"
-        unset "srcinfo_${found}_${name//-/_}"
-        # shellcheck disable=SC2294
-        eval "${eviler[@]}"
-    fi
-    for e in "${eviler[@]}"; do
-        if ! srcinfo._contains printed "${e%\[*}"; then
-            printed+=("${e%\[*}")
-            declare -p "${e%\[*}"
-        fi
-        unset "${e%\[*}"
-    done
+    local compg
+    mapfile -t compg < <(compgen -v "srcinfo_")
+    unset "${compg[@]}" srcinfo_access globase global 2> /dev/null
+    sudo rm -f "${PACDIR}-srcinfo-access"
 }
 
 # @description Output a specific variable from .SRCINFO
 #
 # @example
 #
-#   srcinfo.match_pkg .SRCINFO pkgbase
-#   srcinfo.match_pkg .SRCINFO pkgdesc $(srcinfo.match_pkg .SRCINFO pkgbase)
-# @arg $1 string .SRCINFO file path
+#   srcinfo.match_pkg ref_base pkgbase
+#   srcinfo.match_pkg ref_desc pkgdesc ${ref_base}
+# @arg $1 string Reference to append to
 # @arg $2 string Variable or Array to search
 # @arg $3 string Package name or base to get output for
 function srcinfo.match_pkg() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local declares d bases b guy match out srcfile="${1}" search="${2}" pkg="${3}"
-    pkg="${pkg//./_}"
-    if [[ ${pkg} == "pkgbase:"* || ${search} == "pkgbase" ]]; then
-        pkg="${pkg/pkgbase:/}"
-        match="srcinfo_${search%%_*}_${pkg//-/_}_pkgbase"
-    else
-        match="srcinfo_${search%%_*}_${pkg//-/_}"
-    fi
-    mapfile -t declares < <(srcinfo.print_var "${srcfile}" "${search}" | awk '{sub(/^declare -a |^declare -- |^declare -x /, ""); print}')
-    [[ ${search} == "pkgbase" && -z ${declares[*]} ]] \
-        && mapfile -t declares < <(srcinfo.print_var "${srcfile}" "pkgname" | awk '{sub(/^declare -a |^declare -- |^declare -x /, ""); print}')
+    local search="${2}" pkg="${3}" output var bases d dec declares
+    local -n srcref="${1}"
+    mapfile -t declares < "${PACDIR}-srcinfo-access"
     for d in "${declares[@]}"; do
-        if [[ ${d%=\(*} =~ = ]]; then
-            declare -- "${d}"
-            bases+=("${d%=*}")
-        else
-            declare -a "${d}"
-            bases+=("${d%=\(*}")
-        fi
+        dec="${d##*declare -a }"
+        bases+=("${dec%=\(*}")
     done
-    for b in "${bases[@]}"; do
-        guy="${b}[@]"
-        if [[ -z ${pkg} ]]; then
-            if [[ ${search} == "pkgname" || ${search} == "pkgbase" ]]; then
-                if [[ -n ${pkgbase} ]]; then
-                    out="${pkgbase/\"/}"
-                    out="${out/\"/}"
-                    printf '%s\n' "pkgbase:${out}"
-                    continue
-                fi
-                printf '%s\n' "${!guy}"
-                continue
-            else
-                printf '%s\n' "${guy}"
-                continue
+    pkg="${pkg//./_}"
+    pkg="${pkg//:/_}"
+    pkg="${pkg//-/_}"
+    for var in "${bases[@]}"; do
+        var="${var//./_}"
+        declare -n output="${var}"
+        if [[ -n ${output[*]} ]]; then
+            if [[ ${search} == "pkgbase" ]]; then
+                srcref="pkgbase:${output[0]}"
+            elif [[ ${search} == "pkgname" || ${var} == "srcinfo_${pkg}_array_${search}" ]]; then
+                srcref+=("${output[@]}")
             fi
-        fi
-        if [[ ${b} == "${match}" ]]; then
-            printf '%s\n' "${!guy}"
+        else
+            srcref=""
         fi
     done
 }

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -302,28 +302,20 @@ function srcinfo._contains() {
 # @description Create array based on input
 #
 # @example
-#   srcinfo._create_array base var_name var_prefix
+#   srcinfo._create_array base var_name
 #
-# @arg $1 string (optional) The pkgbase of the section
+# @arg $1 string The pkgbase of the section
 # @arg $2 string The variable name
-# @arg $3 string (optional) The variable prefix
 #
 # @stdout Name of array created.
 function srcinfo._create_array() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local base="${1}" var_name="${2}"
-    if [[ -n ${base} ]]; then
-        base="${base//./_}" var_name="${var_name//./_}"
-        if ! [[ -v "srcinfo_${base}_array_${var_name}" ]]; then
-            declare -ag "srcinfo_${base}_array_${var_name}"
-        fi
-        echo "srcinfo_${base}_array_${var_name}"
-    else
-        if ! [[ -v "srcinfo_array_${var_name}" ]]; then
-            declare -ag "srcinfo_array_${var_name}"
-        fi
-        echo "srcinfo_array_${var_name}"
+    base="${base//./_}" var_name="${var_name//./_}"
+    if ! [[ -v "srcinfo_${base}_array_${var_name}" ]]; then
+        declare -ag "srcinfo_${base}_array_${var_name}"
     fi
+    echo "srcinfo_${base}_array_${var_name}"
 }
 
 function srcinfo.parse() {

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -73,12 +73,12 @@ function calc_repo_ver() {
     compare_safe="${compare_tmp}"
     curl -fsSL "$compare_repo/packages/$compare_package/.SRCINFO" | sudo tee "${compare_safe}" > /dev/null || { ignore_stack=true; return 1; }
     sudo chown "${PACSTALL_USER}" "${compare_safe}"
-    srcinfo.parse "${compare_safe}"
-    srcinfo.match_pkg "compare_base" "pkgbase"
+    srcinfo.parse "${compare_safe}" "${compare_package}"
+    srcinfo.match_pkg "compare_base" "${compare_package}" "pkgbase"
     for comp in "pkgver" "pkgrel" "epoch"; do
-        srcinfo.match_pkg "compare_${comp}" "${comp}" "${compare_base}"
+        srcinfo.match_pkg "compare_${comp}" "${compare_package}" "${comp}" "${compare_base}"
     done
-    srcinfo.match_pkg "compare_source" "source" "${compare_base}"
+    srcinfo.match_pkg "compare_source" "${compare_package}" "source" "${compare_base}"
     if [[ ${compare_package} == *-git ]]; then
         parse_source_entry "${compare_source[0]}"
         calc_git_pkgver
@@ -86,7 +86,7 @@ function calc_repo_ver() {
     else
         comp_repo_ver="${compare_epoch:+$compare_epoch:}${compare_pkgver}-pacstall${compare_pkgrel:-1}"
     fi
-    srcinfo.cleanup
+    srcinfo.cleanup "${compare_package}"
     sudo rm -rf "${compare_safe:?}"
 }
 

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -73,13 +73,12 @@ function calc_repo_ver() {
     compare_safe="${compare_tmp}"
     curl -fsSL "$compare_repo/packages/$compare_package/.SRCINFO" | sudo tee "${compare_safe}" > /dev/null || { ignore_stack=true; return 1; }
     sudo chown "${PACSTALL_USER}" "${compare_safe}"
-    compare_base="$(srcinfo.match_pkg "${compare_safe}" pkgbase)"
+    srcinfo.parse "${compare_safe}"
+    srcinfo.match_pkg "compare_base" "pkgbase"
     for comp in "pkgver" "pkgrel" "epoch"; do
-        local -n decomp="compare_${comp}"
-        # shellcheck disable=SC2034
-        decomp="$(srcinfo.match_pkg "${compare_safe}" "${comp}" "${compare_base}")"
+        srcinfo.match_pkg "compare_${comp}" "${comp}" "${compare_base}"
     done
-    mapfile -t compare_source < <(srcinfo.match_pkg "${compare_safe}" "source" "${compare_base}")
+    srcinfo.match_pkg "compare_source" "source" "${compare_base}"
     if [[ ${compare_package} == *-git ]]; then
         parse_source_entry "${compare_source[0]}"
         calc_git_pkgver
@@ -87,6 +86,7 @@ function calc_repo_ver() {
     else
         comp_repo_ver="${compare_epoch:+$compare_epoch:}${compare_pkgver}-pacstall${compare_pkgrel:-1}"
     fi
+    srcinfo.cleanup
     sudo rm -rf "${compare_safe:?}"
 }
 

--- a/pacstall
+++ b/pacstall
@@ -228,7 +228,7 @@ decl_scriptvars
 
 function cleanup() {
     if [[ -n ${PACDIR} ]]; then
-        sudo rm -f "${PACDIR}-srcinfo-access"
+        sudo rm -f "${PACDIR}-srcinfo-access-"*
         if [[ -n ${KEEP} && -n ${pacname} ]]; then
             sudo rm -rf "${PACDIR}-keep/${pacname}"
             mkdir -p "${PACDIR}-keep/${pacname}"

--- a/pacstall
+++ b/pacstall
@@ -228,6 +228,7 @@ decl_scriptvars
 
 function cleanup() {
     if [[ -n ${PACDIR} ]]; then
+        sudo rm -f "${PACDIR}-srcinfo-access"
         if [[ -n ${KEEP} && -n ${pacname} ]]; then
             sudo rm -rf "${PACDIR}-keep/${pacname}"
             mkdir -p "${PACDIR}-keep/${pacname}"
@@ -257,7 +258,9 @@ function cleanup() {
         [[ -n ${bwrapenv} ]] && sudo rm -f "${bwrapenv}"
         [[ -n ${safeenv} ]] && sudo rm -f "${safeenv}"
     fi
-    unset "${pacstallvars[@]}" 2> /dev/null
+    local compg
+    mapfile -t compg < <(compgen -v "srcinfo_")
+    unset "${pacstallvars[@]}" "${compg[@]}" srcinfo_access globase global 2> /dev/null
     unset -f pre_install pre_upgrade pre_remove post_install post_upgrade post_remove prepare build check package 2> /dev/null
 }
 


### PR DESCRIPTION
## Purpose

A lot of our code didn't do anything, and was just gobbling up CPU time.

## Approach

- Remove redundant rewriting of pkgbase parent variables
- Decouple `srcinfo.parse` from `srcinfo.match_pkg`
    - `srcinfo.parse` now requires a second var to create an access file to write to
    - Refactor `srcinfo.match_pkg` to map results to a ref instead of printing out in a subshell, and read from the access file
- Eliminate functions that did nothing:
    - `srcinfo._promote_to_variable`
    - `srcinfo.reformat_assoc_arr`
    - `srcinfo.print_var`
- Fix description search only giving pkgbase parent + last result for split packages:
    - Before: `foobar` parent exists with children `a` `b` `c`; description search responds: `foobar:pkgbase` `foobar:c`
    - Now: description search responds: `foobar:pkgbase` `foobar:a` `foobar:b` `foobar:c`

## Progress

- [x] do it
- [x] test it

## Addendum

remember to bump srcinfo.sh in programs + pacup too when ready

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
