### PR TITLE
fix(search): fix origin url index of packages when masking packages

### DIFF
--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -415,6 +415,7 @@ if ((${#any_masks[@]} != 0)); then
     for pkg in "${PACKAGELIST[@]}"; do
         if array.contains any_masks "${pkg}"; then
             unset "PACKAGELIST[$mask_itr]"
+            unset "URLLIST[$mask_itr]"
         fi
         { ignore_stack=true; ((mask_itr++)); }
     done

--- a/misc/scripts/search.sh
+++ b/misc/scripts/search.sh
@@ -420,6 +420,7 @@ if ((${#any_masks[@]} != 0)); then
         { ignore_stack=true; ((mask_itr++)); }
     done
     PACKAGELIST=("${PACKAGELIST[@]}")
+    URLLIST=("${URLLIST[@]}")
     unset mask_itr
 fi
 


### PR DESCRIPTION
## Purpose

The `URLLIST` array wasn't getting properly updated when a package is masked.

This is a very rare edge-case, only affecting a couple of packages on multi-repo setups of rhino linux, usually the first of each repo.

## Approach

Unset the index of `URLLIST` along side `PACKAGELIST`.

## Progress

Done and tested.

## Addendum

I don't like our package masking. I feel like it has always been a bad idea and that there are better ways to get the same result.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
