### PR TITLE
chore(README): remove outdated warning to debs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ sudo apt install pacstall
 
 ### Uninstalling
 
-If you installed Pacstall from the bash script, you can run the command below. If you are unsure how you installed Pacstall, please run `pacstall -U`. If it displays an error message, you have installed it with apt.
+If you installed Pacstall from the bash script, you can run the command below. If you are unsure how you installed Pacstall, please run `pacstall -U`. If it displays an error message, you have installed it with APT.
 
 > [!IMPORTANT]
-> If you installed Pacstall with apt, please make sure to uninstall any packages you may have installed before uninstalling Pacstall.
+> If you installed Pacstall with APT, please make sure to remove any unwanted packages with `pacstall -R foo` before uninstalling. You can run `pacstall -L` to list the currently installed packages.
 
 #### Bash
 ```bash

--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@
 
 ### Features
 
-* Supports creating native packages from binaries, git repositories, appimages, release artifacts, and `.deb` packages.
+* Supports creating native packages from binaries, git repositories, appimages,
+release artifacts, and `.deb` packages.
 * Create high quality prebuilt `.deb` packages for distribution to users.
-* During upgrades, you always get the latest build off of the latest commit from the developer for `-git` packages. No need to wait for the pacscript maintainer to update the script!
-* Ability to install programs from multiple repositories instead of a sole centralized repository.
+* During upgrades, you always get the latest build off of the latest commit
+from the developer for `-git` packages. No need to wait for the pacscript maintainer to update the script!
+* Ability to install programs from multiple repositories instead of a sole
+centralized repository.
 * Powerful and expressive package recipe format.
 
 ---

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 ### Installing
 
 You can run the command below to install Pacstall.
-You can also grab the deb file [here](https://github.com/pacstall/pacstall/releases/latest) but it may be a bit older.
+You can also grab the deb file [here](https://github.com/pacstall/pacstall/releases/latest).
 ```bash
 sudo bash -c "$(curl -fsSL https://pacstall.dev/q/install || wget -q https://pacstall.dev/q/install -O -)"
 ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you installed Pacstall from the bash script, you can run the command below. I
 bash -c "$(curl -fsSL https://pacstall.dev/q/uninstall || wget -q https://pacstall.dev/q/uninstall -O -)"
 ```
 
-#### Apt
+#### APT
 ```bash
 sudo apt remove pacstall
 ```

--- a/README.md
+++ b/README.md
@@ -24,12 +24,11 @@
 
 ### Features
 
-*  Supports binary, git, appimage, building and `.deb` packages
-*  Accelerated package download using [axel](https://github.com/axel-download-accelerator/axel) (optional)
-*  During upgrades, you always get the latest build off of the latest commit from the developer for `-git` packages. No need to wait for the pacscript maintainer to update the script!
-*  Ability to install programs from multiple repositories
-*  Ability to track Pacstall updates from any fork/branch easily
-*  Completions available for `bash` (`ZSH`), and `fish`
+* Supports creating native packages from binaries, git repositories, appimages, release artifacts, and `.deb` packages.
+* Create high quality prebuilt `.deb` packages for distribution to users.
+* During upgrades, you always get the latest build off of the latest commit from the developer for `-git` packages. No need to wait for the pacscript maintainer to update the script!
+* Ability to install programs from multiple repositories instead of a sole centralized repository.
+* Powerful and expressive package recipe format.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sudo apt install pacstall
 If you installed Pacstall from the bash script, you can run the command below. If you are unsure how you installed Pacstall, please run `pacstall -U`. If it displays an error message, you have installed it with APT.
 
 > [!IMPORTANT]
-> If you installed Pacstall with APT, please make sure to remove any unwanted packages with `pacstall -R foo` before uninstalling. You can run `pacstall -L` to list the currently installed packages.
+> If you installed Pacstall with APT, please make sure to remove any unwanted packages with `pacstall -R pkgname` before uninstalling. You can run `pacstall -L` to list the packages currently installed through Pacstall.
 
 #### Bash
 ```bash

--- a/README.md
+++ b/README.md
@@ -35,20 +35,16 @@
 
 ### Installing
 
-We offer 3 ways to install Pacstall: from a bash script, from [the PPR](https://ppr.pacstall.dev), and from a deb:
-
-#### Bash Script
+We offer 3 ways to install Pacstall:
+1. From a bash script:
 ```bash
 sudo bash -c "$(curl -fsSL https://pacstall.dev/q/install || wget -q https://pacstall.dev/q/install -O -)"
 ```
-
-#### PPR
+2. From [the PPR](https://ppr.pacstall.dev):
 ```bash
 sudo apt install pacstall
 ```
-
-#### Manual Download
-You can grab the deb file [here](https://github.com/pacstall/pacstall/releases/latest).
+3. From a `.deb` in our [release assets](https://github.com/pacstall/pacstall/releases/latest).
 
 ### Uninstalling
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@
 release artifacts, and `.deb` packages.
 * Create high quality prebuilt `.deb` packages for distribution to users.
 * During upgrades, you always get the latest build off of the latest commit
-from the developer for `-git` packages. No need to wait for the pacscript maintainer to update the script!
+from the developer for `-git` packages. No need to wait for the pacscript
+maintainer to update the script!
 * Ability to install programs from multiple repositories instead of a sole
 centralized repository.
 * Powerful and expressive package recipe format.
@@ -38,14 +39,19 @@ centralized repository.
 ### Installing
 
 We offer 3 ways to install Pacstall:
+
 1. From a bash script:
+
 ```bash
 sudo bash -c "$(curl -fsSL https://pacstall.dev/q/install || wget -q https://pacstall.dev/q/install -O -)"
 ```
+
 2. From [the PPR](https://ppr.pacstall.dev):
+
 ```bash
 sudo apt install pacstall
 ```
+
 3. From a `.deb` in our [release assets](https://github.com/pacstall/pacstall/releases/latest).
 
 ### Uninstalling

--- a/README.md
+++ b/README.md
@@ -35,18 +35,38 @@
 
 ### Installing
 
-You can run the command below to install Pacstall.
-You can also grab the deb file [here](https://github.com/pacstall/pacstall/releases/latest).
+We offer 3 ways to install Pacstall: from a bash script, from [the PPR](https://ppr.pacstall.dev), and from a deb:
+
+#### Bash Script
 ```bash
 sudo bash -c "$(curl -fsSL https://pacstall.dev/q/install || wget -q https://pacstall.dev/q/install -O -)"
 ```
 
+#### PPR
+```bash
+sudo apt install pacstall
+```
+
+#### Manual Download
+You can grab the deb file [here](https://github.com/pacstall/pacstall/releases/latest).
+
 ### Uninstalling
 
-You can run the command below to uninstall Pacstall.
+If you installed Pacstall from the bash script, you can run the command below. If you are unsure how you installed Pacstall, please run `pacstall -U`. If it displays an error message, you have installed it with apt.
+
+> [!IMPORTANT]
+> If you installed Pacstall with apt, please make sure to uninstall any packages you may have installed before uninstalling Pacstall.
+
+#### Bash
 ```bash
 bash -c "$(curl -fsSL https://pacstall.dev/q/uninstall || wget -q https://pacstall.dev/q/uninstall -O -)"
 ```
+
+#### Apt
+```bash
+sudo apt remove pacstall
+```
+
 ---
 
 ### Basic Commands


### PR DESCRIPTION
## Purpose

Because now we have explicit disallowal of updates in debs, the reasoning behind the original warning is moot.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.