### PR TITLE
ref(*): allow local installs to be picked up by upgrade

### DIFF
--- a/misc/po/pacstall.pot
+++ b/misc/po/pacstall.pot
@@ -6,197 +6,201 @@ msgstr ""
 "Content-Transfer-Encoding: ENCODING\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: pacstall:273 misc/scripts/build.sh:163 misc/scripts/build.sh:686
+#: pacstall:286 misc/scripts/build.sh:163 misc/scripts/build.sh:688
 #: misc/scripts/fetch-sources.sh:175 misc/scripts/fetch-sources.sh:735
-#: misc/scripts/fetch-sources.sh:765 misc/scripts/package-base.sh:163
-#: misc/scripts/package-base.sh:184
+#: misc/scripts/fetch-sources.sh:765 misc/scripts/package-base.sh:173
+#: misc/scripts/package-base.sh:194
 msgid "Cleaning up"
 msgstr ""
 
-#: pacstall:367
+#: pacstall:380
 msgid "Suggested solution(s)"
 msgstr ""
 
-#: pacstall:401
+#: pacstall:414
 msgid "Packagelist not found"
 msgstr ""
 
-#: pacstall:402 pacstall:411
+#: pacstall:415 pacstall:424
 msgid "Confirm that '%b' exists"
 msgstr ""
 
-#: pacstall:404
+#: pacstall:417
 msgid "Failed to download file, check your connection"
 msgstr ""
 
-#: pacstall:410
+#: pacstall:423
 msgid "The URL cannot be found"
 msgstr ""
 
-#: pacstall:418
+#: pacstall:431
 msgid "Failed with http code %s"
 msgstr ""
 
-#: pacstall:419
+#: pacstall:432
 msgid "Confirm that '%b' is accessible"
 msgstr ""
 
-#: pacstall:643
+#: pacstall:656
 msgid "Reading input from pipe"
 msgstr ""
 
-#: pacstall:702
+#: pacstall:715
 msgid "Only one command flag can be used at a time"
 msgstr ""
 
-#: pacstall:740
+#: pacstall:753
 msgid "Pacstall is already running another instance"
 msgstr ""
 
-#: pacstall:746
+#: pacstall:759
 msgid "The other instance has finished running, unlocking"
 msgstr ""
 
-#: pacstall:755
+#: pacstall:768
 msgid "Prompts are disabled"
 msgstr ""
 
-#: pacstall:762
+#: pacstall:775
 msgid "Package will be built and not installed"
 msgstr ""
 
-#: pacstall:832 pacstall:905 pacstall:967 pacstall:1008 pacstall:1026
-#: pacstall:1200 pacstall:1256 misc/scripts/query-info.sh:28
+#: pacstall:851 pacstall:924 pacstall:986 pacstall:1027 pacstall:1045
+#: pacstall:1219 pacstall:1276 pacstall:1302 misc/scripts/query-info.sh:28
 msgid "You failed to specify a package"
 msgstr ""
 
-#: pacstall:837
+#: pacstall:856
 msgid "The installation of %s was interrupted, removing files"
 msgstr ""
 
-#: pacstall:874 misc/scripts/package-base.sh:129
+#: pacstall:893 misc/scripts/package-base.sh:139
 msgid "%s does not exist"
 msgstr ""
 
-#: pacstall:912
+#: pacstall:931
 msgid "Payload not found"
 msgstr ""
 
-#: pacstall:925 pacstall:972 pacstall:1012 pacstall:1133 pacstall:1210
-#: pacstall:1243
+#: pacstall:944 pacstall:991 pacstall:1031 pacstall:1152 pacstall:1229
+#: pacstall:1263
 msgid "Could not connect to the internet"
 msgstr ""
 
-#: pacstall:926 pacstall:973 pacstall:1013 pacstall:1134 pacstall:1211
-#: pacstall:1244
+#: pacstall:945 pacstall:992 pacstall:1032 pacstall:1153 pacstall:1230
+#: pacstall:1264
 msgid "Confirm that the URLs '%b' or '%b' are accessible"
 msgstr ""
 
