### PR TITLE
fix({fetch-sources,package}.sh): allow `dest` to define extr when `source` doesn't

### DIFF
--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -91,7 +91,7 @@ function genextr_declare() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     unset ext_method ext_deps ext_to_flag
     # shellcheck disable=SC2031,SC2034
-    case "${source_url,,}" in
+    case "${1}" in
         *.zip)
             ext_method="unzip -qo"
             ext_deps=("unzip")

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -247,7 +247,7 @@ for i in "${!source[@]}"; do
             dest_list+=("${to_location}")
         fi
     fi
-    genextr_declare
+    genextr_declare "${source_url,,}"
     unset ext_dep make_dep in_make_deps
     for ext_dep in "${ext_deps[@]}"; do
         in_make_deps=false
@@ -301,7 +301,7 @@ if ! [[ -f "${PACDIR}-no-download-${pkgbase}" ]]; then
                 source_url="${REPO}/packages/${pacname}/${source_url}"
             fi
         fi
-        case "${source_url}" in
+        case "${source_url,,}" in
             *file://*)
                 source_url="${source_url#file://}"
                 source_url="${source_url#git+}"
@@ -319,13 +319,22 @@ if ! [[ -f "${PACDIR}-no-download-${pkgbase}" ]]; then
                 ;;
             *.zip | *.tar.gz | *.tgz | *.tar.bz2 | *.tbz2 | *.tar.bz | *.tbz | *.tar.xz | *.txz | *.tar.zst | *.tzst | *.gz | *.bz2 | *.xz | *.lz | *.lzma | *.zst | *.7z | *.rar | *.lz4 | *.tar)
                 net_down
-                genextr_declare
+                genextr_declare "${source_url,,}"
                 genextr_down
                 ;;
             *)
-                net_down
-                hashcheck_down
-                gather_down
+                case "${dest,,}" in
+                    *.zip | *.tar.gz | *.tgz | *.tar.bz2 | *.tbz2 | *.tar.bz | *.tbz | *.tar.xz | *.txz | *.tar.zst | *.tzst | *.gz | *.bz2 | *.xz | *.lz | *.lzma | *.zst | *.7z | *.rar | *.lz4 | *.tar)
+                        net_down
+                        genextr_declare "${dest,,}"
+                        genextr_down
+                        ;;
+                    *)
+                        net_down
+                        hashcheck_down
+                        gather_down
+                        ;;
+                esac
                 ;;
         esac
         unset expectedHash dest source_url to_location git_branch git_tag git_commit ext_deps ext_method ext_to_flag


### PR DESCRIPTION
## Purpose

if a source has no compression method clearly defined in the URL, pacstall won't try to extract it, and doesn't currently allow dest to ever control extraction method to override that behavior

## Approach

if no compression method is found from `source_url`, then nest down to `dest` to perform the same check, but without `file://`, `.git`/`git+`, or `.deb`; fallback to the old way if `dest` also has no compression method defined

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
