### PR TITLE
fix({package-base,srcinfo}.sh): give split pkgs access to extended arrays

### DIFF
--- a/misc/scripts/package-base.sh
+++ b/misc/scripts/package-base.sh
@@ -55,8 +55,11 @@ function trap_ctrlc() {
 function package_override() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # shellcheck disable=SC2031
-    local o all_ovars look lbase opac="${pacname}" obase="${pkgbase}" ovars=("gives" "pkgdesc" "url" "priority")
+    local o all_ovars ext_ovars ext_types look lbase opac="${pacname}" obase="${pkgbase}" ovars=("gives" "pkgdesc" "url" "priority")
+    ext_ovars=("gives" "depends" "checkdepends" "optdepends" "pacdeps" "provides" "checkconflicts" "conflicts" "breaks" "replaces" "enhances" "recommends" "suggests")
+    ext_types=("${CARCH}" "${AARCH}" "${DISTRO%:*}" "${DISTRO#*:}" "${DISTRO%:*}_${CARCH}" "${DISTRO#*:}_${CARCH}" "${DISTRO%:*}_${AARCH}" "${DISTRO#*:}_${AARCH}")
     all_ovars=("${ovars[@]}" "arch" "license" "depends" "checkdepends" "optdepends" "pacdeps" "provides" "checkconflicts" "conflicts" "breaks" "replaces" "enhances" "recommends" "suggests" "backup" "repology")
+    mapfile -t -O "${#all_ovars[@]}" all_ovars < <(for i in "${ext_ovars[@]}"; do printf "${i}_%s\n" "${ext_types[@]}"; done)
     srcinfo.parse "${srcinfile}" "${pacname}"
     for o in "${all_ovars[@]}"; do
         unset look lbase

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -132,7 +132,7 @@ function srcinfo.write_details() {
         srcinfo.extract "$1" "${attr}" 1
     done
 
-    srcinfo.get_attr "$1" 'arch' 1 'package_arch' || package_arch=("all")
+    srcinfo.get_attr '' 'arch' 1 'package_arch' || package_arch=("all")
     for a in "${package_arch[@]}"; do
         [[ ${a} == any || ${a} == all ]] && continue
 

--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -39,26 +39,14 @@
 
 { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
 
-function srcinfo.array_build() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local dest="${1}" src="${2}" i keys values
-    declare -p "$2" &> /dev/null || { ignore_stack=true; return 1; }
-    eval "keys=(\"\${!$2[@]}\")"
-    eval "${dest}=()"
-    for i in "${keys[@]}"; do
-        values+=("printf -v '${dest}[${i}]' %s \"\${${src}[${i}]}\";")
-    done
-    eval "${values[*]}"
-}
-
 function srcinfo.extr_globvar() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local attr="${1}" isarray="${2}" outputvar="${3}" ref
+    local attr="${1}" isarray="${2}" outputvar="${3}"
     if ((isarray==1)); then
-        srcinfo.array_build ref "${attr}"
-        if ((${#ref[@]}>=1)); then srcinfo.array_build "${outputvar}" "${attr}"; fi
+        local -n ref="${attr}" out="${outputvar}"
+        if [[ -v ref ]]; then out=("${ref[@]}"); fi
     else
-        if [[ -n ${!attr} ]]; then printf -v "${outputvar}" %s "${!attr}"; fi
+        if [[ -v ${attr} && -n ${!attr} ]]; then printf -v "${outputvar}" %s "${!attr}"; fi
     fi
 }
 
@@ -67,19 +55,21 @@ function srcinfo.extr_fnvar() {
     local funcname="${1}" attr="${2}" isarray="${3}" outputvar="${4}"
     local attr_regex decl r=1
     if ((isarray==1)); then
-        printf -v attr_regex '^[[:space:]]* %s\+?=\(' "${attr}"
+        printf -v attr_regex '[[:space:]]* %s\+?=\(' "${attr}"
     else
-        printf -v attr_regex '^[[:space:]]* %s\+?=[^(]' "${attr}"
+        printf -v attr_regex '[[:space:]]* %s\+?=[^(]' "${attr}"
     fi
     local func_body
-    func_body=$(declare -f "${funcname}" 2> /dev/null)
-    [[ -z ${func_body} ]] && { ignore_stack=true; return 1; }
-    IFS=$'\n' read -r -d '' -a lines <<< "${func_body}"
-    for line in "${lines[@]}"; do
-        [[ ${line} =~ ${attr_regex} ]] || continue
+    mapfile -t func_body < <(declare -f "${funcname}" 2> /dev/null)
+    if [[ -z ${func_body[*]} || ! ${func_body[*]} =~ ${attr_regex} ]]; then
+        { ignore_stack=true; return 1; }
+    fi
+    for line in "${func_body[@]}"; do
+        [[ ${line} =~ ^${attr_regex} ]] || continue
         decl=${line##*([[:space:]])}
         eval "${decl/#${attr}/${outputvar}}"
         r=0
+        break
     done
     { ignore_stack=true; return "${r}"; }
 }
@@ -123,7 +113,7 @@ function srcinfo.extract() {
 
 function srcinfo.write_details() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local attr package_arch a
+    local attr a
     for attr in "${singlevalued[@]}"; do
         srcinfo.extract "$1" "${attr}" 0
     done
@@ -132,8 +122,7 @@ function srcinfo.write_details() {
         srcinfo.extract "$1" "${attr}" 1
     done
 
-    srcinfo.get_attr '' 'arch' 1 'package_arch' || package_arch=("all")
-    for a in "${package_arch[@]}"; do
+    for a in "${arch[@]}"; do
         [[ ${a} == any || ${a} == all ]] && continue
 
         for attr in "${multivalued_arch_attrs[@]}"; do
@@ -155,12 +144,19 @@ function srcinfo.vars() {
     eval "allars+=(${_sums}sums ${_vars}_${_distros} ${_sums}sums_${_distros})"
     eval "allvars+=(gives_${_distros})"
     eval "multivalued_arch_attrs=(${vars} ${_sums}sums ${_vars}_${_distros} ${_sums}sums_${_distros})"
+    multilist=("${multivalued_arch_attrs[@]}")
+    mapfile -t -O "${#multilist[@]}" multilist < <(
+        for i in {amd64,x86_64,arm64,aarch64,armel,arm,armhf,armv7h,i386,i686,mips64el,ppc64el,riscv64,s390x}; do
+            printf "%s_${i}\n" "${multivalued_arch_attrs[@]}"
+        done
+    )
+    export multilist
 }
 
 function srcinfo.write_global() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # shellcheck disable=SC2034
-    local CARCH='CARCH_REPLACE' DISTRO="${DISTRO}" CDISTRO="${CDISTRO}" AARCH='AARCH_REPLACE' var ar aars bar ars rar rep seek multilist
+    local CARCH='CARCH_REPLACE' DISTRO="${DISTRO}" CDISTRO="${CDISTRO}" AARCH='AARCH_REPLACE' var ar aars bar ars rar rep seek
     local -A AARCHS_MAP=(
         ["amd64"]="x86_64"
         ["arm64"]="aarch64"
@@ -183,15 +179,12 @@ function srcinfo.write_global() {
         ["riscv64"]="riscv64"
         ["s390x"]="s390x"
     )
-    multilist=("${multivalued_arch_attrs[@]}")
-    for i in "${multivalued_arch_attrs[@]}"; do
-        for j in {amd64,x86_64,arm64,aarch64,armel,arm,armhf,armv7h,i386,i686,mips64el,ppc64el,riscv64,s390x}; do
-          multilist+=("${i}_${j}")
-        done
-    done
-    for ar in "${multilist[@]}"; do
-        local -n bar="${ar}"
-        if [[ -n ${bar[*]} ]]; then
+    if [[ " ${arch[*]} " != *" all "* && " ${arch[*]} " != *" any "* ]]; then
+        for ar in "${multilist[@]}"; do
+            local -n bar="${ar}"
+            if [[ -z ${bar[*]} || ! ${bar[*]} =~ ARCH_REPLACE ]]; then
+                continue
+            fi
             for ars in "${bar[@]}"; do
                 ars="${ars//+([[:space:]])/ }"
                 ars="${ars#[[:space:]]}"
@@ -201,24 +194,18 @@ function srcinfo.write_global() {
                     for aars in "${arch[@]}"; do
                         if [[ ${ars} =~ AARCH_REPLACE ]]; then
                             seek="AARCH_REPLACE"
-                            if [[ " ${AARCHS_MAP[*]} " =~ ${aars} ]]; then
-                                rep="${aars}"
-                            else
-                                rep="${AARCHS_MAP[${aars}]}"
-                            fi
+                            rep="${AARCHS_MAP[${aars}]:-${aars}}"
                         else
                             seek="CARCH_REPLACE"
-                            if [[ " ${AARCHS_MAP[*]} " =~ ${aars} ]]; then
-                                rep="${CARCHS_MAP[${aars}]}"
-                            else
-                                rep="${aars}"
-                            fi
+                            rep="${CARCHS_MAP[${aars}]:-${aars}}"
                         fi
                         local -n fin="${ar}_${rep}"
                         # shellcheck disable=SC2076
                         if [[ " ${AARCHS_MAP[*]} " =~ " ${ar##*_} " || " ${!AARCHS_MAP[*]} " =~ " ${ar##*_} " || ${ar} == *"x86_64" ]]; then
                             : "${ar}=${ars}"
-                            [[ ${ar} != *"${aars}" ]] && continue
+                            if [[ ${ar} != *"${aars}" ]]; then
+                                continue
+                            fi
                         else
                             : "${ar}_${aars}=${ars}"
                         fi
@@ -232,8 +219,8 @@ function srcinfo.write_global() {
                     fi
                 fi
             done
-        fi
-    done
+        done
+    fi
     local singlevalued=("${allvars[@]}")
     local multivalued=("${allars[@]}")
     printf '%s = %s\n' 'pkgbase' "${pkgbase:-${pkgname}}"
@@ -245,7 +232,6 @@ function srcinfo.write_package() {
     local singlevalued=(gives pkgdesc url priority)
     local multivalued=(arch license depends checkdepends optdepends pacdeps
         provides checkconflicts conflicts breaks replaces enhances recommends suggests backup repology)
-    printf '%s = %s\n' 'pkgname' "$1"
     srcinfo.write_details "$1"
 }
 
@@ -254,8 +240,10 @@ function srcinfo.gen() {
     local pkg
     srcinfo.write_global
     for pkg in "${pkgname[@]}"; do
-        echo
-        srcinfo.write_package "${pkg}"
+        printf '\n%s = %s\n' 'pkgname' "${pkg}"
+        if ((${#pkgname[@]} > 1)); then
+            srcinfo.write_package "${pkg}"
+        fi
     done
 }
 


### PR DESCRIPTION
## Purpose

split packages should be able to access and use the extended array versions of their overrides

## Approach

- fix override to allow extensions
- fix srcinfo to print extensions in children like parents
- speed up processing

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
