### PR TITLE
chan(package): exit 1 on CI incompat again

### DIFF
--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -79,12 +79,7 @@ fi
 if [[ -n ${compatible[*]} ]]; then
     if ! get_compatible_releases "${compatible[@]}"; then
         cleanup
-        if [[ ${GITHUB_ACTIONS} == "true" ]]; then
-            fancy_message warn "Exiting with exit code '0' on CI"
-            exit 0
-        else
-            exit 1
-        fi
+        exit 1
     fi
 elif [[ -n ${incompatible[*]} ]]; then
     if ! get_incompatible_releases "${incompatible[@]}"; then

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -79,12 +79,22 @@ fi
 if [[ -n ${compatible[*]} ]]; then
     if ! get_compatible_releases "${compatible[@]}"; then
         cleanup
-        [[ ${GITHUB_ACTIONS} == "true" ]] && exit 0 || exit 1
+        if [[ ${GITHUB_ACTIONS} == "true" ]]; then
+            fancy_message warn "Exiting with exit code '0' on CI"
+            exit 0
+        else
+            exit 1
+        fi
     fi
 elif [[ -n ${incompatible[*]} ]]; then
     if ! get_incompatible_releases "${incompatible[@]}"; then
         cleanup
-        [[ ${GITHUB_ACTIONS} == "true" ]] && exit 0 || exit 1
+        if [[ ${GITHUB_ACTIONS} == "true" ]]; then
+            fancy_message warn "Exiting with exit code '0' on CI"
+            exit 0
+        else
+            exit 1
+        fi
     fi
 fi
 

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -84,12 +84,7 @@ if [[ -n ${compatible[*]} ]]; then
 elif [[ -n ${incompatible[*]} ]]; then
     if ! get_incompatible_releases "${incompatible[@]}"; then
         cleanup
-        if [[ ${GITHUB_ACTIONS} == "true" ]]; then
-            fancy_message warn "Exiting with exit code '0' on CI"
-            exit 0
-        else
-            exit 1
-        fi
+        exit 1
     fi
 fi
 


### PR DESCRIPTION
## Purpose

Sometimes I'd like to see in the CI logs that pacstall is "succeeding" because of the `GITHUB_ACTION` variable.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.