### PR TITLE
fix(fetch-sources.sh): allow `-deb`s to downgrade

### DIFF
--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -365,7 +365,7 @@ function deb_down() {
             exit 1
         fi
     fi
-    if [[ -n ${pacdeps[*]} || ${depends[*]} || ${makedepends[*]} || ${checkdepends[*]} ]] && repacstall "${dest}" || sudo apt install -y -f ./"${dest}" 2> /dev/null; then
+    if [[ -n ${pacdeps[*]} || ${depends[*]} || ${makedepends[*]} || ${checkdepends[*]} ]] && repacstall "${dest}" || sudo apt install -y -f ./"${dest}" --allow-downgrades 2> /dev/null; then
         meta_log
         if [[ -f "${PACDIR}-pacdeps-$pacname" ]]; then
             sudo apt-mark auto "${gives:-$pacname}" 2> /dev/null


### PR DESCRIPTION
## Purpose

- For all packages besides `-deb` packages, installation is already **always** run with `--allow-downgrades`.
- If a pacscript adds dependencies to a `-deb` package, it is rebuilt with `repacstall` and installed like all other packages, meaning it too is run with `--allow-downgrades`.
- Clean/unaltered `-deb` packages are the outliers here, who don't allow downgrades to occur. This has shown itself to be a problem before in the case of `nala-deb`, where what `dpkg` treats as a downgrade is not actually one, and is occurring for me when testing out adding [`firefox-deb`](https://github.com/pacstall/pacstall-programs/pull/7142), as it is trying to replace `firefox-bin` which uses Pacstall's semantic `-pacstall` versioning, while the deb itself does not. 
<img width="728" alt="Screenshot 2025-03-07 at 2 42 28 PM" src="https://github.com/user-attachments/assets/4fa7dfa2-be48-49d2-b055-9e7c11fdab52" />

## Approach

Give everyone the same behavior

## Progress

- [x] do it
- [x] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
