### PR TITLE
chan(pacstall): `pidof` uses `-q` instead of redirect to null

### DIFF
--- a/pacstall
+++ b/pacstall
@@ -808,7 +808,7 @@ function lock() {
         return 0
     fi
 
-    pidof -o %PPID -x "$0" > /dev/null && return 0 || { ignore_stack=true; return 1; }
+    pidof -q -o %PPID -x "$0" && return 0 || { ignore_stack=true; return 1; }
 }
 
 while lock $@; do


### PR DESCRIPTION
## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
