### PR TITLE
feat(main): only require elevating once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.tar.gz
 *.tar.xz
 *.gz
+target/

--- a/misc/po/pacstall.pot
+++ b/misc/po/pacstall.pot
@@ -7,8 +7,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #: pacstall:287 misc/scripts/build.sh:163 misc/scripts/build.sh:688
-#: misc/scripts/fetch-sources.sh:175 misc/scripts/fetch-sources.sh:735
-#: misc/scripts/fetch-sources.sh:765 misc/scripts/package-base.sh:173
+#: misc/scripts/fetch-sources.sh:175 misc/scripts/fetch-sources.sh:753
+#: misc/scripts/fetch-sources.sh:783 misc/scripts/package-base.sh:173
 #: misc/scripts/package-base.sh:194
 msgid "Cleaning up"
 msgstr ""
@@ -41,171 +41,171 @@ msgstr ""
 msgid "Confirm that '%b' is accessible"
 msgstr ""
 
-#: pacstall:657 misc/scripts/package.sh:394 misc/scripts/package.sh:409
+#: pacstall:676 misc/scripts/package.sh:404 misc/scripts/package.sh:419
 #: misc/scripts/update.sh:47
 msgid "Could not enter into %s"
 msgstr ""
 
-#: pacstall:663
+#: pacstall:682
 msgid "Reading input from pipe"
 msgstr ""
 
-#: pacstall:722
+#: pacstall:741
 msgid "Only one command flag can be used at a time"
 msgstr ""
 
-#: pacstall:760
+#: pacstall:783
 msgid "Pacstall is already running another instance"
 msgstr ""
 
-#: pacstall:766
+#: pacstall:789
 msgid "The other instance has finished running, unlocking"
 msgstr ""
 
-#: pacstall:775
+#: pacstall:819
 msgid "Prompts are disabled"
 msgstr ""
 
-#: pacstall:782
+#: pacstall:826
 msgid "Package will be built and not installed"
 msgstr ""
 
-#: pacstall:858 pacstall:931 pacstall:993 pacstall:1034 pacstall:1052
-#: pacstall:1226 pacstall:1283 pacstall:1309 misc/scripts/query-info.sh:28
+#: pacstall:905 pacstall:978 pacstall:1040 pacstall:1081 pacstall:1100
+#: pacstall:1280 pacstall:1340 pacstall:1368 misc/scripts/query-info.sh:28
 msgid "You failed to specify a package"
 msgstr ""
 
-#: pacstall:863
+#: pacstall:910
 msgid "The installation of %s was interrupted, removing files"
 msgstr ""
 
-#: pacstall:900 misc/scripts/package-base.sh:139
+#: pacstall:947 misc/scripts/package-base.sh:139
 msgid "%s does not exist"
 msgstr ""
 
-#: pacstall:938
+#: pacstall:985
 msgid "Payload not found"
 msgstr ""
 
-#: pacstall:951 pacstall:998 pacstall:1038 pacstall:1159 pacstall:1236
-#: pacstall:1270
+#: pacstall:998 pacstall:1045 pacstall:1085 pacstall:1213 pacstall:1290
+#: pacstall:1327
 msgid "Could not connect to the internet"
 msgstr ""
 
-#: pacstall:952 pacstall:999 pacstall:1039 pacstall:1160 pacstall:1237
-#: pacstall:1271
+#: pacstall:999 pacstall:1046 pacstall:1086 pacstall:1214 pacstall:1291
+#: pacstall:1328
 msgid "Confirm that the URLs '%b' or '%b' are accessible"
 msgstr ""
 
-#: pacstall:968 pacstall:1251 misc/scripts/upgrade.sh:283
+#: pacstall:1015 pacstall:1305 misc/scripts/upgrade.sh:299
 msgid "Failed to download the %b pacscript"
 msgstr ""
 
-#: pacstall:969 pacstall:1252
+#: pacstall:1016 pacstall:1306
 msgid "Confirm that the package exists by running '%b'"
 msgstr ""
 
-#: pacstall:969 pacstall:1252
+#: pacstall:1016 pacstall:1306
 msgid "Check your internet connection"
 msgstr ""
 
-#: pacstall:975 misc/scripts/package-base.sh:163
+#: pacstall:1022 misc/scripts/package-base.sh:163
 #: misc/scripts/package-base.sh:187
 msgid "Failed to install %b"
 msgstr ""
 
-#: pacstall:1061
+#: pacstall:1109
 msgid "Failed to remove %b"
 msgstr ""
 
-#: pacstall:1082
+#: pacstall:1132
 msgid "You failed to specify a repo to add"
 msgstr ""
 
-#: pacstall:1083
+#: pacstall:1133
 msgid "Add a repository in the following format:"
 msgstr ""
 
