### PR TITLE
feat(pacstall): allow env to define TMPDIR

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -32,7 +32,7 @@ export METADIR="/var/lib/pacstall/metadata"
 export LOGDIR="/var/log/pacstall/error_log"
 printf -v LOGFILE "${LOGDIR}/%(%F_%T)T.log"
 export LOGFILE
-export PACDIR="/tmp/pacstall"
+export PACDIR="${PACSTALL_TMPDIR:-/tmp}/pacstall"
 export SCRIPTDIR="/usr/share/pacstall"
 export STAGEDIR="/usr/src/pacstall"
 export TEXTDOMAIN="pacstall"


### PR DESCRIPTION
## Purpose

Some packages are too big for some device's tmpdirs

## Approach

give an envar for users to override the `/tmp` part of `PACDIR` (so if someone tries `PACSTALL_TMPDIR=/` it won't nuke them)

## Progress

- [x] do it
- [ ] test it

## Addendum

https://github.com/pacstall/pacstall/issues/1324

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
