### PR TITLE
fix({upgrade,fetch-sources}.sh): don't overwrite remotes already formatted

### DIFF
--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -836,11 +836,26 @@ function compare_remote_version() {
         *"github.com"*)
             remoterepo="${_remoterepo/'github.com'/'raw.githubusercontent.com'}/${_remotebranch}" ;;
         *"gitlab.com"*)
-            remoterepo="${_remoterepo}/-/raw/${_remotebranch}" ;;
+            if [[ ${_remoterepo} != *"/-/raw/"* ]]; then
+                remoterepo="${_remoterepo}/-/raw/${_remotebranch}"
+            else
+                remoterepo="${_remoterepo}"
+            fi
+        ;;
         *"git.sr.ht"*)
-            remoterepo="${_remoterepo}/blob/${_remotebranch}" ;;
+            if [[ ${_remoterepo} != *"/blob/"* ]]; then
+                remoterepo="${_remoterepo}/blob/${_remotebranch}"
+            else
+                remoterepo="${_remoterepo}"
+            fi
+        ;;
         *"codeberg"*)
-            remoterepo="${_remoterepo}/raw/branch/${_remotebranch}" ;;
+            if [[ ${_remoterepo} != *"/raw/branch/"* ]]; then
+                remoterepo="${_remoterepo}/raw/branch/${_remotebranch}"
+            else
+                remoterepo="${_remoterepo}"
+            fi
+        ;;
         *)
             remoterepo="${_remoterepo}" ;;
     esac

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -152,11 +152,26 @@ N="$(nproc)"
                 *"github.com"*)
                     remoterepo="${_remoterepo/'github.com'/'raw.githubusercontent.com'}/${_remotebranch}" ;;
                 *"gitlab.com"*)
-                    remoterepo="${_remoterepo}/-/raw/${_remotebranch}" ;;
+                    if [[ ${_remoterepo} != *"/-/raw/"* ]]; then
+                        remoterepo="${_remoterepo}/-/raw/${_remotebranch}"
+                    else
+                        remoterepo="${_remoterepo}"
+                    fi
+                ;;
                 *"git.sr.ht"*)
-                    remoterepo="${_remoterepo}/blob/${_remotebranch}" ;;
+                    if [[ ${_remoterepo} != *"/blob/"* ]]; then
+                        remoterepo="${_remoterepo}/blob/${_remotebranch}"
+                    else
+                        remoterepo="${_remoterepo}"
+                    fi
+                ;;
                 *"codeberg"*)
-                    remoterepo="${_remoterepo}/raw/branch/${_remotebranch}" ;;
+                    if [[ ${_remoterepo} != *"/raw/branch/"* ]]; then
+                        remoterepo="${_remoterepo}/raw/branch/${_remotebranch}"
+                    else
+                        remoterepo="${_remoterepo}"
+                    fi
+                ;;
                 *)
                     remoterepo="${_remoterepo}" ;;
             esac


### PR DESCRIPTION
## Purpose

when orphans and using REPO, can cause bad like: `https://gitlab.com/pacstall/pacstall-programs/-/raw/master/-/raw/`

## Approach

check if its already been formatted

## Progress

- [x] do it
- [x] test it

## Addendum

wow 6.3.4

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
