### PR TITLE
fix({srcinfo,upgrade}.sh): repair split pkg upgrades

### DIFF
--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -405,7 +405,7 @@ function srcinfo.match_pkg() {
         var="${var//./_}"
         declare -n output="${var}"
         if [[ -n ${output[*]} ]]; then
-            if [[ ${search} == "pkgbase" ]]; then
+            if [[ ${search} == "pkgbase" && ${var} == *"_array_pkgbase" ]]; then
                 srcref="pkgbase:${output[0]}"
             elif [[ ${search} == "pkgname" || ${var} == "srcinfo_${pkg}_array_${search}" ]]; then
                 srcref+=("${output[@]}")

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -134,7 +134,7 @@ N="$(nproc)"
             if [[ -n ${_pkgbase} ]]; then
                 localbase="${_pkgbase}"
             else
-                localbase="${i}"
+                unset localbase
             fi
 
             # localver is the current version of the package
@@ -162,7 +162,7 @@ N="$(nproc)"
             IDXMATCH=$(printf "%s\n" "${REPOS[@]}" | awk "\$1 ~ /^${remoterepo//\//\\/}$/ {print NR-1}")
 
             if [[ -n $IDXMATCH ]]; then
-                calc_repo_ver "$remoterepo" "$localbase" \
+                calc_repo_ver "$remoterepo" "${localbase:-${i}}" \
                     && remotever="${comp_repo_ver}"
                 unset comp_repo_ver
                 remoteurl="${REPOS[$IDXMATCH]}"
@@ -185,7 +185,7 @@ N="$(nproc)"
                     if [[ -n $IDXMATCH ]] && ((IDX == IDXMATCH)); then
                         continue
                     else
-                        calc_repo_ver "${REPOS[$IDX]}" "$localbase" \
+                        calc_repo_ver "${REPOS[$IDX]}" "${localbase:-${i}}" \
                             && ver="${comp_repo_ver}"
                         unset comp_repo_ver
                         if ver_compare "$alterver" "$ver"; then
@@ -211,8 +211,8 @@ N="$(nproc)"
 
             if [[ -n $remotever ]]; then
                 if ver_compare "$localver" "$remotever"; then
-                    if [[ -n ${_pkgbase} ]]; then
-                        echo "${_pkgbase}:${i}" | tee -a "${up_list}" > /dev/null
+                    if [[ -n ${localbase} ]]; then
+                        echo "${localbase}:${i}" | tee -a "${up_list}" > /dev/null
                     else
                         echo "$i" | tee -a "${up_list}" > /dev/null
                     fi

--- a/pacstall
+++ b/pacstall
@@ -1233,7 +1233,7 @@ Helpful links:
                 fi
 
                 repo.specify "$REPO"
-                export URL="$REPO/packages/$PACKAGE/$PACKAGE.pacscript"
+                export URL="$REPO/packages/${PACKAGE%:*}/${PACKAGE%:*}.pacscript"
 
                 # shellcheck source=./misc/scripts/get-pacscript.sh
                 if ! source "$SCRIPTDIR/scripts/get-pacscript.sh"; then
@@ -1242,7 +1242,7 @@ Helpful links:
                     continue
                 fi
 
-                fancy_message info $"%b pacscript is downloaded to %b" "$GREEN$PACKAGE$NC" "$GREEN$PWD/$PACKAGE.pacscript$NC"
+                fancy_message info $"%b pacscript is downloaded to %b" "$GREEN$PACKAGE$NC" "$GREEN$PWD/${PACKAGE%:*}.pacscript$NC"
             done
             exit 0
             ;;


### PR DESCRIPTION
## Purpose

![image](https://github.com/user-attachments/assets/1f52b6a9-92a8-49d3-b0d7-8913ccc6e9f6)

## Approach

fix vars that are acting weird:
- fixes download of split package pacscripts
- fixes `_pkgbase` bleeding during upgrade
- fixes split packages reading `pkgbase` var

side note, srcinfo change does *not* need to be brought into programs or pacup

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
