### PR TITLE
fix(*): respect TMPDIR override

### DIFF
--- a/misc/po/pacstall.pot
+++ b/misc/po/pacstall.pot
@@ -6,201 +6,206 @@ msgstr ""
 "Content-Transfer-Encoding: ENCODING\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
-#: pacstall:286 misc/scripts/build.sh:163 misc/scripts/build.sh:688
+#: pacstall:287 misc/scripts/build.sh:163 misc/scripts/build.sh:688
 #: misc/scripts/fetch-sources.sh:175 misc/scripts/fetch-sources.sh:735
 #: misc/scripts/fetch-sources.sh:765 misc/scripts/package-base.sh:173
 #: misc/scripts/package-base.sh:194
 msgid "Cleaning up"
 msgstr ""
 
-#: pacstall:380
+#: pacstall:381
 msgid "Suggested solution(s)"
 msgstr ""
 
-#: pacstall:414
+#: pacstall:415
 msgid "Packagelist not found"
 msgstr ""
 
-#: pacstall:415 pacstall:424
+#: pacstall:416 pacstall:425
 msgid "Confirm that '%b' exists"
 msgstr ""
 
-#: pacstall:417
+#: pacstall:418
 msgid "Failed to download file, check your connection"
 msgstr ""
 
-#: pacstall:423
+#: pacstall:424
 msgid "The URL cannot be found"
 msgstr ""
 
-#: pacstall:431
+#: pacstall:432
 msgid "Failed with http code %s"
 msgstr ""
 
-#: pacstall:432
+#: pacstall:433
 msgid "Confirm that '%b' is accessible"
 msgstr ""
 
-#: pacstall:656
+#: pacstall:657 misc/scripts/package.sh:387 misc/scripts/package.sh:402
+#: misc/scripts/update.sh:47
+msgid "Could not enter into %s"
+msgstr ""
+
+#: pacstall:663
 msgid "Reading input from pipe"
 msgstr ""
 
-#: pacstall:715
+#: pacstall:722
 msgid "Only one command flag can be used at a time"
 msgstr ""
 
-#: pacstall:753
+#: pacstall:760
 msgid "Pacstall is already running another instance"
 msgstr ""
 
-#: pacstall:759
+#: pacstall:766
 msgid "The other instance has finished running, unlocking"
 msgstr ""
 
-#: pacstall:768
+#: pacstall:775
 msgid "Prompts are disabled"
 msgstr ""
 
-#: pacstall:775
+#: pacstall:782
 msgid "Package will be built and not installed"
 msgstr ""
 
-#: pacstall:851 pacstall:924 pacstall:986 pacstall:1027 pacstall:1045
-#: pacstall:1219 pacstall:1276 pacstall:1302 misc/scripts/query-info.sh:28
+#: pacstall:858 pacstall:931 pacstall:993 pacstall:1034 pacstall:1052
+#: pacstall:1226 pacstall:1283 pacstall:1309 misc/scripts/query-info.sh:28
 msgid "You failed to specify a package"
 msgstr ""
 
-#: pacstall:856
+#: pacstall:863
 msgid "The installation of %s was interrupted, removing files"
 msgstr ""
 
-#: pacstall:893 misc/scripts/package-base.sh:139
+#: pacstall:900 misc/scripts/package-base.sh:139
 msgid "%s does not exist"
 msgstr ""
 
-#: pacstall:931
+#: pacstall:938
 msgid "Payload not found"
 msgstr ""
 
-#: pacstall:944 pacstall:991 pacstall:1031 pacstall:1152 pacstall:1229
-#: pacstall:1263
+#: pacstall:951 pacstall:998 pacstall:1038 pacstall:1159 pacstall:1236
+#: pacstall:1270
 msgid "Could not connect to the internet"
 msgstr ""
 
-#: pacstall:945 pacstall:992 pacstall:1032 pacstall:1153 pacstall:1230
-#: pacstall:1264
+#: pacstall:952 pacstall:999 pacstall:1039 pacstall:1160 pacstall:1237
+#: pacstall:1271
 msgid "Confirm that the URLs '%b' or '%b' are accessible"
 msgstr ""
 
-#: pacstall:961 pacstall:1244 misc/scripts/upgrade.sh:282
+#: pacstall:968 pacstall:1251 misc/scripts/upgrade.sh:282
 msgid "Failed to download the %b pacscript"
 msgstr ""
 
-#: pacstall:962 pacstall:1245
+#: pacstall:969 pacstall:1252
 msgid "Confirm that the package exists by running '%b'"
 msgstr ""
 
-#: pacstall:962 pacstall:1245
+#: pacstall:969 pacstall:1252
 msgid "Check your internet connection"
 msgstr ""
 
-#: pacstall:968 misc/scripts/package-base.sh:163
+#: pacstall:975 misc/scripts/package-base.sh:163
 #: misc/scripts/package-base.sh:187
 msgid "Failed to install %b"
 msgstr ""
 
-#: pacstall:1054
+#: pacstall:1061
 msgid "Failed to remove %b"
 msgstr ""
 
-#: pacstall:1075
+#: pacstall:1082
 msgid "You failed to specify a repo to add"
 msgstr ""
 