-#: pacstall:942 pacstall:1225 misc/scripts/upgrade.sh:276
+#: pacstall:961 pacstall:1244 misc/scripts/upgrade.sh:282
 msgid "Failed to download the %b pacscript"
 msgstr ""
 
-#: pacstall:943 pacstall:1226
+#: pacstall:962 pacstall:1245
 msgid "Confirm that the package exists by running '%b'"
 msgstr ""
 
-#: pacstall:943 pacstall:1226
+#: pacstall:962 pacstall:1245
 msgid "Check your internet connection"
 msgstr ""
 
-#: pacstall:949 misc/scripts/package-base.sh:153
-#: misc/scripts/package-base.sh:177
+#: pacstall:968 misc/scripts/package-base.sh:163
+#: misc/scripts/package-base.sh:187
 msgid "Failed to install %b"
 msgstr ""
 
-#: pacstall:1035
+#: pacstall:1054
 msgid "Failed to remove %b"
 msgstr ""
 
-#: pacstall:1056
+#: pacstall:1075
 msgid "You failed to specify a repo to add"
 msgstr ""
 
-#: pacstall:1057
+#: pacstall:1076
 msgid "Add a repository in the following format:"
 msgstr ""
 
-#: pacstall:1057 pacstall:1078
+#: pacstall:1076 pacstall:1097
 msgid ""
 "Consult the pacstall man page by running '%b', and searching for the term "
 "'%b'"
 msgstr ""
 
-#: pacstall:1077
+#: pacstall:1096
 msgid "You failed to specify a repo to remove"
 msgstr ""
 
-#: pacstall:1078
+#: pacstall:1097
 msgid "Remove a repository in the following format:"
 msgstr ""
 
-#: pacstall:1102
+#: pacstall:1121
 msgid "%s is not a git repository"
 msgstr ""
 
-#: pacstall:1139
+#: pacstall:1158
 msgid ""
 "The repository you are trying to upgrade to contains a version of pacstall "
 "that cannot be updated from %b"
 msgstr ""
 
-#: pacstall:1140
+#: pacstall:1159
 msgid ""
 "Visit %s for more information on how to reinstall. Most packages will also "
 "need to be reinstalled"
 msgstr ""
 
-#: pacstall:1148
+#: pacstall:1167
 msgid ""
 "Pacstall was installed from a %s, and cannot be updated with this command"
 msgstr ""
 
-#: pacstall:1149
+#: pacstall:1168
 msgid "Install the latest %b from the %b repository"
 msgstr ""
 
-#: pacstall:1149
+#: pacstall:1168
 msgid "Install the latest %b with the command '%b'"
 msgstr ""
 
-#: pacstall:1157 pacstall:1238
+#: pacstall:1176 pacstall:1258
 msgid "Invalid argument '%s'"
 msgstr ""
 
-#: pacstall:1169
+#: pacstall:1188
 msgid "Nothing installed yet"
 msgstr ""
 
-#: pacstall:1230
+#: pacstall:1249
 msgid "%b pacscript is downloaded to %b"
 msgstr ""
 
-#: pacstall:1260 misc/scripts/query-info.sh:33
+#: pacstall:1280 pacstall:1307 misc/scripts/query-info.sh:33
 msgid "Package is not installed"
 msgstr ""
 
-#: pacstall:1294
+#: pacstall:1319
+msgid "'%b' is not a valid option, use '%b' or '%b'"
+msgstr ""
+
+#: pacstall:1342
 msgid "Keeping build files"
 msgstr ""
 
-#: pacstall:1299
+#: pacstall:1347
 msgid "Skipping check() if present"
 msgstr ""
 
-#: pacstall:1304
+#: pacstall:1352
 msgid "Downloading package entries quietly"
 msgstr ""
 
-#: pacstall:1309
+#: pacstall:1357
 msgid "Building package without bwrap sandbox"
 msgstr ""
 
-#: pacstall:1310
+#: pacstall:1358
 msgid "Be cautious, this exposes your system to potential harm"
 msgstr ""
 
