### PR TITLE
fix(pacstall): Sort files for tree display

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -1307,7 +1307,7 @@ Helpful links:
 
             source "$METADIR/$PACKAGE"
 
-            dpkg --listfiles "${_gives:-$_name}" | sed -e "s/[^-][^\/]*\//  │/g" -e "s/│\([^ ]\)/│──\1/"
+            dpkg --listfiles "${_gives:-$_name}" | sort | sed -e "s/[^-][^\/]*\//  │/g" -e "s/│\([^ ]\)/│──\1/"
             exit 0
             ;;
 


### PR DESCRIPTION
`dpkg --listfiles` prints files in an unspecified order.

For example:

    $ dpkg --listfiles less | grep -C 1 /usr/bin/lessfile
    /usr/share/man/man1/lesspipe.1.gz
    /usr/bin/lessfile
    /usr/share/man/man1/lessfile.1.gz

Sort the files used for `pacstall --tree <package>` to ensure the tree is drawn correctly.

See https://github.com/pacstall/pacstall-programs/pull/8213.

- [X] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
