### PR TITLE
feat(fetch-sources.sh): Improve display of source names 

### DIFF
--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -66,6 +66,7 @@ function parse_source_entry() {
     if [[ ${dest} == *"?"* ]]; then
         dest="${dest%%\?*}"
     fi
+    src_dsply="${source_url##*/}"
 }
 
 function calc_git_pkgver() {
@@ -221,18 +222,18 @@ function git_down() {
     if [[ -n ${git_branch} || -n ${git_tag} ]]; then
         if [[ -n ${git_branch} ]]; then
             revision="${git_branch}"
-            fancy_message info $"Cloning %b from branch %b" "${BPurple}${dest}${NC}" "${CYAN}${git_branch}${NC}"
+            fancy_message info $"Cloning %b from branch %b" "${BPurple}${src_dsply}${NC}" "${CYAN}${git_branch}${NC}"
         elif [[ -n ${git_tag} ]]; then
             revision="${git_tag}"
-            fancy_message info $"Cloning %b from tag %b" "${BPurple}${dest}${NC}" "${CYAN}${git_tag}${NC}"
+            fancy_message info $"Cloning %b from tag %b" "${BPurple}${src_dsply}${NC}" "${CYAN}${git_tag}${NC}"
         fi
         gitopts="-b ${revision}"
     elif [[ -n ${git_commit} ]]; then
         gitopts=("--no-checkout" "--filter=blob:none")
-        fancy_message info $"Cloning %b with no blobs" "${BPurple}${dest}${NC}"
+        fancy_message info $"Cloning %b with no blobs" "${BPurple}${src_dsply}${NC}"
     else
         unset gitopts
-        fancy_message info $"Cloning %b from %b" "${BPurple}${dest}${NC}" "${CYAN}HEAD${NC}"
+        fancy_message info $"Cloning %b from %b" "${BPurple}${src_dsply}${NC}" "${CYAN}HEAD${NC}"
     fi
     # git clone quietly, with no history, and if submodules are there, download with 10 jobs
     # shellcheck disable=SC2086,SC2031
@@ -258,7 +259,7 @@ function git_down() {
         # don't send this one to /dev/null like the others
         git submodule update "${quiet[@]}" --init --recursive --depth=1 || fail_down
     else
-        fancy_message sub $"Not cloning submodules for %b" "${PURPLE}${dest}${NC}"
+        fancy_message sub $"Not cloning submodules for %b" "${PURPLE}${src_dsply}${NC}"
     fi
     # Check the integrity
     calc_git_pkgver
@@ -276,7 +277,7 @@ function git_down() {
         else
             fancy_message error $"Cloned git repository does not match upstream hash"
             clean_fail_down
-        fi
+       fi
     fi
     # cd back to srcdir
     gather_down
@@ -284,7 +285,7 @@ function git_down() {
 
 function net_down() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    fancy_message info $"Downloading %b" "${BPurple}${dest}${NC}"
+    fancy_message info $"Downloading %b" "${BPurple}${src_dsply}${NC}"
     # shellcheck disable=SC2031
     download "$source_url" "$dest" || fail_down
 }
@@ -308,7 +309,7 @@ function genextr_down() {
         fi
     done
     if ${extract}; then
-        fancy_message sub $"Extracting %b" "${CYAN}${dest}${NC}"
+        fancy_message sub $"Extracting %b" "${CYAN}${src_dsply}${NC}"
         if [[ -n ${to_location} ]]; then
             mkdir -p "temp_ext"
             case "${ext_to_flag}" in
@@ -410,7 +411,7 @@ function deb_down() {
 
 function file_down() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    fancy_message info $"Copying local archive %b" "${BPurple}${dest}${NC}"
+    fancy_message info $"Copying local archive %b" "${BPurple}${src_dsply}${NC}"
     # shellcheck disable=SC2031
     cp -r "${source_url}" "${dest}" || fail_down
     case "${source_url,,}" in


### PR DESCRIPTION
Currently, while a script is processed, messages about actions on sources, such as "Downloading" and "Extracting", are not consistent across different cases, or necessarily strongly helpful to identify each of the sources.

If a script provides no named destination (i.e. `dest::` prefix) for the source field, then the file name or repository name, stripped of the full address, is displayed in highlighted text.

Such behavior seems generally strongly desirable.

However, if a script names a destination, then the name is shown instead of the actual source information. The destination name is often opaque for the end user, chosen as an implementation detail of the script, best to facilitate its maintenance. It may be exceedingly terse, to prevent source fields from appearing overly cluttered or redundant in the script specifications.

From the standpoint of reporting major operations processing the source, the destination name is irrelevant and confusing.

The commit makes the behavior correct and consistent in either case.

---

Note, please, that I have not found a testing framework in the codebase, nor a description of testing processes in basic documentation. The revisions have been casually tested for correctness, but I rely on further guidance to understand the expected methods for testing, that the revisions be considered seriously for integration into the project.

---


*I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.*