@@ -261,7 +265,7 @@ msgstr ""
 
 #: misc/scripts/build.sh:95 misc/scripts/build.sh:100
 #: misc/scripts/fetch-sources.sh:687 misc/scripts/fetch-sources.sh:700
-#: misc/scripts/package.sh:225
+#: misc/scripts/package.sh:227
 msgid "%b [required]"
 msgstr ""
 
@@ -270,7 +274,7 @@ msgid "%b [remote]"
 msgstr ""
 
 #: misc/scripts/build.sh:109 misc/scripts/fetch-sources.sh:696
-#: misc/scripts/package.sh:220
+#: misc/scripts/package.sh:222
 msgid "%b [installed]"
 msgstr ""
 
@@ -292,7 +296,7 @@ msgstr ""
 msgid "%b has exceeded the maximum number of optional dependencies. Skipping"
 msgstr ""
 
-#: misc/scripts/build.sh:217 misc/scripts/package-base.sh:140
+#: misc/scripts/build.sh:217 misc/scripts/package-base.sh:150
 msgid "Selecting packages %b"
 msgstr ""
 
@@ -316,39 +320,39 @@ msgstr ""
 msgid "Packaging %b as %b"
 msgstr ""
 
-#: misc/scripts/build.sh:367 misc/scripts/package-base.sh:149
+#: misc/scripts/build.sh:367 misc/scripts/package-base.sh:159
 msgid "Packaging %b"
 msgstr ""
 
-#: misc/scripts/build.sh:591
+#: misc/scripts/build.sh:594
 msgid "Empty key... Skipping"
 msgstr ""
 
-#: misc/scripts/build.sh:597
+#: misc/scripts/build.sh:600
 msgid "'%s' cannot contain empty path... Skipping"
 msgstr ""
 
-#: misc/scripts/build.sh:601 misc/scripts/build.sh:609
+#: misc/scripts/build.sh:604 misc/scripts/build.sh:612
 msgid "'%s' cannot contain path starting with '/'... Skipping"
 msgstr ""
 
-#: misc/scripts/build.sh:604
+#: misc/scripts/build.sh:607
 msgid "'%s' is inside the package... Skipping"
 msgstr ""
 
-#: misc/scripts/build.sh:683
+#: misc/scripts/build.sh:685
 msgid "Failed to install %s deb"
 msgstr ""
 
-#: misc/scripts/build.sh:707
+#: misc/scripts/build.sh:710
 msgid "Package built at %b"
 msgstr ""
 
-#: misc/scripts/build.sh:709 misc/scripts/package.sh:50
+#: misc/scripts/build.sh:712 misc/scripts/package.sh:50
 msgid "Moving %b to %b"
 msgstr ""
 
-#: misc/scripts/build.sh:726
+#: misc/scripts/build.sh:729
 msgid "Repacking %b"
 msgstr ""
 
@@ -585,11 +589,11 @@ msgstr ""
 msgid "Could not run %s hook successfully"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:373 misc/scripts/package.sh:386
+#: misc/scripts/fetch-sources.sh:373 misc/scripts/package.sh:397
 msgid "Performing post install operations"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:389 misc/scripts/package.sh:387
+#: misc/scripts/fetch-sources.sh:389 misc/scripts/package.sh:398
 msgid "Storing pacscript"
 msgstr ""
 
@@ -597,7 +601,7 @@ msgstr ""
 msgid "Could not enter into %b"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:400 misc/scripts/package.sh:401
+#: misc/scripts/fetch-sources.sh:400 misc/scripts/package.sh:412
 msgid "Done installing %b"
 msgstr ""
 
@@ -647,7 +651,7 @@ msgstr ""
 msgid "Run '%b'"
 msgstr ""
 
-#: misc/scripts/get-pacscript.sh:38 misc/scripts/upgrade.sh:257
+#: misc/scripts/get-pacscript.sh:38 misc/scripts/upgrade.sh:263
 msgid "Could not enter %s"
 msgstr ""
 
@@ -675,31 +679,31 @@ msgstr ""
 msgid "Interrupted, cleaning up"
 msgstr ""
 
-#: misc/scripts/package-base.sh:93
+#: misc/scripts/package-base.sh:103
 msgid "Found pkgbase: %b"
 msgstr ""
 
