### PR TITLE
fix(stty): dirty fix for conflicting coreutil standards

### DIFF
--- a/misc/scripts/update.sh
+++ b/misc/scripts/update.sh
@@ -107,13 +107,6 @@ tabs -4
 
 tty_settings=$(stty -g)
 
-# TODO: REMOVE THIS AFTER https://github.com/uutils/coreutils/issues/9056.
-if dpkg -s "coreutils-from-uutils" &>/dev/null; then
-    rust_stty=1
-else
-    rust_stty=0
-fi
-
 # shellcheck disable=SC2207
 old_version=($(pacstall -V))
 # shellcheck disable=SC2207
@@ -144,7 +137,7 @@ sudo wget -q -O "${MAN8DIR}/pacstall.8" "${REPO}/misc/man/pacstall.8" &
 sudo wget -q -O "${MAN5DIR}/pacstall.5" "${REPO}/misc/man/pacstall.5" &
 sudo wget -q -O "${BASH_COMPLETION_DIR}/pacstall" "${REPO}/misc/completion/bash" &
 sudo wget -q -O "${FISH_COMPLETION_DIR}/pacstall.fish" "${REPO}/misc/completion/fish" &
-wait && if ((rust_stty)); then echo "${tty_settings}" | stty &>/dev/null; else stty "${tty_settings}"; fi
+wait && { stty "${tty_settings}" &>/dev/null || echo "${tty_settings}" | stty &>/dev/null; }
 
 fancy_message sub $"Rebuilding translations"
 for lang in "${linguas[@]}"; do

--- a/misc/scripts/upgrade.sh
+++ b/misc/scripts/upgrade.sh
@@ -125,18 +125,11 @@ fancy_message sub $"Checking versions"
 
 tty_settings=$(stty -g)
 
-# TODO: REMOVE THIS AFTER https://github.com/uutils/coreutils/issues/9056.
-if dpkg -s "coreutils-from-uutils" &>/dev/null; then
-    rust_stty=1
-else
-    rust_stty=0
-fi
-
 N="$(nproc)"
 (
     for i in "${list[@]}"; do
         ((n = n % N))
-        ((n++ == 0)) && wait && if ((rust_stty)); then echo "${tty_settings}" | stty &>/dev/null; else stty "${tty_settings}"; fi
+        ((n++ == 0)) && wait && { stty "${tty_settings}" &>/dev/null || echo "${tty_settings}" | stty &>/dev/null; }
         (
             unset _pkgbase _remoterepo
             source "$METADIR/$i"
@@ -257,7 +250,7 @@ N="$(nproc)"
             fi
         ) &
     done
-    wait && if ((rust_stty)); then echo "${tty_settings}" | stty &>/dev/null; else stty "${tty_settings}"; fi
+    wait && { stty "${tty_settings}" &>/dev/null || echo "${tty_settings}" | stty &>/dev/null; }
 )
 
 if [[ ! -s ${up_list} ]]; then


### PR DESCRIPTION
## Purpose

uutils, likely by incompetence, missed functionality in how arguments are passed to `stty`, leading to a complete breakage of `pacstall -U/-Up` on any system with uutils. This fixes the uutils one and preserves the *correct* GNU coreutils implementation.

## Approach

Detect if `stty` is a rust binary and apply the correct fix.

## Addendum

Closes #1397.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.