### PR TITLE
fix(fetch-sources.sh): use proper `is_apt_package_installed` check

### DIFF
--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -688,7 +688,7 @@ function check_builddepends() {
         return 0
     fi
     if dep_const.apt_compare_to_constraints "${build_dep}"; then
-        if ! is_apt_package_installed "${just_build[0]}"; then
+        if ! is_apt_package_installed "${build_dep}"; then
             echo "${realbuild}" >> "${PACDIR}-needed-${type}-${pacname}"
             just_arch="$(dep_const.get_arch "${just_build[0]}")"
             fancy_message sub $"%b [remote]" "${CYAN}${just_build[0]}${NC} ${GREEN}↑${YELLOW}↓${NC}"


### PR DESCRIPTION
## Purpose

I missed one in #1359 ....

## Progress

- [x] do it
- [x] test it
- [x] extra test it

## Addendum

pacstall 6.3.1 chartreuse baby!!!!

lets https://github.com/pacstall/pacstall-programs/pull/7420 actually work 

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