-#: misc/scripts/package-base.sh:119
+#: misc/scripts/package-base.sh:129
 msgid "%b has exceeded the maximum number of packages to build. Skipping"
 msgstr ""
 
-#: misc/scripts/package-base.sh:199
+#: misc/scripts/package-base.sh:209
 msgid "%b is not an integer. Falling back to 1"
 msgstr ""
 
-#: misc/scripts/package-base.sh:208
+#: misc/scripts/package-base.sh:218
 msgid "(%b) Do you want to view/edit the pacscript?"
 msgstr ""
 
-#: misc/scripts/package-base.sh:221
+#: misc/scripts/package-base.sh:231
 msgid "Editor not found, falling back to '%s'"
 msgstr ""
 
-#: misc/scripts/package-base.sh:226
+#: misc/scripts/package-base.sh:236
 msgid "Sourcing pacscript"
 msgstr ""
 
-#: misc/scripts/package-base.sh:249
+#: misc/scripts/package-base.sh:259
 msgid "Could not source pacscript"
 msgstr ""
 
@@ -765,31 +769,31 @@ msgstr ""
 msgid "Checking pacstall dependencies"
 msgstr ""
 
-#: misc/scripts/package.sh:213
+#: misc/scripts/package.sh:215
 msgid "%b [update]"
 msgstr ""
 
-#: misc/scripts/package.sh:215 misc/scripts/package.sh:226
+#: misc/scripts/package.sh:217 misc/scripts/package.sh:228
 msgid "Failed to install dependency (%s from %s)"
 msgstr ""
 
-#: misc/scripts/package.sh:240
+#: misc/scripts/package.sh:242
 msgid "%s is associated with multiple source entries"
 msgstr ""
 
-#: misc/scripts/package.sh:274
+#: misc/scripts/package.sh:276
 msgid "Retrieving packages"
 msgstr ""
 
-#: misc/scripts/package.sh:363
+#: misc/scripts/package.sh:374
 msgid "Running functions"
 msgstr ""
 
-#: misc/scripts/package.sh:368
+#: misc/scripts/package.sh:379
 msgid "Could not %s %s properly"
 msgstr ""
 
-#: misc/scripts/package.sh:376 misc/scripts/package.sh:391
+#: misc/scripts/package.sh:387 misc/scripts/package.sh:402
 msgid "Could not enter into %s"
 msgstr ""
 
@@ -821,7 +825,7 @@ msgstr ""
 msgid "Installing %b"
 msgstr ""
 
-#: misc/scripts/query-info.sh:99
+#: misc/scripts/query-info.sh:101
 msgid "Key '%s' does not exist"
 msgstr ""
 
@@ -834,45 +838,45 @@ msgid ""
 "You may have dangling PPAs on your system. You can remove them using '%b'"
 msgstr ""
 
-#: misc/scripts/search.sh:252 misc/scripts/search.sh:254
-#: misc/scripts/search.sh:286
+#: misc/scripts/search.sh:256 misc/scripts/search.sh:258
+#: misc/scripts/search.sh:290
 msgid "There is no package with the name %b in the repo %b"
 msgstr ""
 
-#: misc/scripts/search.sh:302
+#: misc/scripts/search.sh:306
 msgid "%b is not on your repo list or does not exist"
 msgstr ""
 
-#: misc/scripts/search.sh:357 misc/scripts/search.sh:438
-#: misc/scripts/search.sh:469
+#: misc/scripts/search.sh:361 misc/scripts/search.sh:444
+#: misc/scripts/search.sh:475
 msgid "There is no package with the name %b"
 msgstr ""
 
-#: misc/scripts/search.sh:375
+#: misc/scripts/search.sh:379
 msgid "Add %s to the local repo absolute path on %b"
 msgstr ""
 
-#: misc/scripts/search.sh:379
+#: misc/scripts/search.sh:383
 msgid "Replace '~' with the full home path on %b"
 msgstr ""
 
-#: misc/scripts/search.sh:385
+#: misc/scripts/search.sh:389
 msgid "Pacstall repo line improperly formatted: %b"
 msgstr ""
 