-#: pacstall:1083 pacstall:1104
+#: pacstall:1133 pacstall:1156
 msgid ""
 "Consult the pacstall man page by running '%b', and searching for the term "
 "'%b'"
 msgstr ""
 
-#: pacstall:1103
+#: pacstall:1155
 msgid "You failed to specify a repo to remove"
 msgstr ""
 
-#: pacstall:1104
+#: pacstall:1156
 msgid "Remove a repository in the following format:"
 msgstr ""
 
-#: pacstall:1128
+#: pacstall:1182
 msgid "%s is not a git repository"
 msgstr ""
 
-#: pacstall:1165
+#: pacstall:1219
 msgid ""
 "The repository you are trying to upgrade to contains a version of pacstall "
 "that cannot be updated from %b"
 msgstr ""
 
-#: pacstall:1166
+#: pacstall:1220
 msgid ""
 "Visit %s for more information on how to reinstall. Most packages will also "
 "need to be reinstalled"
 msgstr ""
 
-#: pacstall:1174
+#: pacstall:1228
 msgid ""
 "Pacstall was installed from a %s, and cannot be updated with this command"
 msgstr ""
 
-#: pacstall:1175
+#: pacstall:1229
 msgid "Install the latest %b from the %b repository"
 msgstr ""
 
-#: pacstall:1175
+#: pacstall:1229
 msgid "Install the latest %b with the command '%b'"
 msgstr ""
 
-#: pacstall:1183 pacstall:1265
+#: pacstall:1237 pacstall:1322
 msgid "Invalid argument '%s'"
 msgstr ""
 
-#: pacstall:1195
+#: pacstall:1249
 msgid "Nothing installed yet"
 msgstr ""
 
-#: pacstall:1256
+#: pacstall:1310
 msgid "%b pacscript is downloaded to %b"
 msgstr ""
 
-#: pacstall:1287 pacstall:1314 misc/scripts/query-info.sh:33
+#: pacstall:1344 pacstall:1373 misc/scripts/query-info.sh:33
 msgid "Package is not installed"
 msgstr ""
 
-#: pacstall:1326
+#: pacstall:1385
 msgid "'%b' is not a valid option, use '%b' or '%b'"
 msgstr ""
 
-#: pacstall:1349
+#: pacstall:1408
 msgid "Keeping build files"
 msgstr ""
 
-#: pacstall:1354
+#: pacstall:1413
 msgid "Skipping check() if present"
 msgstr ""
 
-#: pacstall:1359
+#: pacstall:1418
 msgid "Downloading package entries quietly"
 msgstr ""
 
-#: pacstall:1364
+#: pacstall:1423
 msgid "Building package without bwrap sandbox"
 msgstr ""
 
-#: pacstall:1365
+#: pacstall:1424
 msgid "Be cautious, this exposes your system to potential harm"
 msgstr ""
 
@@ -269,27 +269,27 @@ msgid "Could not find srcinfo.sh"
 msgstr ""
 
 #: misc/scripts/build.sh:95 misc/scripts/build.sh:100
-#: misc/scripts/fetch-sources.sh:687 misc/scripts/fetch-sources.sh:700
-#: misc/scripts/package.sh:234
+#: misc/scripts/fetch-sources.sh:705 misc/scripts/fetch-sources.sh:718
+#: misc/scripts/package.sh:240
 msgid "%b [required]"
 msgstr ""
 
-#: misc/scripts/build.sh:107 misc/scripts/fetch-sources.sh:694
+#: misc/scripts/build.sh:107 misc/scripts/fetch-sources.sh:712
 msgid "%b [remote]"
 msgstr ""
 
-#: misc/scripts/build.sh:109 misc/scripts/fetch-sources.sh:696
-#: misc/scripts/package.sh:229
+#: misc/scripts/build.sh:109 misc/scripts/fetch-sources.sh:714
+#: misc/scripts/package.sh:235
 msgid "%b [installed]"
 msgstr ""
 
 #: misc/scripts/build.sh:156 misc/scripts/build.sh:176
-#: misc/scripts/fetch-sources.sh:724 misc/scripts/fetch-sources.sh:758
+#: misc/scripts/fetch-sources.sh:742 misc/scripts/fetch-sources.sh:776
 msgid "%b does not exist in apt repositories"
 msgstr ""
 
 #: misc/scripts/build.sh:160 misc/scripts/build.sh:180
-#: misc/scripts/fetch-sources.sh:762
+#: misc/scripts/fetch-sources.sh:780
 msgid "%b version(s) cannot be satisfied"
 msgstr ""
 
@@ -353,7 +353,7 @@ msgstr ""
 msgid "Package built at %b"
 msgstr ""
 
-#: misc/scripts/build.sh:712 misc/scripts/package.sh:56
+#: misc/scripts/build.sh:712 misc/scripts/package.sh:108
 msgid "Moving %b to %b"
 msgstr ""
 
