### PR TITLE
fix(pacstall,package-base.sh): PACDIR should never be a file

### DIFF
--- a/misc/scripts/package-base.sh
+++ b/misc/scripts/package-base.sh
@@ -239,6 +239,7 @@ homedir="$(eval echo ~"$PACSTALL_USER")"
 export homedir
 
 if ! [[ -f "${PACDIR}/${PACKAGE}.pacscript" ]]; then
+    mkdir -p "${PACDIR}"
     sudo cp "${PACKAGE}.pacscript" "${PACDIR}"
     sudo chmod a+r "${PACDIR}/${PACKAGE}.pacscript"
 fi

--- a/pacstall
+++ b/pacstall
@@ -696,6 +696,10 @@ if ! $(cd "${PACTMP}" 2> /dev/null); then
     exit 1
 fi
 
+if [[ -f "${PACDIR}" ]]; then
+    rm -rf "${PACDIR}"
+fi
+
 if [[ ! -t 0 ]]; then
     NON_INTERACTIVE=true
     fancy_message warn $"Reading input from pipe"

--- a/pacstall
+++ b/pacstall
@@ -697,7 +697,7 @@ if ! $(cd "${PACTMP}" 2> /dev/null); then
 fi
 
 if [[ -f "${PACDIR}" ]]; then
-    rm -rf "${PACDIR}"
+    rm -f "${PACDIR}"
 fi
 
 if [[ ! -t 0 ]]; then


### PR DESCRIPTION
## Purpose

PACDIR might accidentally be created as a file instead of a folder

## Approach

Ensure creation of PACDIR before copying, ensure removal of a PACDIR file at init if exists

## Progress

- [x] do it
- [x] test it

## Addendum

Closes #1471.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
