### PR TITLE
feat(main): add `PACSTALL_XTRACE{FD,LOG}` for debugging

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -46,6 +46,12 @@ export PACSTALL_INSTALL=1
 
 PACSTALL_DEBUG=0
 if [[ "${1}" == "-x" || "${1}" == "--debug" ]]; then
+  if [[ -v PACSTALL_LOG ]]; then
+    # Separate elevated log file because of permissions issues
+    [[ $PACSTALL_ELEVATED ]] && PACSTALL_LOG="${PACSTALL_LOG}.elevated"
+    exec 3>>"${PACSTALL_LOG}"
+    export BASH_XTRACEFD=3
+  fi
   set -x
   PACSTALL_DEBUG=1
   shift 1
@@ -804,15 +810,16 @@ function elevate() {
         [[ $NOCHECK ]] && nocheck="-Nc"
         ${PACSTALL_VERBOSE} || quiet="-Q"
         [[ $NOSANDBOX ]] && nosandbox="-Ns"
+        [[ -v PACSTALL_LOG ]] && xtrace="PACSTALL_LOG=${PACSTALL_LOG}"
 
-        trap - ERR RETURN
-        unset ignore_stack
         sudo PACSTALL_SUPPRESS_SOLUTIONS="$PACSTALL_SUPPRESS_SOLUTIONS" \
             PACSTALL_BUILD_CORES="$PACSTALL_BUILD_CORES" PACSTALL_EDITOR="$PACSTALL_EDITOR" \
             PACSTALL_DOWNLOADER="$PACSTALL_DOWNLOADER" PACSTALL_PAYLOAD="$PACSTALL_PAYLOAD" \
             PACSTALL_TMPDIR="$PACSTALL_TMPDIR" NO_COLOR="$NO_COLOR" SUDO_USER="${SUDO_USER}" \
-            DISABLE_PROMPTS="$DISABLE_PROMPTS" PACSTALL_ELEVATED=true \
+            DISABLE_PROMPTS="$DISABLE_PROMPTS" PACSTALL_ELEVATED=true $xtrace \
             pacstall $debug $keep $build $nocheck $quiet $nosandbox $@
+        cat "${PACSTALL_LOG}" "${PACSTALL_LOG}.elevated" > ${PACSTALL_LOG}
+        sudo rm "${PACSTALL_LOG}.elevated"
         exit $?
     fi
 }

--- a/pacstall
+++ b/pacstall
@@ -48,11 +48,13 @@ PACSTALL_DEBUG=0
 if [[ "${1}" == "-x" || "${1}" == "--debug" ]]; then
     if [[ -n ${PACSTALL_XTRACELOG} && -n ${PACSTALL_XTRACEFD} ]]; then
         if ! [[ ${PACSTALL_XTRACEFD} =~ ^[0-9]+$ ]]; then
-            # avoid having to duplicate gettext string used in later checks
-            printf '[\033[1;31m!\033[0m] \033[1mERROR\033[0m: '
-            printf $"'%s' must be an unsigned integer" 'PACSTALL_XTRACEFD' >&2
-            # avoid having the newline in a gettext string
-            printf '\n'
+            {
+                # avoid having to duplicate gettext string used in later checks
+                printf '[\033[1;31m!\033[0m] \033[1mERROR\033[0m: ';
+                printf $"'%s' must be an unsigned integer" 'PACSTALL_XTRACEFD';
+                # avoid having the newline in a gettext string
+                printf '\n';
+            } >&2
             exit 1
         fi
         # Separate elevated log file because of permissions issues

--- a/pacstall
+++ b/pacstall
@@ -46,20 +46,20 @@ export PACSTALL_INSTALL=1
 
 PACSTALL_DEBUG=0
 if [[ "${1}" == "-x" || "${1}" == "--debug" ]]; then
-    if [[ -n ${PACSTALL_LOG} && -n ${PACSTALL_XTRACE} ]]; then
-        if ! [[ ${PACSTALL_XTRACE} =~ ^[0-9]+$ ]]; then
-            printf $'%b must be an integer' '[\033[1;31m!\033[0m] \033[1mERROR\033[0m: PACSTALL_XTRACE' >&2
+    if [[ -n ${PACSTALL_XTRACELOG} && -n ${PACSTALL_XTRACEFD} ]]; then
+        if ! [[ ${PACSTALL_XTRACEFD} =~ ^[0-9]+$ ]]; then
+            printf $'%b must be an integer' '[\033[1;31m!\033[0m] \033[1mERROR\033[0m: PACSTALL_XTRACEFD' >&2
             # avoid having the newline in a gettext string
             printf '\n'
             exit 1
         fi
         # Separate elevated log file because of permissions issues
         if [[ $PACSTALL_ELEVATED ]]; then