@@ -367,7 +367,7 @@ msgstr ""
 
 #: misc/scripts/checks.sh:33 misc/scripts/checks.sh:127
 #: misc/scripts/checks.sh:175 misc/scripts/checks.sh:228
-#: misc/scripts/checks.sh:610
+#: misc/scripts/checks.sh:579
 msgid "Package does not contain '%s'"
 msgstr ""
 
@@ -411,7 +411,7 @@ msgid ""
 msgstr ""
 
 #: misc/scripts/checks.sh:92 misc/scripts/checks.sh:107
-#: misc/scripts/checks.sh:679
+#: misc/scripts/checks.sh:648
 msgid "'%s' is empty"
 msgstr ""
 
@@ -434,10 +434,10 @@ msgid "Package does not have a maintainer. Please be advised"
 msgstr ""
 
 #: misc/scripts/checks.sh:282 misc/scripts/checks.sh:309
-#: misc/scripts/checks.sh:359 misc/scripts/checks.sh:425
-#: misc/scripts/checks.sh:558 misc/scripts/checks.sh:581
-#: misc/scripts/checks.sh:615 misc/scripts/checks.sh:652
-#: misc/scripts/checks.sh:697
+#: misc/scripts/checks.sh:359 misc/scripts/checks.sh:402
+#: misc/scripts/checks.sh:527 misc/scripts/checks.sh:550
+#: misc/scripts/checks.sh:584 misc/scripts/checks.sh:621
+#: misc/scripts/checks.sh:666
 msgid "'%s' index '%s' cannot be empty"
 msgstr ""
 
@@ -453,62 +453,62 @@ msgstr ""
 msgid "%s index '%s' is improperly formatted"
 msgstr ""
 
-#: misc/scripts/checks.sh:430
+#: misc/scripts/checks.sh:407
 msgid "'%s' is already used as a field in pacstall"
 msgstr ""
 
-#: misc/scripts/checks.sh:436
+#: misc/scripts/checks.sh:410
 msgid "'%s' custom field cannot contain a space in field name"
 msgstr ""
 
-#: misc/scripts/checks.sh:440
+#: misc/scripts/checks.sh:413
 msgid "'%s' custom field cannot contain a number in field name"
 msgstr ""
 
-#: misc/scripts/checks.sh:444
+#: misc/scripts/checks.sh:416
 msgid ""
 "'%s' custom field must capitalize only the first letter of each word in "
 "field name"
 msgstr ""
 
-#: misc/scripts/checks.sh:448
+#: misc/scripts/checks.sh:419
 msgid "'%s' custom field cannot start or end with a hyphen"
 msgstr ""
 
-#: misc/scripts/checks.sh:475 misc/scripts/checks.sh:500
-#: misc/scripts/checks.sh:508
+#: misc/scripts/checks.sh:444 misc/scripts/checks.sh:469
+#: misc/scripts/checks.sh:477
 msgid "Only one checksum method can be provided for hashes"
 msgstr ""
 
-#: misc/scripts/checks.sh:536 misc/scripts/checks.sh:666
+#: misc/scripts/checks.sh:505 misc/scripts/checks.sh:635
 msgid "'%s' is improperly formatted"
 msgstr ""
 
-#: misc/scripts/checks.sh:551 misc/scripts/checks.sh:574
+#: misc/scripts/checks.sh:520 misc/scripts/checks.sh:543
 msgid "'%s' and '%s' indices cannot both be provided"
 msgstr ""
 
-#: misc/scripts/checks.sh:566 misc/scripts/checks.sh:589
+#: misc/scripts/checks.sh:535 misc/scripts/checks.sh:558
 msgid "'%s' index '%s' is improperly formatted"
 msgstr ""
 
-#: misc/scripts/checks.sh:626
+#: misc/scripts/checks.sh:595
 msgid "'%s' is not a valid architecture"
 msgstr ""
 
-#: misc/scripts/checks.sh:639
+#: misc/scripts/checks.sh:608
 msgid "cannot use both Debian and Arch style naming in '%s' array"
 msgstr ""
 
-#: misc/scripts/checks.sh:682
+#: misc/scripts/checks.sh:651
 msgid "'%s' must be either: '%s', '%s', '%s', '%s', or '%s'"
 msgstr ""
 
-#: misc/scripts/checks.sh:703
+#: misc/scripts/checks.sh:672
 msgid "'%s' is not a valid license"
 msgstr ""
 
-#: misc/scripts/checks.sh:717
+#: misc/scripts/checks.sh:686
 msgid "'%s' must be prefixed with a constraint (<=|>=|=|<|>)"
 msgstr ""
 
@@ -598,11 +598,11 @@ msgstr ""
 msgid "Could not run %s hook successfully"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:373 misc/scripts/package.sh:404
