### PR TITLE
ci: use arm64 runners for docker

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -21,10 +21,50 @@ jobs:
   build:
     strategy:
       matrix:
-        OS: ["ubuntu:latest", "ubuntu:devel", "ubuntu:rolling", "debian:stable", "debian:testing", "debian:unstable"]
-        platform: ["linux/amd64", "linux/arm64"]
+        include:
+          - OS: "ubuntu:latest"
+            platform: "linux/amd64"
+            runner: "ubuntu-latest"
+          - OS: "ubuntu:latest"
+            platform: "linux/arm64"
+            runner: "ubuntu-24.04-arm"
+
+          - OS: "ubuntu:devel"
+            platform: "linux/amd64"
+            runner: "ubuntu-latest"
+          - OS: "ubuntu:devel"
+            platform: "linux/arm64"
+            runner: "ubuntu-24.04-arm"
+
+          - OS: "ubuntu:rolling"
+            platform: "linux/amd64"
+            runner: "ubuntu-latest"
+          - OS: "ubuntu:rolling"
+            platform: "linux/arm64"
+            runner: "ubuntu-24.04-arm"
+
+          - OS: "debian:stable"
+            platform: "linux/amd64"
+            runner: "ubuntu-latest"
+          - OS: "debian:stable"
+            platform: "linux/arm64"
+            runner: "ubuntu-24.04-arm"
+
+          - OS: "debian:testing"
+            platform: "linux/amd64"
+            runner: "ubuntu-latest"
+          - OS: "debian:testing"
+            platform: "linux/arm64"
+            runner: "ubuntu-24.04-arm"
+
+          - OS: "debian:unstable"
+            platform: "linux/amd64"
+            runner: "ubuntu-latest"
+          - OS: "debian:unstable"
+            platform: "linux/arm64"
+            runner: "ubuntu-24.04-arm"
       fail-fast: true
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Purpose

pros: will run docker builds wayyyyyy faster

## Approach

cons: have to explicitly define each matrix combo now

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
