### PR TITLE
fix({checks,package}.sh): split up `checks` function

### DIFF
--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -723,7 +723,17 @@ function lint_kver() {
 
 function checks() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local ret=0 check linting_checks=(lint_pacname lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_deps lint_ppa lint_relations lint_fields lint_hash lint_incompatible lint_arch lint_mask lint_priority lint_license lint_bugs lint_kver)
+    local ret=0 check linting_checks=(lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_deps lint_ppa lint_relations lint_fields lint_hash lint_priority lint_license lint_bugs)
+    for check in "${linting_checks[@]}"; do
+        "${check}" || ret=1
+    done
+    # shellcheck disable=SC2034
+    { ignore_stack=true; return "${ret}"; }
+}
+
+function pre_checks() {
+    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
+    local ret=0 check linting_checks=(lint_pacname lint_incompatible lint_arch lint_mask lint_kver)
     for check in "${linting_checks[@]}"; do
         "${check}" || ret=1
     done


### PR DESCRIPTION
## Purpose

some checks need to be ran at different times than the rest

## Approach

- move `checks` back to where it was pre-https://github.com/pacstall/pacstall/commit/c9e3cfa59a341e34e6a356a3aebb409b2891abee
- move the 5 that need to be run before the rest (`lint_pacname`, `lint_incompatible`, `lint_arch`, `lint_mask`, `lint_kver`) to `pre_checks`, which goes where `checks` was moved to in that PR
- ensure deb download only comes after `lint_source`

## Progress

- [x] do it
- [x] test it

## Addendum

https://github.com/pacstall/pacstall-programs/pull/7587

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
