### PR TITLE
feat: Add loong64(loongarch64) as a new arch

### DIFF
--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -146,7 +146,7 @@ function srcinfo.vars() {
     eval "multivalued_arch_attrs=(${vars} ${_sums}sums ${_vars}_${_distros} ${_sums}sums_${_distros})"
     multilist=("${multivalued_arch_attrs[@]}")
     mapfile -t -O "${#multilist[@]}" multilist < <(
-        for i in {amd64,x86_64,arm64,aarch64,armel,arm,armhf,armv7h,i386,i686,mips64el,ppc64el,riscv64,s390x}; do
+        for i in {amd64,x86_64,arm64,aarch64,armel,arm,armhf,armv7h,i386,i686,mips64el,ppc64el,riscv64,s390x,loong64}; do
             printf "%s_${i}\n" "${multivalued_arch_attrs[@]}"
         done
     )
@@ -167,6 +167,7 @@ function srcinfo.write_global() {
         ["ppc64el"]="ppc64el"
         ["riscv64"]="riscv64"
         ["s390x"]="s390x"
+        ["loong64"]="loongarch64"
     )
     local -A CARCHS_MAP=(
         ["x86_64"]="amd64"
@@ -178,6 +179,7 @@ function srcinfo.write_global() {
         ["ppc64el"]="ppc64el"
         ["riscv64"]="riscv64"
         ["s390x"]="s390x"
+        ["loongarch64"]="loong64"
     )
     if [[ " ${arch[*]} " != *" all "* && " ${arch[*]} " != *" any "* ]]; then
         for ar in "${multilist[@]}"; do

--- a/pacstall
+++ b/pacstall
@@ -196,7 +196,7 @@ function fancy_message() {
 function decl_scriptvars() {
     local _distros _vars _archs _sums distros \
         vars="source depends makedepends optdepends pacdeps checkdepends provides conflicts breaks replaces enhances recommends suggests makeconflicts checkconflicts" \
-        archs="amd64 x86_64 arm64 aarch64 armel arm armhf armv7h i386 i686 mips64el ppc64el riscv64 s390x" \
+        archs="amd64 x86_64 arm64 aarch64 armel arm armhf armv7h i386 i686 mips64el ppc64el riscv64 s390x loong64" \
         sums="b2 sha512 sha384 sha256 sha224 sha1 md5"
     pacstallvars=(pkgbase pkgname repology pkgver git_pkgver epoch source_url source depends makedepends checkdepends conflicts
         breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps NOBUILDDEP provides incompatible


### PR DESCRIPTION
Add loong64(loongarch64) as a new arch

## Purpose

loong64(AARCH: loongarch64) is an architecture under active development in debian-ports. This patch add this structure to pacstall.

## Approach

Add loong64 to `srcinfo.sh` and `pacstall`.

## Progress

- [x] srcinfo.sh
- [x] pacstall

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