-#: misc/scripts/search.sh:386 misc/scripts/search.sh:391
+#: misc/scripts/search.sh:390 misc/scripts/search.sh:395
 msgid "You can remove or fix the URL by editing %b"
 msgstr ""
 
-#: misc/scripts/search.sh:390
+#: misc/scripts/search.sh:394
 msgid "Cannot connect to Pacstall repo: %b"
 msgstr ""
 
-#: misc/scripts/search.sh:499
+#: misc/scripts/search.sh:505
 msgid "%bDo you want to %s %b from the official repo?"
 msgstr ""
 
-#: misc/scripts/search.sh:517
+#: misc/scripts/search.sh:523
 msgid "%bDo you want to %s %b from the repo %b?"
 msgstr ""
 
@@ -920,7 +924,7 @@ msgstr ""
 msgid "Checking for updates"
 msgstr ""
 
-#: misc/scripts/upgrade.sh:109 misc/scripts/upgrade.sh:235
+#: misc/scripts/upgrade.sh:109 misc/scripts/upgrade.sh:240
 msgid "Nothing to upgrade"
 msgstr ""
 
@@ -932,14 +936,14 @@ msgstr ""
 msgid "Checking versions"
 msgstr ""
 
-#: misc/scripts/upgrade.sh:175
+#: misc/scripts/upgrade.sh:180
 msgid "Package %b is not on %b anymore"
 msgstr ""
 
-#: misc/scripts/upgrade.sh:238
+#: misc/scripts/upgrade.sh:243
 msgid "Packages can be upgraded"
 msgstr ""
 
-#: misc/scripts/upgrade.sh:262
+#: misc/scripts/upgrade.sh:268
 msgid "Do you want to upgrade %b?"
 msgstr ""