+#: misc/scripts/fetch-sources.sh:373 misc/scripts/package.sh:414
 msgid "Performing post install operations"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:389 misc/scripts/package.sh:405
+#: misc/scripts/fetch-sources.sh:389 misc/scripts/package.sh:415
 msgid "Storing pacscript"
 msgstr ""
 
@@ -610,7 +610,7 @@ msgstr ""
 msgid "Could not enter into %b"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:400 misc/scripts/package.sh:419
+#: misc/scripts/fetch-sources.sh:400 misc/scripts/package.sh:429
 msgid "Done installing %b"
 msgstr ""
 
@@ -622,41 +622,41 @@ msgstr ""
 msgid "Copying local archive %b"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:593 misc/scripts/fetch-sources.sh:627
-#: misc/scripts/fetch-sources.sh:634 misc/scripts/fetch-sources.sh:640
-#: misc/scripts/fetch-sources.sh:672
+#: misc/scripts/fetch-sources.sh:611 misc/scripts/fetch-sources.sh:645
+#: misc/scripts/fetch-sources.sh:652 misc/scripts/fetch-sources.sh:658
+#: misc/scripts/fetch-sources.sh:690
 msgid "This Pacscript does not work on %b"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:660
+#: misc/scripts/fetch-sources.sh:678
 msgid "This package is for %b, which is a foreign architecture"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:709
+#: misc/scripts/fetch-sources.sh:727
 msgid "Checking build dependencies"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:729
+#: misc/scripts/fetch-sources.sh:747
 msgid "%b versions cannot be satisfied"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:731
+#: misc/scripts/fetch-sources.sh:749
 msgid "%b version cannot be satisfied"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:743
+#: misc/scripts/fetch-sources.sh:761
 msgid "Checking check dependencies"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:784
+#: misc/scripts/fetch-sources.sh:802
 msgid "Creating build dependency/conflicts dummy package"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:799
+#: misc/scripts/fetch-sources.sh:817
 msgid "Failed to install build or check dependencies"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:882
+#: misc/scripts/fetch-sources.sh:915
 msgid "Kernel version constraint for this Pacscript not satisfied: %b"
 msgstr ""
 
@@ -664,7 +664,7 @@ msgstr ""
 msgid "Run '%b'"
 msgstr ""
 
-#: misc/scripts/get-pacscript.sh:38 misc/scripts/upgrade.sh:264
+#: misc/scripts/get-pacscript.sh:38 misc/scripts/upgrade.sh:280
 msgid "Could not enter %s"
 msgstr ""
 
@@ -724,85 +724,85 @@ msgstr ""
 msgid "This package will connect to the internet during its build process."
 msgstr ""
 
-#: misc/scripts/package.sh:53
-msgid "Failed to download '%s'"
-msgstr ""
-
-#: misc/scripts/package.sh:69
+#: misc/scripts/package.sh:56
 msgid ""
 "The package %b is masking %b. By installing the masked package, you may "
 "cause damage to your operating system"
 msgstr ""
 
-#: misc/scripts/package.sh:72
+#: misc/scripts/package.sh:59
 msgid ""
 "Somehow, '%s' found masked packages that match the package you want to "
 "install, but '%s' could not find it. Report this upstream"
 msgstr ""
 
-#: misc/scripts/package.sh:110
+#: misc/scripts/package.sh:105
+msgid "Failed to download '%s'"
+msgstr ""
+
+#: misc/scripts/package.sh:116
 msgid ""
 "This package has '%s', meaning once this is installed, it should be assumed "
 "to be unremovable. Do you want to continue?"
 msgstr ""
 
-#: misc/scripts/package.sh:129
+#: misc/scripts/package.sh:135
 msgid "Reinstalling '%s'"
 msgstr ""
 
-#: misc/scripts/package.sh:140
+#: misc/scripts/package.sh:146
 msgid "This script replaces %s. Do you want to proceed?"
 msgstr ""
 
-#: misc/scripts/package.sh:156
+#: misc/scripts/package.sh:162
 msgid "%b conflicts with %s, which is currently installed by apt"
 msgstr ""
 
-#: misc/scripts/package.sh:157 misc/scripts/package.sh:179
+#: misc/scripts/package.sh:163 misc/scripts/package.sh:185
 msgid "Remove the apt package by running '%b'"
 msgstr ""
 
-#: misc/scripts/package.sh:164
+#: misc/scripts/package.sh:170
 msgid "%b conflicts with %s, which is currently installed by pacstall"
 msgstr ""
 
-#: misc/scripts/package.sh:165 misc/scripts/package.sh:186
+#: misc/scripts/package.sh:171 misc/scripts/package.sh:192
 msgid "Remove the pacstall package by running '%b'"
 msgstr ""
 
