### PR TITLE
fix(bwrap): use full env context to filter new vars

### DIFF
--- a/misc/scripts/bwrap.sh
+++ b/misc/scripts/bwrap.sh
@@ -106,8 +106,8 @@ function bwrap_function() {
     tmpfile="$(sudo mktemp -p "${PACDIR}")"
     sudo tee -a "$tmpfile" > /dev/null << EOF
 #!/bin/bash -a
-mapfile -t OLD_ENV < <(compgen -A variable | sort)
 source ${bwrapenv}
+mapfile -t OLD_ENV < <(compgen -A variable | sort)
 ${func} 2>&1 "${LOGDIR}/$(printf '%(%Y-%m-%d_%T)T')-$name-$func.log" && FUNCSTATUS="\${PIPESTATUS[0]}" && \
 if [[ \$FUNCSTATUS ]]; then \
     mapfile -t NEW_ENV < <(


### PR DESCRIPTION
## Purpose

Not every var was being filtered correctly

## Approach

Source `bwrapenv` before getting the old env.

## Progress

- [x] Do it
- [x] Test it (thanks @oklopfer) 

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
