### PR TITLE
fix(pacstall): catch at all non-zero values instead of only ones

### DIFF
--- a/misc/scripts/srcinfo.sh
+++ b/misc/scripts/srcinfo.sh
@@ -323,7 +323,7 @@ function srcinfo.parse() {
     srcfile="${1:?No .SRCINFO passed to srcinfo.parse}"
     access="${2:?No output file given to srcinfo.parse}"
     srcinfo.cleanup "${PACDIR}-srcinfo-access-${access}"
-    [[ ! -s ${srcfile} ]] && return 5
+    [[ ! -s ${srcfile} ]] && { ignore_stack=true; return 5; }
     mapfile -t srcinfo_data < "${srcfile}"
     for line in "${srcinfo_data[@]}"; do
         # Skip blank lines
@@ -333,12 +333,12 @@ function srcinfo.parse() {
         declare -A temp_line
         if ! srcinfo._basic_check "${line}"; then
             echo "Could not parse line: '${line}'" >&2
-            return 3
+            { ignore_stack=true; return 3; }
         fi
         srcinfo.parse_key_val "${line}" temp_line
         if [[ -z ${temp_line[value]} ]]; then
             echo "Empty value for: '${line}'" >&2
-            return 4
+            { ignore_stack=true; return 4; }
         fi
         # Define pkgbase first, it must be the first thing listed
         if [[ -z ${globase} ]]; then

--- a/pacstall
+++ b/pacstall
@@ -287,7 +287,7 @@ function cleanup() {
 function stacktrace() {
     local catch=$?
     if ((catch!=0)) && ! ${ignore_stack}; then
-        local i stack_size=${#FUNCNAME[@]} func linen src trace content stack_color color_idx \
+        local i stack_size=${#FUNCNAME[@]} func linen src trace stack_color color_idx \
             colors=(196 197 198 199 200 201 165 129 93 57 21 27 33 39 45 51 50 49 48 47 46 82 118 154 190 226 220 214 208 202)
         echo -e "[${BRed}!${NC}] ${BOLD}ERROR${NC}: Stacktrace (most recent call last)" >&2
         for ((i = stack_size - 1; i >= 1; i--)); do

--- a/pacstall
+++ b/pacstall
@@ -286,7 +286,7 @@ function cleanup() {
 
 function stacktrace() {
     local catch=$?
-    if ((catch==1)) && ! ${ignore_stack}; then
+    if ((catch!=0)) && ! ${ignore_stack}; then
         local i stack_size=${#FUNCNAME[@]} func linen src trace content stack_color color_idx \
             colors=(196 197 198 199 200 201 165 129 93 57 21 27 33 39 45 51 50 49 48 47 46 82 118 154 190 226 220 214 208 202)
         echo -e "[${BRed}!${NC}] ${BOLD}ERROR${NC}: Stacktrace (most recent call last)" >&2


### PR DESCRIPTION
## Purpose
Catching at only 1 is probably too narrow

## Approach
Catch at all non-zero values. We should ensure that this doesn't have any unintended consequences as we do sometimes emit other values for various purposes, including error_log. There are a handful of return 3s, for example.

## Progress
- [x] do it
- [ ] test it

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
