### PR TITLE
fix(build.sh): fix `STAGEDIR` dropping

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -567,7 +567,7 @@ function makedeb() {
                 'declare -g NCPU="${PACSTALL_BUILD_CORES:-1}"' 'else' 'declare -g NCPU="$(nproc)"' 'fi'
             )
             echo '#!/bin/bash' | sudo tee "$STAGEDIR/$pacname/DEBIAN/$deb_post_file" > /dev/null
-            for pacmf_out in "${pac_min_functions[@]}"; do
+            for pacmf_out in "${pac_min_functions[@]}" "export STAGEDIR=${STAGEDIR}"; do
                 echo "${pacmf_out}" | sudo tee -a "$STAGEDIR/$pacname/DEBIAN/$deb_post_file" > /dev/null
             done
             {


### PR DESCRIPTION
## Purpose

for whatever stupid reason this var drops even tho others dont

## Progress

- [x] do
- [x] test

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
