### PR TITLE
fix(bwrap): don't place the bwrap `tmpfile` in the srcdir

### DIFF
--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -96,7 +96,7 @@ function bwrap_function() {
     # shellcheck disable=SC2034
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local func="$1"
-    tmpfile="$(sudo mktemp -p "${PWD}")"
+    tmpfile="$(sudo mktemp -p "${PACDIR}")"
     sudo tee -a "$tmpfile" > /dev/null << EOF
 #!/bin/bash -a
 mapfile -t OLD_ENV < <(compgen -A variable -P "--unset ")


### PR DESCRIPTION
## Purpose

`srcdir` should only contain source files

## Approach

Place the `tmpfile`, responsible for the function exectution inside `bwrap`, in the `PACDIR` folder, just like the `safeenv` and `bwrapenv` files.

## Progress

- [x] Do it
- [x] Test it

## Addendum

Fix for the glob issue encountered in #1447
