### PR TITLE
fix(repo): properly handle codeberg repos

### DIFF
--- a/misc/scripts/manage-repo.sh
+++ b/misc/scripts/manage-repo.sh
@@ -76,7 +76,7 @@ function repo.unraw_types() {
             ;;
         "codeberg")
             pTYPE="${type}"
-            pURL="${rep%raw/branch/*}"
+            pURL="${rep%/raw/branch/*}"
             pBRANCH="${rep##*/}"
             pISSUES="${pURL}/issues"
             pTYPE="${type}"
@@ -204,7 +204,7 @@ function repo.specify() {
     if [[ $1 == "file://"* ]] || [[ $1 == "/"* ]] || [[ $1 == "~"* ]] || [[ $1 == "."* ]]; then
         repo.get_path "${1}" URLNAME
         export URLNAME
-    elif [[ $1 == "github:"* ]] || [[ $1 == "gitlab:"* ]] || [[ $1 == "sourchut:"* ]] || [[ $1 == "codeberg:"* ]]; then
+    elif [[ $1 == "github:"* ]] || [[ $1 == "gitlab:"* ]] || [[ $1 == "sourcehut:"* ]] || [[ $1 == "codeberg:"* ]]; then
         export URLNAME="${1}"
     elif [[ $1 == *"github"* ]] || [[ $1 == *"gitlab"* ]] || [[ $1 == *"git.sr.ht"* ]] || [[ $1 == *"codeberg"* ]]; then
         URLNAME="$(repo.to_metalink "${1}")"


### PR DESCRIPTION
## Purpose

Fix codeberg repo serde. Also fixes sourcehut's `:` repo specification.

## Approach

Just remove and extra `/` from the string, and fix typo

## Progress

- [x] Do it
- [x] Test it

## Addendum

Closes #1473 

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