-#: misc/scripts/package.sh:178
+#: misc/scripts/package.sh:184
 msgid "%b breaks %s, which is currently installed by apt"
 msgstr ""
 
-#: misc/scripts/package.sh:185
+#: misc/scripts/package.sh:191
 msgid "%b breaks %s, which is currently installed by pacstall"
 msgstr ""
 
-#: misc/scripts/package.sh:203
+#: misc/scripts/package.sh:209
 msgid "Checking pacstall dependencies"
 msgstr ""
 
-#: misc/scripts/package.sh:222
+#: misc/scripts/package.sh:228
 msgid "%b [update]"
 msgstr ""
 
-#: misc/scripts/package.sh:224 misc/scripts/package.sh:235
+#: misc/scripts/package.sh:230 misc/scripts/package.sh:241
 msgid "Failed to install dependency (%s from %s)"
 msgstr ""
 
-#: misc/scripts/package.sh:249
+#: misc/scripts/package.sh:255
 msgid "%s is associated with multiple source entries"
 msgstr ""
 
-#: misc/scripts/package.sh:283
+#: misc/scripts/package.sh:289
 msgid "Retrieving packages"
 msgstr ""
 
-#: misc/scripts/package.sh:381
+#: misc/scripts/package.sh:391
 msgid "Running functions"
 msgstr ""
 
-#: misc/scripts/package.sh:386
+#: misc/scripts/package.sh:396
 msgid "Could not %s %s properly"
 msgstr ""
 
@@ -889,39 +889,39 @@ msgstr ""
 msgid "%bDo you want to %s %b from the repo %b?"
 msgstr ""
 
-#: misc/scripts/update.sh:64
+#: misc/scripts/update.sh:73
 msgid "Invalid URL"
 msgstr ""
 
-#: misc/scripts/update.sh:65
+#: misc/scripts/update.sh:74
 msgid "Confirm that '%b' is valid"
 msgstr ""
 
-#: misc/scripts/update.sh:70
+#: misc/scripts/update.sh:79
 msgid "Fetching translation list"
 msgstr ""
 
-#: misc/scripts/update.sh:73
+#: misc/scripts/update.sh:82
 msgid "Updating directories"
 msgstr ""
 
-#: misc/scripts/update.sh:81
+#: misc/scripts/update.sh:90
 msgid "Checking dependencies"
 msgstr ""
 
-#: misc/scripts/update.sh:108
+#: misc/scripts/update.sh:118
 msgid "Pulling scripts from GitHub"
 msgstr ""
 
-#: misc/scripts/update.sh:132
+#: misc/scripts/update.sh:142
 msgid "Rebuilding translations"
 msgstr ""
 
-#: misc/scripts/update.sh:137
+#: misc/scripts/update.sh:147
 msgid "Rebuilding manpages"
 msgstr ""
 
-#: misc/scripts/update.sh:141
+#: misc/scripts/update.sh:151
 msgid "Making scripts executable"
 msgstr ""
 
@@ -933,7 +933,7 @@ msgstr ""
 msgid "Checking for updates"
 msgstr ""
 
-#: misc/scripts/upgrade.sh:110 misc/scripts/upgrade.sh:241
+#: misc/scripts/upgrade.sh:110 misc/scripts/upgrade.sh:257
 msgid "Nothing to upgrade"
 msgstr ""
 
@@ -945,14 +945,14 @@ msgstr ""
 msgid "Checking versions"
 msgstr ""
 
-#: misc/scripts/upgrade.sh:181
+#: misc/scripts/upgrade.sh:197
 msgid "Package %b is not on %b anymore"
 msgstr ""
 
-#: misc/scripts/upgrade.sh:244
+#: misc/scripts/upgrade.sh:260
 msgid "Packages can be upgraded"
 msgstr ""
 
-#: misc/scripts/upgrade.sh:269
+#: misc/scripts/upgrade.sh:285
 msgid "Do you want to upgrade %b?"
 msgstr ""

--- a/pacstall
+++ b/pacstall
@@ -1316,8 +1316,7 @@ Helpful links:
                 exit 1
             fi
 
