### PR TITLE
fix(is_apt_package_installed): check against version constraints

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -103,7 +103,7 @@ function check_apt_dep() {
     fi
     # Add to the dependency list if already installed so it doesn't get autoremoved on upgrade
     echo "${real_dep}" >> "${PACDIR}-deps-${pacname}"
-    if ! is_apt_package_installed "${just_name[0]}"; then
+    if ! is_apt_package_installed "${dep}"; then
         fancy_message sub $"%b [remote]" "${BLUE}${just_name[0]} ${GREEN}↑${YELLOW}↓${NC}"
     else
         fancy_message sub $"%b [installed]" "${BLUE}${just_name[0]} ${GREEN}✓${NC}"
@@ -139,7 +139,7 @@ function check_opt_dep() {
     fi
     # Add to the dependency list if already installed so it doesn't get autoremoved on upgrade
     # If the package is not installed already, add it to the list. It's much easier for a user to choose from a list of uninstalled packages than every single one regardless of it's status
-    if ((PACSTALL_INSTALL == 0)) || ! is_apt_package_installed "${just_name[0]}"; then
+    if ((PACSTALL_INSTALL == 0)) || ! is_apt_package_installed "${opt}"; then
         echo "${realopt}: ${optdesc}" >> "${PACDIR}-suggested-optdeps-${pacname}"
     else
         echo "${realopt}" >> "${PACDIR}-already-installed-optdeps-${pacname}"

--- a/misc/scripts/version-constraints.sh
+++ b/misc/scripts/version-constraints.sh
@@ -47,7 +47,7 @@ function dep_const.apt_compare_to_constraints() {
         *">"*) compare_type="gt" ;;
     esac
     const_arch="$(dep_const.get_arch "${split_up[0]}")"
-    if is_apt_package_installed "${split_up[0]}"; then
+    if is_apt_package_installed "${compare_pkg}"; then
         pkg_version="$(dpkg-query --showformat='${Version}' --show "${split_up[0]}")"
     else
         pkg_version="$(aptitude search --quiet --disable-columns "?exact-name(${split_up[0]%:*})?architecture(${const_arch})" -F "%V")"
@@ -180,7 +180,7 @@ function dep_const.get_pipe() {
         if dep_const.apt_compare_to_constraints "${pkg}"; then
             dep_const.split_name_and_version "${pkg}" check_name
             pipe_arch="$(dep_const.get_arch "${check_name[0]}")"
-            if is_package_installed "${check_name[0]}" || is_apt_package_installed "${check_name[0]}"; then
+            if is_package_installed "${check_name[0]}" || is_apt_package_installed "${pkg}"; then
                 echo "${pkg}"
                 return 0
             else

--- a/pacstall
+++ b/pacstall
@@ -566,7 +566,24 @@ function is_package_installed() {
 # Returns 0 if exists, 1 if not
 function is_apt_package_installed() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    if [[ $(dpkg-query -W --showformat='${db:Status-Status}' "${1}" 2> /dev/null) == "installed" ]]; then
+    local precheck="${1}" status pkg_split
+    # break out into ([0]=name [1]=compare [2]=version) if constraints present
+    case "${precheck}" in
+        *"<="*) pkg_split=("${precheck%%<=*}" "le" "${precheck##*<=}") ;;
+        *">="*) pkg_split=("${precheck%%>=*}" "ge" "${precheck##*>=}") ;;
+        *"="*) pkg_split=("${precheck%%=*}" "eq" "${precheck##*=}") ;;
+        *"<"*) pkg_split=("${precheck%%<*}" "lt" "${precheck##*<}") ;;
+        *">"*) pkg_split=("${precheck%%>*}" "gt" "${precheck##*>}") ;;
+        *) pkg_split=("${precheck}") ;;
+    esac
+    # record ([0]=installed [1]=version) if present
+    mapfile -t status < <(dpkg-query -W --showformat='${db:Status-Status}\n${Version}' "${pkg_split[0]}" 2> /dev/null)
+    if [[ ${status[0]} == "installed" ]]; then
+        if [[ -n "${pkg_split[1]}" ]]; then
+            if ! dpkg --compare-versions "${status[1]}" "${pkg_split[1]}" "${pkg_split[2]}"; then
+                { ignore_stack=true; return 1; }
+            fi
+        fi
         return 0
     else
         { ignore_stack=true; return 1; }


### PR DESCRIPTION
## Purpose

Installed packages incorrectly avoid detection of their version; in situations where `foo=1.0` is installed but `foo>=1.1` is specified, we are treating this as a valid match, because `foo` is installed.  For a cascade of reasons, this results in problematic situations like the following:
<img width="570" alt="Screenshot 2025-05-18 at 8 48 28 PM" src="https://github.com/user-attachments/assets/7224dbcf-8ab2-4e0c-971a-c67357cd5bd7" />

## Approach

- Make `is_apt_package_installed` aware of version constraints, and return error (not installed) if constraints are not satisfied.
  - Pass full package name + version strings in places where it is needed to `is_apt_package_installed`

## Progress

- [x] do it
- [x] test it

## Addendum

`vala-panel-appmenu-xfce4-git` requires `valac-0.56-vapi` -> `valac-0.56-vapi>=0.56.18` in its `makedepends`, but this will currently cause breakage if the package is not updated to that version beforehand. Pacstall should be able to call this update.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
