### PR TITLE
add: meowdo

### DIFF
--- a/packages/meowdo/meowdo.pacscript
+++ b/packages/meowdo/meowdo.pacscript
@@ -1,0 +1,32 @@
+pkgname="meowdo"
+pkgver="1.3.5"
+pkgrel="1"
+pkgdesc="A cute, keyboard-driven todo list with a cat sidekick for your terminal"
+arch=('amd64' 'arm64')
+url="https://github.com/Sycorlax/Meowdo"
+source=("https://github.com/Sycorlax/Meowdo/archive/refs/tags/v${pkgver}.tar.gz")
+sha256sums=('SKIP')
+depends=("libncurses6")
+makedepends=("gcc" "make" "libncurses-dev")
+maintainer=("Sycorlax <mehdidiuori2002@gmail.com>")
+license=('GPL-3.0')
+
+prepare() {
+  cd "${pkgname^}-${pkgver}"
+}
+
+build() {
+  cd "${pkgname^}-${pkgver}"
+  make
+}
+
+package() {
+  cd "${pkgname^}-${pkgver}"
+  install -Dm755 "meowdo" -t "${pkgdir}/usr/bin"
+  install -Dm644 "README.md" -t "${pkgdir}/usr/share/doc/${pkgname}"
+}
+
+post_install() {
+  echo "meowdo installed successfully!"
+  echo "Run 'meowdo' to start using your new todo list."
+}


### PR DESCRIPTION
## Purpose
Add meowdo, a cute keyboard-driven todo list with a cat sidekick, to Pacstall. This is a C-based ncurses TUI application that supports tags, search, pinning, and persistent storage.

## Approach
Created a new pacscript following Pacstall conventions:
- Source from GitHub releases (`v${pkgver}` tag)
- Proper dependency declarations (libncurses6 runtime, gcc/make/libncurses-dev for build)
- Standard build flow: prepare → build → package
- Install binary to `/usr/bin` and documentation to `/usr/share/doc/meowdo`
- Post-install message to guide users

## Progress
- [x] Edit packagelist
- [x] Add initial pacscript
- [x] Generate .SRCINFO file
- [x] Test pacscript syntax
- [x] Add maintainer to pacscript

## Addendum
- Meowdo is maintained at: https://github.com/Sycorlax/Meowdo
- Package has been tested locally on amd64 architecture
- Upstream repository uses GPL-3.0 license
- Application stores user data in `~/.meowdo/todos.txt` (no special handling needed during install/upgrade)
- Tested with: `make` compilation and binary execution

## Checklist
- [x] I confirm that I have read the [[contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md)](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.