-            elevate
-            apt_update
+            [[ $LIST_ONLY ]] || { elevate; apt_update }
 
             check_url "https://github.com" 2> /dev/null || check_url "https://gitlab.com" 2> /dev/null || {
                 fancy_message error $"Could not connect to the internet"

--- a/pacstall
+++ b/pacstall
@@ -801,14 +801,15 @@ function elevate() {
         ${PACSTALL_VERBOSE} || quiet="-Q"
         [[ $NOSANDBOX ]] && nosandbox="-Ns"
 
+        trap - ERR RETURN
+        unset ignore_stack
         sudo PACSTALL_SUPPRESS_SOLUTIONS="$PACSTALL_SUPPRESS_SOLUTIONS" \
             PACSTALL_BUILD_CORES="$PACSTALL_BUILD_CORES" PACSTALL_EDITOR="$PACSTALL_EDITOR" \
             PACSTALL_DOWNLOADER="$PACSTALL_DOWNLOADER" PACSTALL_PAYLOAD="$PACSTALL_PAYLOAD" \
             PACSTALL_TMPDIR="$PACSTALL_TMPDIR" NO_COLOR="$NO_COLOR" SUDO_USER="${SUDO_USER}" \
             DISABLE_PROMPTS="$DISABLE_PROMPTS" PACSTALL_ELEVATED=true \
             pacstall $debug $keep $build $nocheck $quiet $nosandbox $@
-        code=$?
-        { ignore_stack=true; exit $code; }
+        exit $?
     fi
 }
 

--- a/pacstall
+++ b/pacstall
@@ -1309,14 +1309,17 @@ Helpful links:
             ;;
 
         -Up | --upgrade | -Lu | --list-upgrades)
+            elevate
             [[ ${1} == "-Lu" || ${1} == "--list-upgrades" ]] && LIST_ONLY=true
+            [[ $LIST_ONLY ]] || apt_update
+
             shift
             if [[ -n $* ]]; then
                 fancy_message error $"Invalid argument '%s'" "$*"
                 exit 1
             fi
 
-            [[ $LIST_ONLY ]] || { elevate; apt_update }
+
 
             check_url "https://github.com" 2> /dev/null || check_url "https://gitlab.com" 2> /dev/null || {
                 fancy_message error $"Could not connect to the internet"

--- a/pacstall
+++ b/pacstall
@@ -658,11 +658,13 @@ function getMasks_offending_pkg() {
     { ignore_stack=true; return 1; }
 }
 
-# run sudo apt update if it's been more than a week
-eval "$(apt-config shell State Dir::State)"
-eval "$(apt-config shell List Dir::State::Lists)"
-[[ -z "$(find -H "/${State}/${List}" -maxdepth 0 -mtime -7)" ]] && sudo apt-get update -qq --allow-releaseinfo-change
-unset State List
+function apt_update() {
+    # run sudo apt update if it's been more than a week
+    eval "$(apt-config shell State Dir::State)"
+    eval "$(apt-config shell List Dir::State::Lists)"
+    [[ -z "$(find -H "/${State}/${List}" -maxdepth 0 -mtime -7)" ]] && sudo apt-get update -qq --allow-releaseinfo-change
+    unset State List
+}
 
 # shellcheck source=./misc/scripts/error-log.sh
 source "$SCRIPTDIR/scripts/error-log.sh"
@@ -750,6 +752,8 @@ function lock() {
     local ignore_long="--search --download --add-repo --remove-repo --version --tree --search-description --search-info --cache-info --help"
     local ignore="$ignore_short $ignore_long"
 
+    ((EUID != 0)) && { ignore_stack=true; return 0; }
+
     for ((i = 1; i <= option_flags + 1; i++)); do
         if [[ $ignore =~ (^|[[:space:]])"${!i}"($|[[:space:]]) ]]; then
             { ignore_stack=true; return 1; }
@@ -785,6 +789,25 @@ fi
 
 # don't allow nosandbox to be run with envars
 unset NOSANDBOX
+
+function elevate() {
+    if ((EUID != 0)); then
+        ((PACSTALL_DEBUG == 0)) || debug="-x"
+        [[ $KEEP ]] && keep="-K"
+        ((PACSTALL_INSTALL == 0)) || build="-B"
+        [[ $NOCHECK ]] && nocheck="-Nc"
+        [[ $PACSTALL_VERBOSE ]] || quiet="-Q"
+        [[ $NOSANDBOX ]] && nosandbox="-Ns"
+
+        sudo PACSTALL_SUPPRESS_SOLUTIONS="$PACSTALL_SUPPRESS_SOLUTIONS" \
+            PACSTALL_BUILD_CORES="$PACSTALL_BUILD_CORES" PACSTALL_EDITOR="$PACSTALL_EDITOR" \
+            PACSTALL_DOWNLOADER="$PACSTALL_DOWNLOADER" PACSTALL_PAYLOAD="$PACSTALL_PAYLOAD" \
+            PACSTALL_TMPDIR="$PACSTALL_TMPDIR" NO_COLOR="$NO_COLOR" SUDO_USER="${SUDO_USER}" \
+            DISABLE_PROMPTS="$DISABLE_PROMPTS" pacstall "$debug" "$keep" "$build" "$nocheck" "$quiet" "$nosandbox" $@
+        code=$?
+        { ignore_stack=true; exit $code; }
+    fi
+}
 
 while [[ $1 != "--" ]]; do
     case "$1" in
@@ -870,6 +893,9 @@ Helpful links:
             ;;
 
         -I | --install)
+            elevate
+            apt_update
+
             unset CHILD PKGPATH
             if [[ -z $2 ]]; then
                 fancy_message error $"You failed to specify a package"
@@ -1064,6 +1090,7 @@ Helpful links:
             ;;
 
         -R | --remove)