-#: pacstall:1076
+#: pacstall:1083
 msgid "Add a repository in the following format:"
 msgstr ""
 
-#: pacstall:1076 pacstall:1097
+#: pacstall:1083 pacstall:1104
 msgid ""
 "Consult the pacstall man page by running '%b', and searching for the term "
 "'%b'"
 msgstr ""
 
-#: pacstall:1096
+#: pacstall:1103
 msgid "You failed to specify a repo to remove"
 msgstr ""
 
-#: pacstall:1097
+#: pacstall:1104
 msgid "Remove a repository in the following format:"
 msgstr ""
 
-#: pacstall:1121
+#: pacstall:1128
 msgid "%s is not a git repository"
 msgstr ""
 
-#: pacstall:1158
+#: pacstall:1165
 msgid ""
 "The repository you are trying to upgrade to contains a version of pacstall "
 "that cannot be updated from %b"
 msgstr ""
 
-#: pacstall:1159
+#: pacstall:1166
 msgid ""
 "Visit %s for more information on how to reinstall. Most packages will also "
 "need to be reinstalled"
 msgstr ""
 
-#: pacstall:1167
+#: pacstall:1174
 msgid ""
 "Pacstall was installed from a %s, and cannot be updated with this command"
 msgstr ""
 
-#: pacstall:1168
+#: pacstall:1175
 msgid "Install the latest %b from the %b repository"
 msgstr ""
 
-#: pacstall:1168
+#: pacstall:1175
 msgid "Install the latest %b with the command '%b'"
 msgstr ""
 
-#: pacstall:1176 pacstall:1258
+#: pacstall:1183 pacstall:1265
 msgid "Invalid argument '%s'"
 msgstr ""
 
-#: pacstall:1188
+#: pacstall:1195
 msgid "Nothing installed yet"
 msgstr ""
 
-#: pacstall:1249
+#: pacstall:1256
 msgid "%b pacscript is downloaded to %b"
 msgstr ""
 
-#: pacstall:1280 pacstall:1307 misc/scripts/query-info.sh:33
+#: pacstall:1287 pacstall:1314 misc/scripts/query-info.sh:33
 msgid "Package is not installed"
 msgstr ""
 
-#: pacstall:1319
+#: pacstall:1326
 msgid "'%b' is not a valid option, use '%b' or '%b'"
 msgstr ""
 
-#: pacstall:1342
+#: pacstall:1349
 msgid "Keeping build files"
 msgstr ""
 
-#: pacstall:1347
+#: pacstall:1354
 msgid "Skipping check() if present"
 msgstr ""
 
-#: pacstall:1352
+#: pacstall:1359
 msgid "Downloading package entries quietly"
 msgstr ""
 
-#: pacstall:1357
+#: pacstall:1364
 msgid "Building package without bwrap sandbox"
 msgstr ""
 
-#: pacstall:1358
+#: pacstall:1365
 msgid "Be cautious, this exposes your system to potential harm"
 msgstr ""
 
@@ -793,10 +798,6 @@ msgstr ""
 msgid "Could not %s %s properly"
 msgstr ""
 
-#: misc/scripts/package.sh:387 misc/scripts/package.sh:402
-msgid "Could not enter into %s"
-msgstr ""
-
 #: misc/scripts/quality-assurance.sh:49
 msgid "%b is not a valid provider!"
 msgstr ""
@@ -880,39 +881,39 @@ msgstr ""
 msgid "%bDo you want to %s %b from the repo %b?"
 msgstr ""
 
-#: misc/scripts/update.sh:57
+#: misc/scripts/update.sh:64
 msgid "Invalid URL"
 msgstr ""
 
-#: misc/scripts/update.sh:58
+#: misc/scripts/update.sh:65
 msgid "Confirm that '%b' is valid"
 msgstr ""
 
-#: misc/scripts/update.sh:63
+#: misc/scripts/update.sh:70
 msgid "Fetching translation list"
 msgstr ""
 
-#: misc/scripts/update.sh:66
+#: misc/scripts/update.sh:73
 msgid "Updating directories"
 msgstr ""
 
-#: misc/scripts/update.sh:74
+#: misc/scripts/update.sh:81
 msgid "Checking dependencies"
 msgstr ""
 
-#: misc/scripts/update.sh:101
+#: misc/scripts/update.sh:108
 msgid "Pulling scripts from GitHub"
 msgstr ""
 
-#: misc/scripts/update.sh:125
+#: misc/scripts/update.sh:132
 msgid "Rebuilding translations"
 msgstr ""
 
-#: misc/scripts/update.sh:130
+#: misc/scripts/update.sh:137
 msgid "Rebuilding manpages"
 msgstr ""
 
-#: misc/scripts/update.sh:134
+#: misc/scripts/update.sh:141
 msgid "Making scripts executable"
 msgstr ""
 

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -84,7 +84,7 @@ EOF
             "$tmpfile" && sudo rm "$tmpfile"
     else
         sudo env - bwrap --unshare-all --die-with-parent --new-session --ro-bind / / \
