### PR TITLE
fix(pacstall): rm stacktrace avoidance that does nothing

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -801,8 +801,6 @@ function elevate() {
         ${PACSTALL_VERBOSE} || quiet="-Q"
         [[ $NOSANDBOX ]] && nosandbox="-Ns"
 
-        trap - ERR RETURN
-        unset ignore_stack
         sudo PACSTALL_SUPPRESS_SOLUTIONS="$PACSTALL_SUPPRESS_SOLUTIONS" \
             PACSTALL_BUILD_CORES="$PACSTALL_BUILD_CORES" PACSTALL_EDITOR="$PACSTALL_EDITOR" \
             PACSTALL_DOWNLOADER="$PACSTALL_DOWNLOADER" PACSTALL_PAYLOAD="$PACSTALL_PAYLOAD" \


### PR DESCRIPTION
## Purpose

doesn't restore stacktrace full capability, but also seems to not do anything

## Approach

rm nothings

## Progress

- [x] do it
- [x] test it

## Addendum

<!--Link any issues with this PR and/or write something that you want to inform us about (optional)-->

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