+            elevate
 
             if [[ -z $2 ]]; then
                 fancy_message error $"You failed to specify a package"
@@ -1082,6 +1109,8 @@ Helpful links:
             ;;
 
         -A | --add-repo)
+            elevate
+
             REPO="${2%/}"
             ALIAS="${3#*@}"
             REPOCMD="add"
@@ -1103,6 +1132,8 @@ Helpful links:
             ;;
 
         -Rr | --remove-repo)
+            elevate
+
             REPO="${2%/}"
             ALIAS="${3#*@}"
             REPOCMD="remove"
@@ -1137,6 +1168,8 @@ Helpful links:
             ;;
 
         -U | --update)
+            elevate
+
             if ! is_apt_package_installed "pacstall"; then
                 # If the input is `.`, is a directory, and there is no other input
                 if [[ $2 == "." && -d $2 && -z $3 ]]; then
@@ -1283,6 +1316,9 @@ Helpful links:
                 exit 1
             fi
 
+            elevate
+            apt_update
+
             check_url "https://github.com" 2> /dev/null || check_url "https://gitlab.com" 2> /dev/null || {
                 fancy_message error $"Could not connect to the internet"
                 suggested_solution $"Confirm that the URLs '%b' or '%b' are accessible" "${UGreen}https://github.com${NC}" "${UGreen}https://gitlab.com${NC}"
@@ -1320,6 +1356,8 @@ Helpful links:
             ;;
 
         -M | --mark)
+            elevate
+
             PACKAGE=$2
             STATE=$3
             if [[ -z $PACKAGE ]]; then