-            eval "exec ${PACSTALL_XTRACE}>'${PACSTALL_LOG}.elevated'"
+            eval "exec ${PACSTALL_XTRACEFD}>'${PACSTALL_XTRACELOG}.elevated'"
         else
-            eval "exec ${PACSTALL_XTRACE}>'${PACSTALL_LOG}'"
+            eval "exec ${PACSTALL_XTRACEFD}>'${PACSTALL_XTRACELOG}'"
         fi
-        export BASH_XTRACEFD="${PACSTALL_XTRACE}"
+        export BASH_XTRACEFD="${PACSTALL_XTRACEFD}"
     fi
     set -x
     PACSTALL_DEBUG=1
@@ -825,13 +825,13 @@ function elevate() {
             PACSTALL_DOWNLOADER="$PACSTALL_DOWNLOADER" PACSTALL_PAYLOAD="$PACSTALL_PAYLOAD" \
             PACSTALL_TMPDIR="$PACSTALL_TMPDIR" NO_COLOR="$NO_COLOR" SUDO_USER="${SUDO_USER}" \
             DISABLE_PROMPTS="$DISABLE_PROMPTS" PACSTALL_ELEVATED=true \
-            PACSTALL_LOG="${PACSTALL_LOG}" PACSTALL_XTRACE="${PACSTALL_XTRACE}" \
+            PACSTALL_XTRACELOG="${PACSTALL_XTRACELOG}" PACSTALL_XTRACEFD="${PACSTALL_XTRACEFD}" \
             pacstall $debug $keep $build $nocheck $quiet $nosandbox $@
         exit_code=$?
-        if [[ -n ${debug} && -n ${PACSTALL_LOG} && -n ${PACSTALL_XTRACE} ]]; then
+        if [[ -n ${debug} && -n ${PACSTALL_XTRACELOG} && -n ${PACSTALL_XTRACEFD} ]]; then
             set +x
-            tail -n +1 -v "${PACSTALL_LOG}.elevated" >> "${PACSTALL_LOG}" \
-                && sudo rm -rf "${PACSTALL_LOG}.elevated"
+            tail -n +1 -v "${PACSTALL_XTRACELOG}.elevated" >> "${PACSTALL_XTRACELOG}" \
+                && sudo rm -rf "${PACSTALL_XTRACELOG}.elevated"
         fi
         exit ${exit_code}
     fi

--- a/pacstall
+++ b/pacstall
@@ -46,7 +46,7 @@ export PACSTALL_INSTALL=1
 
 PACSTALL_DEBUG=0
 if [[ "${1}" == "-x" || "${1}" == "--debug" ]]; then
-    if [[ -n ${PACSTALL_XTRACE} ]] && ! [[ ${PACSTALL_XTRACE} =~ ^[0-9]+$ ]]; then
+    if [[ -n ${PACSTALL_LOG} && -n ${PACSTALL_XTRACE} ]] && ! [[ ${PACSTALL_XTRACE} =~ ^[0-9]+$ ]]; then
         printf $'%b must be an integer' '[\033[1;31m!\033[0m] \033[1mERROR\033[0m: PACSTALL_XTRACE' >&2
         # avoid having the newline in a gettext string
         printf '\n'

--- a/pacstall
+++ b/pacstall
@@ -830,7 +830,7 @@ function elevate() {
         exit_code=$?
         if [[ -n ${debug} && -n ${PACSTALL_LOG} && -n ${PACSTALL_XTRACE} ]]; then
             set +x
-            cat "${PACSTALL_LOG}.elevated" >> "${PACSTALL_LOG}" \
+            tail -n +1 -v "${PACSTALL_LOG}.elevated" >> "${PACSTALL_LOG}" \
                 && sudo rm -rf "${PACSTALL_LOG}.elevated"
         fi
         exit ${exit_code}

--- a/pacstall
+++ b/pacstall
@@ -45,13 +45,13 @@ export PACSTALL_USER=$(logname 2> /dev/null || echo "${SUDO_USER:-${USER:-$(whoa
 export PACSTALL_INSTALL=1
 
 PACSTALL_DEBUG=0
-if [[ -n ${PACSTALL_XTRACE} ]] && ! [[ ${PACSTALL_XTRACE} =~ ^[0-9]+$ ]]; then
-    printf $'%b must be an integer' '[\033[1;31m!\033[0m] \033[1mERROR\033[0m: PACSTALL_XTRACE' >&2
-    # avoid having the newline in a gettext string
-    printf '\n'
-    exit 1
-fi
 if [[ "${1}" == "-x" || "${1}" == "--debug" ]]; then
+    if [[ -n ${PACSTALL_XTRACE} ]] && ! [[ ${PACSTALL_XTRACE} =~ ^[0-9]+$ ]]; then
+        printf $'%b must be an integer' '[\033[1;31m!\033[0m] \033[1mERROR\033[0m: PACSTALL_XTRACE' >&2
+        # avoid having the newline in a gettext string
+        printf '\n'
+        exit 1
+    fi
     if [[ -n ${PACSTALL_LOG} && -n ${PACSTALL_XTRACE} ]]; then
         # Separate elevated log file because of permissions issues
         if [[ $PACSTALL_ELEVATED ]]; then

--- a/pacstall
+++ b/pacstall
@@ -829,6 +829,7 @@ function elevate() {
             pacstall $debug $keep $build $nocheck $quiet $nosandbox $@
         exit_code=$?
         if [[ -n ${debug} && -n ${PACSTALL_LOG} && -n ${PACSTALL_XTRACE} ]]; then
+            set +x
             cat "${PACSTALL_LOG}.elevated" >> "${PACSTALL_LOG}" \
                 && sudo rm -rf "${PACSTALL_LOG}.elevated"
         fi

--- a/pacstall
+++ b/pacstall
@@ -45,18 +45,25 @@ export PACSTALL_USER=$(logname 2> /dev/null || echo "${SUDO_USER:-${USER:-$(whoa
 export PACSTALL_INSTALL=1
 
 PACSTALL_DEBUG=0
+if [[ -n ${PACSTALL_XTRACE} ]] && ! [[ ${PACSTALL_XTRACE} =~ ^[0-9]+$ ]]; then
+    printf $'%b %b must be an integer\n' '[\033[1;31m!\033[0m] \033[1mERROR\033[0m:' 'PACSTALL_XTRACE' >&2
+    exit 1
+fi
 if [[ "${1}" == "-x" || "${1}" == "--debug" ]]; then
-  if [[ -v PACSTALL_LOG ]]; then
-    # Separate elevated log file because of permissions issues
-    [[ $PACSTALL_ELEVATED ]] && PACSTALL_LOG="${PACSTALL_LOG}.elevated"
-    exec 3>>"${PACSTALL_LOG}"
-    export BASH_XTRACEFD=3
-  fi
-  set -x
-  PACSTALL_DEBUG=1
-  shift 1
+    if [[ -n ${PACSTALL_LOG} && -n ${PACSTALL_XTRACE} ]]; then
+        # Separate elevated log file because of permissions issues
+        if [[ $PACSTALL_ELEVATED ]]; then
+            eval "exec ${PACSTALL_XTRACE}>'${PACSTALL_LOG}.elevated'"
+        else
+            eval "exec ${PACSTALL_XTRACE}>'${PACSTALL_LOG}'"
+        fi
+        export BASH_XTRACEFD="${PACSTALL_XTRACE}"
+    fi
+    set -x
+    PACSTALL_DEBUG=1
+    shift 1
 else
-  set +x
+    set +x
 fi
 export PACSTALL_DEBUG
 
@@ -810,17 +817,20 @@ function elevate() {
         [[ $NOCHECK ]] && nocheck="-Nc"
         ${PACSTALL_VERBOSE} || quiet="-Q"
         [[ $NOSANDBOX ]] && nosandbox="-Ns"
-        [[ -v PACSTALL_LOG ]] && xtrace="PACSTALL_LOG=${PACSTALL_LOG}"
 
         sudo PACSTALL_SUPPRESS_SOLUTIONS="$PACSTALL_SUPPRESS_SOLUTIONS" \
             PACSTALL_BUILD_CORES="$PACSTALL_BUILD_CORES" PACSTALL_EDITOR="$PACSTALL_EDITOR" \
             PACSTALL_DOWNLOADER="$PACSTALL_DOWNLOADER" PACSTALL_PAYLOAD="$PACSTALL_PAYLOAD" \
             PACSTALL_TMPDIR="$PACSTALL_TMPDIR" NO_COLOR="$NO_COLOR" SUDO_USER="${SUDO_USER}" \
-            DISABLE_PROMPTS="$DISABLE_PROMPTS" PACSTALL_ELEVATED=true $xtrace \
+            DISABLE_PROMPTS="$DISABLE_PROMPTS" PACSTALL_ELEVATED=true \
+            PACSTALL_LOG="${PACSTALL_LOG}" PACSTALL_XTRACE="${PACSTALL_XTRACE}" \
             pacstall $debug $keep $build $nocheck $quiet $nosandbox $@
-        cat "${PACSTALL_LOG}" "${PACSTALL_LOG}.elevated" > ${PACSTALL_LOG}
-        sudo rm "${PACSTALL_LOG}.elevated"
-        exit $?
+        exit_code=$?
+        if [[ -n ${debug} && -n ${PACSTALL_LOG} && -n ${PACSTALL_XTRACE} ]]; then
+            sudo cat "${PACSTALL_LOG}.elevated" >> "${PACSTALL_LOG}" \
+                && sudo rm -rf "${PACSTALL_LOG}.elevated"
+        fi
+        exit ${exit_code}
     fi
 }
 

--- a/pacstall
+++ b/pacstall
@@ -46,13 +46,13 @@ export PACSTALL_INSTALL=1
 
 PACSTALL_DEBUG=0
 if [[ "${1}" == "-x" || "${1}" == "--debug" ]]; then
-    if [[ -n ${PACSTALL_LOG} && -n ${PACSTALL_XTRACE} ]] && ! [[ ${PACSTALL_XTRACE} =~ ^[0-9]+$ ]]; then
-        printf $'%b must be an integer' '[\033[1;31m!\033[0m] \033[1mERROR\033[0m: PACSTALL_XTRACE' >&2
-        # avoid having the newline in a gettext string
-        printf '\n'
-        exit 1
-    fi
     if [[ -n ${PACSTALL_LOG} && -n ${PACSTALL_XTRACE} ]]; then
+        if ! [[ ${PACSTALL_XTRACE} =~ ^[0-9]+$ ]]; then
+            printf $'%b must be an integer' '[\033[1;31m!\033[0m] \033[1mERROR\033[0m: PACSTALL_XTRACE' >&2
+            # avoid having the newline in a gettext string
+            printf '\n'
+            exit 1
+        fi
         # Separate elevated log file because of permissions issues
         if [[ $PACSTALL_ELEVATED ]]; then
             eval "exec ${PACSTALL_XTRACE}>'${PACSTALL_LOG}.elevated'"

--- a/pacstall
+++ b/pacstall
@@ -827,7 +827,7 @@ function elevate() {
             pacstall $debug $keep $build $nocheck $quiet $nosandbox $@
         exit_code=$?
         if [[ -n ${debug} && -n ${PACSTALL_LOG} && -n ${PACSTALL_XTRACE} ]]; then
-            sudo cat "${PACSTALL_LOG}.elevated" >> "${PACSTALL_LOG}" \
+            cat "${PACSTALL_LOG}.elevated" >> "${PACSTALL_LOG}" \
                 && sudo rm -rf "${PACSTALL_LOG}.elevated"
         fi
         exit ${exit_code}

--- a/pacstall
+++ b/pacstall
@@ -46,7 +46,9 @@ export PACSTALL_INSTALL=1
 
 PACSTALL_DEBUG=0
 if [[ -n ${PACSTALL_XTRACE} ]] && ! [[ ${PACSTALL_XTRACE} =~ ^[0-9]+$ ]]; then
-    printf $'%b %b must be an integer\n' '[\033[1;31m!\033[0m] \033[1mERROR\033[0m:' 'PACSTALL_XTRACE' >&2
+    printf $'%b must be an integer' '[\033[1;31m!\033[0m] \033[1mERROR\033[0m: PACSTALL_XTRACE' >&2
+    # avoid having the newline in a gettext string
+    printf '\n'
     exit 1
 fi
 if [[ "${1}" == "-x" || "${1}" == "--debug" ]]; then

--- a/pacstall
+++ b/pacstall
@@ -48,7 +48,9 @@ PACSTALL_DEBUG=0
 if [[ "${1}" == "-x" || "${1}" == "--debug" ]]; then
     if [[ -n ${PACSTALL_XTRACELOG} && -n ${PACSTALL_XTRACEFD} ]]; then
         if ! [[ ${PACSTALL_XTRACEFD} =~ ^[0-9]+$ ]]; then
-            printf $'%b must be an integer' '[\033[1;31m!\033[0m] \033[1mERROR\033[0m: PACSTALL_XTRACEFD' >&2
+            # avoid having to duplicate gettext string used in later checks
+            printf '[\033[1;31m!\033[0m] \033[1mERROR\033[0m: '
+            printf $"'%s' must be an unsigned integer" 'PACSTALL_XTRACEFD' >&2
             # avoid having the newline in a gettext string
             printf '\n'
             exit 1


### PR DESCRIPTION
## Purpose

Fix the redirect with xtrace in elevated instance

## Approach

Add `PACSTALL_XTRACELOG` and `PACSTALL_XTRACEFD` variables used in conjunction with the debug flag

## Progress

- [x] Do it
- [x] Test it

## Addendum
Partially fixes #1457