### PR TITLE
fix(bwrap): declare arrays in bwrapenv

### DIFF
--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -55,7 +55,7 @@ readonly __OLD_ENV
 $(declare -pf def_colors) && def_colors
 $(for i in {ask,fancy_message,parse_source_entry,calc_git_pkgver}; do declare -pf "${i}"; done)
 source "${input}"
-mapfile -t NEW_ENV < <(comm -13 --nocheck-order <(printf '%s\n' \"\${__OLD_ENV[@]}\") <(compgen -A variable |sort))
+mapfile -t NEW_ENV < <(comm -13 --nocheck-order <(printf '%s\n' \"\${__OLD_ENV[@]}\") <(compgen -A variable | sort))
 declare -p \${NEW_ENV[@]} >> "${bwrapenv}"
 declare -pf >> "${bwrapenv}"
 echo > "${safeenv}"
@@ -102,7 +102,7 @@ mapfile -t OLD_ENV < <(compgen -A variable | sort)
 source ${bwrapenv}
 ${func} 2>&1 "${LOGDIR}/$(printf '%(%Y-%m-%d_%T)T')-$name-$func.log" && FUNCSTATUS="\${PIPESTATUS[0]}" && \
 if [[ \$FUNCSTATUS ]]; then \
-    mapfile -t NEW_ENV < <(comm -13 --nocheck-order <(printf '%s\n' \"\${OLD_ENV[@]}\") <(compgen -A variable |sort)); \
+    mapfile -t NEW_ENV < <(comm -13 --nocheck-order <(printf '%s\n' \"\${OLD_ENV[@]}\") <(compgen -A variable | sort)); \
     declare -p \${NEW_ENV[@]} >> "${bwrapenv}"; \
 fi && ignore_stack=true && exit \$FUNCSTATUS
 EOF

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -50,13 +50,12 @@ function safe_source() {
 
     sudo tee "$tmpfile" > /dev/null << EOF
 #!/bin/bash -a
-mapfile -t __OLD_ENV < <(compgen -A variable  -P "--unset ")
+mapfile -t __OLD_ENV < <(compgen -A variable | sort)
 readonly __OLD_ENV
 $(declare -pf def_colors) && def_colors
 $(for i in {ask,fancy_message,parse_source_entry,calc_git_pkgver}; do declare -pf "${i}"; done)
 source "${input}"
-mapfile -t NEW_ENV < <(/bin/env -0 \${__OLD_ENV[@]} | \
-    sed -ze 's/BASH_FUNC_\(.*\)%%=\(.*\)\$/\n/g;s/^\(.[[:alnum:]_]*\)=\(.*\)\$/\1/g'|tr '\0' '\n')
+mapfile -t NEW_ENV < <(comm -13 <(printf '%s\n' \"\${__OLD_ENV[@]}\") <(compgen -A variable |sort))
 declare -p \${NEW_ENV[@]} >> "${bwrapenv}"
 declare -pf >> "${bwrapenv}"
 echo > "${safeenv}"
@@ -99,12 +98,11 @@ function bwrap_function() {
     tmpfile="$(sudo mktemp -p "${PWD}")"
     sudo tee -a "$tmpfile" > /dev/null << EOF
 #!/bin/bash -a
-mapfile -t OLD_ENV < <(compgen -A variable -P "--unset ")
+mapfile -t OLD_ENV < <(compgen -A variable | sort)
 source ${bwrapenv}
 ${func} 2>&1 "${LOGDIR}/$(printf '%(%Y-%m-%d_%T)T')-$name-$func.log" && FUNCSTATUS="\${PIPESTATUS[0]}" && \
 if [[ \$FUNCSTATUS ]]; then \
-    mapfile -t NEW_ENV < <(/bin/env -0 \${OLD_ENV[@]} | \
-        sed -ze 's/BASH_FUNC_\(.*\)%%=\(.*\)\$/\\n/g;s/^\\(.[[:alnum:]_]*\\)=\\(.*\\)\$/\\1/g'|tr '\0' '\n'); \
+    mapfile -t NEW_ENV < <(comm -13 <(printf '%s\n' \"\${OLD_ENV[@]}\") <(compgen -A variable |sort)); \
     declare -p \${NEW_ENV[@]} >> "${bwrapenv}"; \
 fi && ignore_stack=true && exit \$FUNCSTATUS
 EOF

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -55,7 +55,7 @@ readonly __OLD_ENV
 $(declare -pf def_colors) && def_colors
 $(for i in {ask,fancy_message,parse_source_entry,calc_git_pkgver}; do declare -pf "${i}"; done)
 source "${input}"
-mapfile -t NEW_ENV < <(comm -13 <(printf '%s\n' \"\${__OLD_ENV[@]}\") <(compgen -A variable |sort))
+mapfile -t NEW_ENV < <(comm -13 --nocheck-order <(printf '%s\n' \"\${__OLD_ENV[@]}\") <(compgen -A variable |sort))
 declare -p \${NEW_ENV[@]} >> "${bwrapenv}"
 declare -pf >> "${bwrapenv}"
 echo > "${safeenv}"
@@ -102,7 +102,7 @@ mapfile -t OLD_ENV < <(compgen -A variable | sort)
 source ${bwrapenv}
 ${func} 2>&1 "${LOGDIR}/$(printf '%(%Y-%m-%d_%T)T')-$name-$func.log" && FUNCSTATUS="\${PIPESTATUS[0]}" && \
 if [[ \$FUNCSTATUS ]]; then \
-    mapfile -t NEW_ENV < <(comm -13 <(printf '%s\n' \"\${OLD_ENV[@]}\") <(compgen -A variable |sort)); \
+    mapfile -t NEW_ENV < <(comm -13 --nocheck-order <(printf '%s\n' \"\${OLD_ENV[@]}\") <(compgen -A variable |sort)); \
     declare -p \${NEW_ENV[@]} >> "${bwrapenv}"; \
 fi && ignore_stack=true && exit \$FUNCSTATUS
 EOF

--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -50,6 +50,7 @@ function safe_source() {
 
     sudo tee "$tmpfile" > /dev/null << EOF
 #!/bin/bash -a
+declare __OLD_ENV=""
 mapfile -t __OLD_ENV < <(compgen -A variable | sort)
 readonly __OLD_ENV
 $(declare -pf def_colors) && def_colors


### PR DESCRIPTION
## Purpose

Properly export the normal and associative arrays to the bwrap functions

## Approach

`env` doesn't list arrays, so `compgen` ftw

## Progress

- [x] Do it
- [x] Test it

## Addendum

Closes #1449