--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -846,6 +846,8 @@ function write_meta() {
         if [[ -n ${pBRANCH} ]]; then
             echo "_remotebranch=\"$pBRANCH\""
         fi
+    else
+        echo '_remoterepo="orphan"'
     fi
     if [[ -n ${pacdeps[*]} ]]; then
         _pacdeps=("${pacdeps[@]}")

--- a/misc/scripts/dep-tree.sh
+++ b/misc/scripts/dep-tree.sh
@@ -58,11 +58,11 @@ function dep_tree.load_traits() {
     local -n out_arr
     pkg="${1:?No pkg given to dep_tree.load_traits}"
     out_arr="${2:?No arr given to dep_tree.load_traits}"
-    unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask 2> /dev/null
+    unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask _upgrade 2> /dev/null
     # shellcheck disable=SC1090
     source "${METADIR}/${pkg}"
 
-    if [[ -z ${_remoterepo} ]]; then
+    if ! ${_upgrade}; then
         out_arr['upgrade']=false
     else
         out_arr['upgrade']=true
@@ -158,7 +158,7 @@ function dep_tree.trim_pacdeps() {
     local -n merged_array="${1:?Pass array to dep_tree.trim_pacdeps}"
     local i z
     for i in "${merged_array[@]}"; do
-        unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask 2> /dev/null
+        unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask _upgrade 2> /dev/null
         # shellcheck disable=SC1090
         source "${METADIR}/${i}"
         if [[ -n ${_pacdeps[*]} ]]; then

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -92,7 +92,9 @@ fi
 if [[ -n ${_mask[*]} ]]; then
     mask="${_mask[*]}"
 fi
-
+if ! ${_upgrade}; then
+    upg="hold"
+fi
 if [[ -n ${QUERY} ]]; then
     query="${!QUERY}"
     if [[ -z ${query} ]]; then
@@ -138,6 +140,9 @@ if [[ -v dependencies ]]; then
     echo -e "${BGreen}dependencies${NC}: ${dependencies}"
 fi
 echo -e "${BGreen}install type${NC}: ${install_type}"
+if [[ -v upg ]]; then
+    echo -e "${BGreen}upgrade${NC}: ${upg}"
+fi
 if [[ ${PACKAGE} == *"-deb" ]]; then
     echo -e "${BGreen}modified by pacstall${NC}: ${mbp}"
 fi

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -129,7 +129,7 @@ N="$(nproc)"
         ((n = n % N))
         ((n++ == 0)) && wait && stty "$tty_settings"
         (
-            unset _pkgbase
+            unset _pkgbase _remoterepo
             source "$METADIR/$i"
             if [[ -n ${_pkgbase} ]]; then
                 localbase="${_pkgbase}"
@@ -142,6 +142,11 @@ N="$(nproc)"
             # if localver does not end with the correct pacstall version format, append it
             [[ ! $localver =~ -pacstall[0-9]+$ && ! $localver =~ -pacstall[0-9]+~git[a-zA-Z0-9_-]{8}$ ]] && localver="${localver}-pacstall1"
 
+            if [[ -z "${_remoterepo}" ]]; then
+                _remoterepo="orphan"
+                sudo sed -i '/_remotebranch=/d' "$METADIR/$i"
+                echo '_remoterepo="orphan"' | sudo tee -a "$METADIR/$i" > /dev/null
+            fi
             case "${_remoterepo}" in
                 *"github.com"*)
                     remoterepo="${_remoterepo/'github.com'/'raw.githubusercontent.com'}/${_remotebranch}" ;;

--- a/pacstall
+++ b/pacstall
@@ -616,7 +616,7 @@ function getMasks() {
         if [[ -n ${_mask[*]} ]]; then
             masks+=("${_mask[@]}")
         fi
-        unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask 2> /dev/null
+        unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask _upgrade 2> /dev/null
     done
 }
 
@@ -635,7 +635,7 @@ function getMasks_offending_pkg() {
                 return 0
             fi
         fi
-        unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask 2> /dev/null
+        unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask _upgrade 2> /dev/null
     done
     { ignore_stack=true; return 1; }
 }
@@ -687,7 +687,7 @@ done
 
 # Remove duplicates
 declare -A arg_map=(
-    ["--install"]="-I" ["--search"]="-S" ["--remove"]="-R" ["--download"]="-D"
+    ["--install"]="-I" ["--search"]="-S" ["--remove"]="-R" ["--download"]="-D" ["--mark"]="-M"
     ["--add-repo"]="-A" ["--remove-repo"]="-Rr" ["--update"]="-U" ["--list"]="-L" ["--list-upgrades"]="-Lu"
     ["--upgrade"]="-Up" ["--search-description"]="-Sd" ["--search-info"]="-Si" ["--cache-info"]="-Ci"
     ["--quality-assurance"]="-Qa" ["--tree"]="-T" ["--version"]="-V" ["--help"]="-h" ["--build"]="-B"
@@ -704,8 +704,8 @@ for arg in "${argument_list[@]}"; do
 done
 
 # Check if only one command flag is being used
-short_commands=("-I" "-S" "-R" "-D" "-A" "-Rr" "-U" "-L" "-Lu" "-Up" "-Qa" "-Sd" "-Si" "-Ci" "-T" "-V" "-h")
-long_commands=("--install" "--search" "--remove" "--download" "--add-repo" "--remove-repo" "--update" "--list" "--list-upgrades" "--upgrade" "--quality-assurance" "--search-description" "--search-info" "--cache-info" "--tree" "--version" "--help")
+short_commands=("-I" "-S" "-R" "-D" "-A" "-Rr" "-U" "-L" "-Lu" "-Up" "-Qa" "-Sd" "-Si" "-Ci" "-M" "-T" "-V" "-h")
+long_commands=("--install" "--search" "--remove" "--download" "--add-repo" "--remove-repo" "--update" "--list" "--list-upgrades" "--upgrade" "--quality-assurance" "--search-description" "--search-info" "--cache-info" "--mark" "--tree" "--version" "--help")
 commands=("${short_commands[@]}" "${long_commands[@]}")
 matches=($(comm -12 <(sort <(printf "%s\n" "${unique_argument_list[@]}")) <(sort <(printf "%s\n" "${commands[@]}"))))
 if ((${#matches[@]} <= 1)); then
@@ -777,7 +777,7 @@ while [[ $1 != "--" ]]; do
             ;;
 
         -h | --help)
-            echo -e "Usage: pacstall [-x] [-h] {-I,-S,-R,-D,-A,-Rr,-U,-L,-Lu,-Up,-Qa,-Sd,-Si,-Ci,-T,-V} [-P] [-K] [-B] [-Nc] [-Q] [-Ns]
+            echo -e "Usage: pacstall [-x] [-h] {-I,-S,-R,-D,-A,-Rr,-U,-L,-Lu,-Up,-Qa,-Sd,-Si,-Ci,-M,-T,-V} [-P] [-K] [-B] [-Nc] [-Q] [-Ns]
 
 An AUR inspired package manager for Ubuntu.
 
@@ -810,6 +810,8 @@ Commands:
         Query information about a remote package.
     ${BOLD}-Ci${NC}, ${BOLD}--cache-info${NC} <package>
         Query information about an installed package.
+    ${BOLD}-M${NC}, ${BOLD}--mark${NC} <package> {hold|unhold}
+        Toggle upgrade checking of an installed package.
     ${BOLD}-T${NC}, ${BOLD}--tree${NC} <package>
         Display a tree graph of an installed package.
     ${BOLD}-V${NC}, ${BOLD}--version${NC}
@@ -1191,7 +1193,7 @@ Helpful links:
 
             if [[ -t 1 ]]; then
                 for pkg in "${packages_installed[@]}"; do
-                    unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _maintainer _mask 2> /dev/null
+                    unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _maintainer _mask _upgrade 2> /dev/null
                     source ./"${pkg}"
                     echo -e "${BYellow}~${NC} ${BGreen}${_name}${BPurple}@${BCyan}${_version}${NC}"
                     if [[ -n ${_gives} ]]; then
@@ -1199,7 +1201,7 @@ Helpful links:
                     fi
                     echo -e "   ${BBlue}maintainer${NC}   : ${BOLD}${_maintainer:-$(dpkg-query '--showformat=${Maintainer}\n' --show "${_gives:-$_name}")}${NC}"
                     echo -e "   ${BBlue}size${NC}         : ${BOLD}${_install_size:-unknown}${NC}"
-                    echo -e "   ${BBlue}repository${NC}   : ${BOLD}${_remoterepo:-local}${NC}"
+                    echo -e "   ${BBlue}repository${NC}   : ${BOLD}${_remoterepo:-orphan}${NC}"
                     echo -e "   ${BBlue}install date${NC} : ${BOLD}${_date:-unknown}${NC}"
                     if [[ ${pkg} != "${packages_installed[-1]}" ]]; then
                         echo
@@ -1290,6 +1292,34 @@ Helpful links:
             QUERY=$3
             # shellcheck source=./misc/scripts/query-info.sh
             source "$SCRIPTDIR/scripts/query-info.sh"
+            exit 0
+            ;;
+
+        -M | --mark)
+            PACKAGE=$2
+            STATE=$3
+            if [[ -z $PACKAGE ]]; then
+                fancy_message error $"You failed to specify a package"
+                exit 1
+            fi
+
+            if [[ ! -f "$METADIR/$PACKAGE" ]]; then
+                fancy_message error $"Package is not installed"
+                exit 1
+            fi
+            case "${STATE}" in
+                hold)
+                    sudo sed -i '/_upgrade=/d' "$METADIR/$PACKAGE"
+                    echo "_upgrade=false" | sudo tee -a "$METADIR/$PACKAGE" > /dev/null
+                    ;;
+                unhold)
+                    sudo sed -i '/_upgrade=/d' "$METADIR/$PACKAGE"
+                    ;;
+                *)
+                    fancy_message error $"'%b' is not a valid option, use '%b' or '%b'" "${STATE}" "hold" "unhold"
+                    exit 1
+                    ;;
+            esac
             exit 0
             ;;
 


### PR DESCRIPTION
## Purpose

if a pacscript is local installed, it won't ever get checked for upgrades (problem if using double click mime install)

## Approach

- treat locals like orphans
- add new `-M`/`--mark` command to set packages to be held from upgrading

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
