### PR TITLE
fix({fetch-sources,package}.sh): fix `ext_to` for payloads + debs

### DIFF
--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -413,20 +413,38 @@ function file_down() {
     fancy_message info $"Copying local archive %b" "${BPurple}${dest}${NC}"
     # shellcheck disable=SC2031
     cp -r "${source_url}" "${dest}" || fail_down
-    genextr_declare
-    if [[ ${dest} == *".deb" ]]; then
-        if deb_down; then
-            exit 0
-        else
-            clean_fail_down
-        fi
-    elif [[ -n ${ext_method} ]]; then
-        genextr_down
-    else
-        hashcheck_down
-    fi
-    # back to srcdir
-    gather_down
+    case "${source_url,,}" in
+        *.deb)
+            if deb_down; then
+                exit 0
+            else
+                clean_fail_down
+            fi
+            ;;
+        *.zip | *.tar.gz | *.tgz | *.tar.bz2 | *.tbz2 | *.tar.bz | *.tbz | *.tar.xz | *.txz | *.tar.zst | *.tzst | *.gz | *.bz2 | *.xz | *.lz | *.lzma | *.zst | *.7z | *.rar | *.lz4 | *.tar)
+            genextr_declare "${source_url,,}"
+            genextr_down
+            ;;
+        *)
+            case "${dest,,}" in
+                *.deb)
+                    if deb_down; then
+                        exit 0
+                    else
+                        clean_fail_down
+                    fi
+                    ;;
+                *.zip | *.tar.gz | *.tgz | *.tar.bz2 | *.tbz2 | *.tar.bz | *.tbz | *.tar.xz | *.txz | *.tar.zst | *.tzst | *.gz | *.bz2 | *.xz | *.lz | *.lzma | *.zst | *.7z | *.rar | *.lz4 | *.tar)
+                    genextr_declare "${dest,,}"
+                    genextr_down
+                    ;;
+                *)
+                    hashcheck_down
+                    gather_down
+                    ;;
+            esac
+            ;;
+    esac
 }
 
 # currently expecting: 1=hash 2=PACSTALL_KNOWN_SUMS 3=hashum_method 4=${CARCH}/${DISTRO} 5=${CARCH}

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -331,6 +331,10 @@ if ! [[ -f "${PACDIR}-no-download-${pkgbase}" ]]; then
                 ;;
             *)
                 case "${dest,,}" in
+                    *.deb)
+                        net_down
+                        deb_down && return 0
+                        ;;
                     *.zip | *.tar.gz | *.tgz | *.tar.bz2 | *.tbz2 | *.tar.bz | *.tbz | *.tar.xz | *.txz | *.tar.zst | *.tzst | *.gz | *.bz2 | *.xz | *.lz | *.lzma | *.zst | *.7z | *.rar | *.lz4 | *.tar)
                         net_down
                         genextr_declare "${dest,,}"


### PR DESCRIPTION
## Purpose

pacup payloads broken on pacscripts that use `ext_to` bc I forgot to update the new usage of the declare function 💀 

## Approach

- fixed `genextr_declare $1` usage in `file_down`
    - split dest checking in the off chance that a deb's base download doesn't include `.deb` in the name 
        - fix that deb thing in regular (non payload) downloads too

## Progress

- [x] do it
- [ ] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