-            --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run --dev-bind /dev/null /dev/null \
+            --proc /proc --dev /dev --tmpfs "$PACTMP" --tmpfs /run --dev-bind /dev/null /dev/null \
             --ro-bind "$input" "$input" --bind "$PACDIR" "$PACDIR" --ro-bind "$tmpfile" "$tmpfile" \
             --setenv homedir "$homedir" --setenv CARCH "$CARCH" --setenv AARCH "$AARCH" --setenv DISTRO "$DISTRO" \
             --setenv CDISTRO "$CDISTRO" --setenv NCPU "$NCPU" --setenv PACSTALL_USER "$PACSTALL_USER" \
@@ -129,7 +129,7 @@ EOF
     else
         # shellcheck disable=SC2086
         sudo bwrap --unshare-all ${share_net} --die-with-parent --new-session \
-            --ro-bind / / --proc /proc --dev /dev --tmpfs /tmp --tmpfs /run ${dns_resolve} \
+            --ro-bind / / --proc /proc --dev /dev --tmpfs "$PACTMP" --tmpfs /run ${dns_resolve} \
             --dev-bind /dev/null /dev/null --tmpfs /root --tmpfs /home --setenv safeenv "$safeenv" \
             --bind "$STAGEDIR" "$STAGEDIR" --bind "$PACDIR" "$PACDIR" --setenv LOGDIR "$LOGDIR" \
             --setenv SCRIPTDIR "$SCRIPTDIR" --setenv STAGEDIR "$STAGEDIR" --setenv pkgdir "$pkgdir" \

--- a/misc/scripts/package-base.sh
+++ b/misc/scripts/package-base.sh
@@ -238,9 +238,9 @@ DIR="$PWD"
 homedir="$(eval echo ~"$PACSTALL_USER")"
 export homedir
 
-sudo cp "${PACKAGE}.pacscript" /tmp
-sudo chmod a+r "/tmp/${PACKAGE}.pacscript"
-pacfile="$(readlink -f "/tmp/${PACKAGE}.pacscript")"
+sudo cp "${PACKAGE}.pacscript" "${PACTMP}"
+sudo chmod a+r "${PACTMP}/${PACKAGE}.pacscript"
+pacfile="$(readlink -f "${PACTMP}/${PACKAGE}.pacscript")"
 export pacfile
 mapfile -t FARCH < <(dpkg --print-foreign-architectures)
 CARCH="$(dpkg --print-architecture)"
@@ -260,8 +260,8 @@ if ! source "${safeenv}"; then
     error_log 12 "install $PACKAGE"
     clean_fail_down
 fi
-srcinfo.print_out > "/tmp/${PACKAGE}.SRCINFO"
-srcinfile="$(readlink -f "/tmp/${PACKAGE}.SRCINFO")"
+srcinfo.print_out > "${PACTMP}/${PACKAGE}.SRCINFO"
+srcinfile="$(readlink -f "${PACTMP}/${PACKAGE}.SRCINFO")"
 export srcinfile
 
 package_pkg

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -116,9 +116,9 @@ tput cnorm # Show cursor again
 list=("${update_order[@]}")
 
 mkdir -p "${PACDIR}"
-up_list="$(mktemp /tmp/XXXXXX-pacstall-up-list)"
-up_print="$(mktemp /tmp/XXXXXX-pacstall-up-print)"
-up_urls="$(mktemp /tmp/XXXXXX-pacstall-up-urls)"
+up_list="$(mktemp ${PACTMP}/XXXXXX-pacstall-up-list)"
+up_print="$(mktemp ${PACTMP}/XXXXXX-pacstall-up-print)"
+up_urls="$(mktemp ${PACTMP}/XXXXXX-pacstall-up-urls)"
 
 fancy_message sub $"Checking versions"
 

--- a/pacstall
+++ b/pacstall
@@ -32,7 +32,8 @@ export METADIR="/var/lib/pacstall/metadata"
 export LOGDIR="/var/log/pacstall/error_log"
 printf -v LOGFILE "${LOGDIR}/%(%F_%T)T.log"
 export LOGFILE
-export PACDIR="${PACSTALL_TMPDIR:-/tmp}/pacstall"
+export PACTMP="${PACSTALL_TMPDIR:-/tmp}"
+export PACDIR="${PACTMP}/pacstall"
 export SCRIPTDIR="/usr/share/pacstall"
 export STAGEDIR="/usr/src/pacstall"
 export TEXTDOMAIN="pacstall"
@@ -650,6 +651,12 @@ unset State List
 source "$SCRIPTDIR/scripts/error-log.sh"
 # shellcheck source=./misc/scripts/bwrap.sh
 source "$SCRIPTDIR/scripts/bwrap.sh"
+
+if ! $(cd "${PACTMP}" 2> /dev/null); then
+    error_log 1 "init main"
+    fancy_message error $"Could not enter into %s" "${PACTMP}"
+    exit 1
+fi
 
 if [[ ! -t 0 ]]; then
     NON_INTERACTIVE=true


### PR DESCRIPTION
## Purpose

#1334 didn't do enough

## Approach

make the TMPDIR override its own variable that falls back to /tmp, and use that in place of /tmp anywhere in da code

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