--- a/pacstall
+++ b/pacstall
@@ -752,7 +752,7 @@ function lock() {
     local ignore_long="--search --download --add-repo --remove-repo --version --tree --search-description --search-info --cache-info --help"
     local ignore="$ignore_short $ignore_long"
 
-    ((EUID != 0)) && { ignore_stack=true; return 0; }
+    ((EUID != 0)) && { ignore_stack=true; return 1; }
 
     for ((i = 1; i <= option_flags + 1; i++)); do
         if [[ $ignore =~ (^|[[:space:]])"${!i}"($|[[:space:]]) ]]; then
@@ -764,9 +764,11 @@ function lock() {
         fi
     done
 
-    if [[ -f "$SCRIPTDIR/repo/pacstallrepo.pacstall-qa.bak" ]]; then
+    if [[ -f "$SCRIPTDIR/repo/pacstallrepo.pacstall-qa.bak" ]] || [[ $PACSTALL_ELEVATED ]]; then
+        valid=2
+        [[ -f "$SCRIPTDIR/repo/pacstallrepo.pacstall-qa.bak" ]] && [[ $PACSTALL_ELEVATED ]] && valid=3
         instances=($(pidof -o %PPID -x "$0"))
-        if [[ ${#instances[@]} -lt 2 ]]; then
+        if [[ ${#instances[@]} -lt $valid ]]; then
             { ignore_stack=true; return 1; }
         fi
         return 0
@@ -794,16 +796,17 @@ function elevate() {
     if ((EUID != 0)); then
         ((PACSTALL_DEBUG == 0)) || debug="-x"
         [[ $KEEP ]] && keep="-K"
-        ((PACSTALL_INSTALL == 0)) || build="-B"
+        ((PACSTALL_INSTALL == 1)) || build="-B"
         [[ $NOCHECK ]] && nocheck="-Nc"
-        [[ $PACSTALL_VERBOSE ]] || quiet="-Q"
+        ${PACSTALL_VERBOSE} || quiet="-Q"
         [[ $NOSANDBOX ]] && nosandbox="-Ns"
 
         sudo PACSTALL_SUPPRESS_SOLUTIONS="$PACSTALL_SUPPRESS_SOLUTIONS" \
             PACSTALL_BUILD_CORES="$PACSTALL_BUILD_CORES" PACSTALL_EDITOR="$PACSTALL_EDITOR" \
             PACSTALL_DOWNLOADER="$PACSTALL_DOWNLOADER" PACSTALL_PAYLOAD="$PACSTALL_PAYLOAD" \
             PACSTALL_TMPDIR="$PACSTALL_TMPDIR" NO_COLOR="$NO_COLOR" SUDO_USER="${SUDO_USER}" \
-            DISABLE_PROMPTS="$DISABLE_PROMPTS" pacstall "$debug" "$keep" "$build" "$nocheck" "$quiet" "$nosandbox" $@
+            DISABLE_PROMPTS="$DISABLE_PROMPTS" PACSTALL_ELEVATED=true \
+            pacstall $debug $keep $build $nocheck $quiet $nosandbox $@
         code=$?
         { ignore_stack=true; exit $code; }
     fi
@@ -893,7 +896,7 @@ Helpful links:
             ;;
 
         -I | --install)
-            elevate
+            elevate $@
             apt_update
 
             unset CHILD PKGPATH
@@ -1090,7 +1093,7 @@ Helpful links:
             ;;
 
         -R | --remove)
-            elevate
+            elevate $@
 
             if [[ -z $2 ]]; then
                 fancy_message error $"You failed to specify a package"
@@ -1109,7 +1112,7 @@ Helpful links:
             ;;
 
         -A | --add-repo)
-            elevate
+            elevate $@
 
             REPO="${2%/}"
             ALIAS="${3#*@}"
@@ -1132,7 +1135,7 @@ Helpful links:
             ;;
 
         -Rr | --remove-repo)
-            elevate
+            elevate $@
 
             REPO="${2%/}"
             ALIAS="${3#*@}"
@@ -1168,7 +1171,7 @@ Helpful links:
             ;;
 
         -U | --update)
-            elevate
+            elevate $@
 
             if ! is_apt_package_installed "pacstall"; then
                 # If the input is `.`, is a directory, and there is no other input
@@ -1309,7 +1312,7 @@ Helpful links:
             ;;
 
         -Up | --upgrade | -Lu | --list-upgrades)
-            elevate
+            elevate $@
             [[ ${1} == "-Lu" || ${1} == "--list-upgrades" ]] && LIST_ONLY=true
             [[ $LIST_ONLY ]] || apt_update
 
@@ -1358,7 +1361,7 @@ Helpful links:
             ;;
 
         -M | --mark)
-            elevate
+            elevate $@
 
             PACKAGE=$2
             STATE=$3

--- a/pacstall
+++ b/pacstall
@@ -816,14 +816,14 @@ function elevate() {
 while [[ $1 != "--" ]]; do
     case "$1" in
         -P | --disable-prompts)
-            fancy_message warn $"Prompts are disabled"
+            [[ $PACSTALL_ELEVATED ]] || fancy_message warn $"Prompts are disabled"
             export DISABLE_PROMPTS=yes
             export DEBIAN_FRONTEND=noninteractive
             ;;
 
         -B | --build-only)
             export PACDEB_DIR="$PWD"
-            fancy_message info $"Package will be built and not installed"
+            [[ $PACSTALL_ELEVATED ]] || fancy_message info $"Package will be built and not installed"
             export PACSTALL_INSTALL=0
             ;;
 
@@ -1323,8 +1323,6 @@ Helpful links:
                 exit 1
             fi
 
-
-
             check_url "https://github.com" 2> /dev/null || check_url "https://gitlab.com" 2> /dev/null || {
                 fancy_message error $"Could not connect to the internet"
                 suggested_solution $"Confirm that the URLs '%b' or '%b' are accessible" "${UGreen}https://github.com${NC}" "${UGreen}https://gitlab.com${NC}"
@@ -1407,23 +1405,23 @@ Helpful links:
             ;;
 
         -K | --keep)
-            fancy_message info $"Keeping build files"
+            [[ $PACSTALL_ELEVATED ]] || fancy_message info $"Keeping build files"
             KEEP=true
             ;;
 
         -Nc | --nocheck)
-            fancy_message info $"Skipping check() if present"
+            [[ $PACSTALL_ELEVATED ]] || fancy_message info $"Skipping check() if present"
             NOCHECK=true
             ;;
 
         -Q | --quiet)
-            fancy_message info $"Downloading package entries quietly"
+            [[ $PACSTALL_ELEVATED ]] || fancy_message info $"Downloading package entries quietly"
             PACSTALL_VERBOSE=false
             ;;
 
         -Ns | --nosandbox)
-            fancy_message warn $"Building package without bwrap sandbox"
-            fancy_message sub $"Be cautious, this exposes your system to potential harm"
+            [[ $PACSTALL_ELEVATED ]] || fancy_message warn $"Building package without bwrap sandbox"
+            [[ $PACSTALL_ELEVATED ]] || fancy_message sub $"Be cautious, this exposes your system to potential harm"
             NOSANDBOX=true
             ;;
 


### PR DESCRIPTION
## Purpose

Reducing the number of times sudo password is required.
Fixing bugs related to sudo-rs timeout.

## Approach

Elevate user when required.
Make lock only check when elevated.
Apt upgrade only when needed.

## Progress

<!--Make a checklist of your progress-->

- [x] Do it
- [x] Test it

## Addendum

Another approach to what #1398 intended to do.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
