### PR TITLE
chore: drop mips64 support

### DIFF
--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -146,7 +146,7 @@ function srcinfo.vars() {
     eval "multivalued_arch_attrs=(${vars} ${_sums}sums ${_vars}_${_distros} ${_sums}sums_${_distros})"
     multilist=("${multivalued_arch_attrs[@]}")
     mapfile -t -O "${#multilist[@]}" multilist < <(
-        for i in {amd64,x86_64,arm64,aarch64,armel,arm,armhf,armv7h,i386,i686,mips64el,ppc64el,riscv64,s390x}; do
+        for i in {amd64,x86_64,arm64,aarch64,armel,arm,armhf,armv7h,i386,i686,ppc64el,riscv64,s390x}; do
             printf "%s_${i}\n" "${multivalued_arch_attrs[@]}"
         done
     )
@@ -163,7 +163,6 @@ function srcinfo.write_global() {
         ["armel"]="arm"
         ["armhf"]="armv7h"
         ["i386"]="i686"
-        ["mips64el"]="mips64el"
         ["ppc64el"]="ppc64el"
         ["riscv64"]="riscv64"
         ["s390x"]="s390x"
@@ -174,7 +173,6 @@ function srcinfo.write_global() {
         ["arm"]="armel"
         ["armv7h"]="armhf"
         ["i686"]="i386"
-        ["mips64el"]="mips64el"
         ["ppc64el"]="ppc64el"
         ["riscv64"]="riscv64"
         ["s390x"]="s390x"

--- a/pacstall
+++ b/pacstall
@@ -196,7 +196,7 @@ function fancy_message() {
 function decl_scriptvars() {
     local _distros _vars _archs _sums distros \
         vars="source depends makedepends optdepends pacdeps checkdepends provides conflicts breaks replaces enhances recommends suggests makeconflicts checkconflicts" \
-        archs="amd64 x86_64 arm64 aarch64 armel arm armhf armv7h i386 i686 mips64el ppc64el riscv64 s390x" \
+        archs="amd64 x86_64 arm64 aarch64 armel arm armhf armv7h i386 i686 ppc64el riscv64 s390x" \
         sums="b2 sha512 sha384 sha256 sha224 sha1 md5"
     pacstallvars=(pkgbase pkgname repology pkgver git_pkgver epoch source_url source depends makedepends checkdepends conflicts
         breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps NOBUILDDEP provides incompatible


### PR DESCRIPTION
## Purpose

aint supported anymore by ubuntu nor debian, saves unnecessary array checking

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
