### PR TITLE
feat(incompatible): add optional failure reason

### DIFF
--- a/misc/po/pacstall.pot
+++ b/misc/po/pacstall.pot
@@ -11,8 +11,8 @@ msgid "'%s' must be an unsigned integer"
 msgstr ""
 
 #: pacstall:306 misc/scripts/build.sh:163 misc/scripts/build.sh:672
-#: misc/scripts/fetch-sources.sh:175 misc/scripts/fetch-sources.sh:761
-#: misc/scripts/fetch-sources.sh:791 misc/scripts/package-base.sh:173
+#: misc/scripts/fetch-sources.sh:175 misc/scripts/fetch-sources.sh:784
+#: misc/scripts/fetch-sources.sh:814 misc/scripts/package-base.sh:173
 #: misc/scripts/package-base.sh:194
 msgid "Cleaning up"
 msgstr ""
@@ -50,166 +50,166 @@ msgstr ""
 msgid "Could not enter into %s"
 msgstr ""
 
-#: pacstall:701
+#: pacstall:705
 msgid "Reading input from pipe"
 msgstr ""
 
-#: pacstall:764
+#: pacstall:772
 msgid "Only one command flag can be used at a time"
 msgstr ""
 
-#: pacstall:806
+#: pacstall:817
 msgid "Pacstall is already running another instance"
 msgstr ""
 
-#: pacstall:812
+#: pacstall:823
 msgid "The other instance has finished running, unlocking"
 msgstr ""
 
-#: pacstall:847
+#: pacstall:858
 msgid "Prompts are disabled"
 msgstr ""
 
-#: pacstall:854
+#: pacstall:865
 msgid "Package will be built and not installed"
 msgstr ""
 
-#: pacstall:933 pacstall:1006 pacstall:1068 pacstall:1109 pacstall:1128
-#: pacstall:1308 pacstall:1368 pacstall:1396 misc/scripts/query-info.sh:28
+#: pacstall:944 pacstall:1017 pacstall:1079 pacstall:1120 pacstall:1139
+#: pacstall:1319 pacstall:1379 pacstall:1407 misc/scripts/query-info.sh:28
 msgid "You failed to specify a package"
 msgstr ""
 
-#: pacstall:938
+#: pacstall:949
 msgid "The installation of %s was interrupted, removing files"
 msgstr ""
 
-#: pacstall:975 misc/scripts/package-base.sh:139
+#: pacstall:986 misc/scripts/package-base.sh:139
 msgid "%s does not exist"
 msgstr ""
 
-#: pacstall:1013
+#: pacstall:1024
 msgid "Payload not found"
 msgstr ""
 
-#: pacstall:1026 pacstall:1073 pacstall:1113 pacstall:1241 pacstall:1318
-#: pacstall:1355
+#: pacstall:1037 pacstall:1084 pacstall:1124 pacstall:1252 pacstall:1329
+#: pacstall:1366
 msgid "Could not connect to the internet"
 msgstr ""
 
-#: pacstall:1027 pacstall:1074 pacstall:1114 pacstall:1242 pacstall:1319
-#: pacstall:1356
+#: pacstall:1038 pacstall:1085 pacstall:1125 pacstall:1253 pacstall:1330
+#: pacstall:1367
 msgid "Confirm that the URLs '%b' or '%b' are accessible"
 msgstr ""
 
-#: pacstall:1043 pacstall:1333 misc/scripts/upgrade.sh:301
+#: pacstall:1054 pacstall:1344 misc/scripts/upgrade.sh:301
 msgid "Failed to download the %b pacscript"
 msgstr ""
 
-#: pacstall:1044 pacstall:1334
+#: pacstall:1055 pacstall:1345
 msgid "Confirm that the package exists by running '%b'"
 msgstr ""
 
-#: pacstall:1044 pacstall:1334
+#: pacstall:1055 pacstall:1345
 msgid "Check your internet connection"
 msgstr ""
 
-#: pacstall:1050 misc/scripts/package-base.sh:163
+#: pacstall:1061 misc/scripts/package-base.sh:163
 #: misc/scripts/package-base.sh:187
 msgid "Failed to install %b"
 msgstr ""
 
-#: pacstall:1137
+#: pacstall:1148
 msgid "Failed to remove %b"
 msgstr ""
 
-#: pacstall:1160
+#: pacstall:1171
 msgid "You failed to specify a repo to add"
 msgstr ""
 
-#: pacstall:1161
+#: pacstall:1172
 msgid "Add a repository in the following format:"
 msgstr ""
 
-#: pacstall:1161 pacstall:1184
+#: pacstall:1172 pacstall:1195
 msgid ""
 "Consult the pacstall man page by running '%b', and searching for the term "
 "'%b'"
 msgstr ""
 
-#: pacstall:1183
+#: pacstall:1194
 msgid "You failed to specify a repo to remove"
 msgstr ""
 
-#: pacstall:1184
+#: pacstall:1195
 msgid "Remove a repository in the following format:"
 msgstr ""
 
-#: pacstall:1210
+#: pacstall:1221
 msgid "%s is not a git repository"
 msgstr ""
 
-#: pacstall:1247
+#: pacstall:1258
 msgid ""
 "The repository you are trying to upgrade to contains a version of pacstall "
 "that cannot be updated from %b"
 msgstr ""
 
-#: pacstall:1248
+#: pacstall:1259
 msgid ""
 "Visit %s for more information on how to reinstall. Most packages will also "
 "need to be reinstalled"
 msgstr ""
 
-#: pacstall:1256
+#: pacstall:1267
 msgid ""
 "Pacstall was installed from a %s, and cannot be updated with this command"
 msgstr ""
 
-#: pacstall:1257
+#: pacstall:1268
 msgid "Install the latest %b from the %b repository"
 msgstr ""
 
-#: pacstall:1257
+#: pacstall:1268
 msgid "Install the latest %b with the command '%b'"
 msgstr ""
 
-#: pacstall:1265 pacstall:1350
+#: pacstall:1276 pacstall:1361
 msgid "Invalid argument '%s'"
 msgstr ""
 
-#: pacstall:1277
+#: pacstall:1288
 msgid "Nothing installed yet"
 msgstr ""
 
-#: pacstall:1338
+#: pacstall:1349
 msgid "%b pacscript is downloaded to %b"
 msgstr ""
 
-#: pacstall:1372 pacstall:1401 misc/scripts/query-info.sh:33
+#: pacstall:1383 pacstall:1412 misc/scripts/query-info.sh:33
 msgid "Package is not installed"
 msgstr ""
 
-#: pacstall:1413
+#: pacstall:1424
 msgid "'%b' is not a valid option, use '%b' or '%b'"
 msgstr ""
 
-#: pacstall:1436
+#: pacstall:1447
 msgid "Keeping build files"
 msgstr ""
 
-#: pacstall:1441
+#: pacstall:1452
 msgid "Skipping check() if present"
 msgstr ""
 
-#: pacstall:1446
+#: pacstall:1457
 msgid "Downloading package entries quietly"
 msgstr ""
 
-#: pacstall:1451
+#: pacstall:1462
 msgid "Building package without bwrap sandbox"
 msgstr ""
 
-#: pacstall:1452
+#: pacstall:1463
 msgid "Be cautious, this exposes your system to potential harm"
 msgstr ""
 
@@ -273,27 +273,27 @@ msgid "Could not find srcinfo.sh"
 msgstr ""
 
 #: misc/scripts/build.sh:95 misc/scripts/build.sh:100
-#: misc/scripts/fetch-sources.sh:713 misc/scripts/fetch-sources.sh:726
+#: misc/scripts/fetch-sources.sh:736 misc/scripts/fetch-sources.sh:749
 #: misc/scripts/package.sh:240
 msgid "%b [required]"
 msgstr ""
 
-#: misc/scripts/build.sh:107 misc/scripts/fetch-sources.sh:720
+#: misc/scripts/build.sh:107 misc/scripts/fetch-sources.sh:743
 msgid "%b [remote]"
 msgstr ""
 
-#: misc/scripts/build.sh:109 misc/scripts/fetch-sources.sh:722
+#: misc/scripts/build.sh:109 misc/scripts/fetch-sources.sh:745
 #: misc/scripts/package.sh:235
 msgid "%b [installed]"
 msgstr ""
 
 #: misc/scripts/build.sh:156 misc/scripts/build.sh:176
-#: misc/scripts/fetch-sources.sh:750 misc/scripts/fetch-sources.sh:784
+#: misc/scripts/fetch-sources.sh:773 misc/scripts/fetch-sources.sh:807
 msgid "%b does not exist in apt repositories"
 msgstr ""
 
 #: misc/scripts/build.sh:160 misc/scripts/build.sh:180
-#: misc/scripts/fetch-sources.sh:788
+#: misc/scripts/fetch-sources.sh:811
 msgid "%b version(s) cannot be satisfied"
 msgstr ""
 
@@ -618,41 +618,46 @@ msgstr ""
 msgid "Copying local archive %b"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:619 misc/scripts/fetch-sources.sh:653
-#: misc/scripts/fetch-sources.sh:660 misc/scripts/fetch-sources.sh:666
-#: misc/scripts/fetch-sources.sh:698
+#: misc/scripts/fetch-sources.sh:619 misc/scripts/fetch-sources.sh:667
+#: misc/scripts/fetch-sources.sh:678 misc/scripts/fetch-sources.sh:688
+#: misc/scripts/fetch-sources.sh:721
 msgid "This Pacscript does not work on %b"
 msgstr ""
 
+#: misc/scripts/fetch-sources.sh:665 misc/scripts/fetch-sources.sh:676
 #: misc/scripts/fetch-sources.sh:686
+msgid "This Pacscript does not work on %b: %b"
+msgstr ""
+
+#: misc/scripts/fetch-sources.sh:709
 msgid "This package is for %b, which is a foreign architecture"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:735
+#: misc/scripts/fetch-sources.sh:758
 msgid "Checking build dependencies"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:755
+#: misc/scripts/fetch-sources.sh:778
 msgid "%b versions cannot be satisfied"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:757
+#: misc/scripts/fetch-sources.sh:780
 msgid "%b version cannot be satisfied"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:769
+#: misc/scripts/fetch-sources.sh:792
 msgid "Checking check dependencies"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:810
+#: misc/scripts/fetch-sources.sh:833
 msgid "Creating build dependency/conflicts dummy package"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:825
+#: misc/scripts/fetch-sources.sh:848
 msgid "Failed to install build or check dependencies"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:923
+#: misc/scripts/fetch-sources.sh:946
 msgid "Kernel version constraint for this Pacscript not satisfied: %b"
 msgstr ""
 
@@ -712,7 +717,7 @@ msgstr ""
 msgid "Sourcing pacscript"
 msgstr ""
 
-#: misc/scripts/package-base.sh:264
+#: misc/scripts/package-base.sh:265
 msgid "Could not source pacscript"
 msgstr ""
 

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -554,7 +554,7 @@ function lint_incompatible() {
         done
         idx=0
         for incompat in "${incompatible[@]}"; do
-            if [[ $incompat != *:* ]] || [[ $incompat == "*:*" ]]; then
+            if [[ $incompat != *:* ]] || [[ $incompat == "*:*" ]] || [[ ! $incompat =~ ^[^:\[\]]+:[^:\[\]]+(\[[^\[\]]+\])?$ ]]; then
                 fancy_message error $"'%s' index '%s' is improperly formatted" "incompatible" "${idx}"
                 ret=1
             fi

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -513,7 +513,7 @@ function lint_hash() {
 
 function lint_incompatible() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local ret=0 incompat compat idx=0 comp_err=0
+    local ret=0 incompat compat idx=0 comp_err=0 incompat_regex='^[^:[]+:[^:[]+(\[[^]]+\])?$'
     if [[ -n ${compatible[*]} ]]; then
         if [[ -n ${incompatible[*]} ]]; then
             if [[ ${comp_err} != 1 ]]; then
@@ -554,7 +554,7 @@ function lint_incompatible() {
         done
         idx=0
         for incompat in "${incompatible[@]}"; do
-            if [[ $incompat != *:* ]] || [[ $incompat == "*:*" ]] || [[ ! $incompat =~ ^[^:\[\]]+:[^:\[\]]+(\[[^\[\]]+\])?$ ]]; then
+            if [[ $incompat != *:* ]] || [[ $incompat == "*:*" ]] || [[ ! $incompat =~ ${incompat_regex} ]]; then
                 fancy_message error $"'%s' index '%s' is improperly formatted" "incompatible" "${idx}"
                 ret=1
             fi

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -531,7 +531,7 @@ function lint_incompatible() {
         done
         idx=0
         for compat in "${compatible[@]}"; do
-            if [[ $compat != *:* ]] || [[ $compat == "*:*" ]]; then
+            if [[ ${compat} != *":"* ]] || [[ ${compat} =~ "*:*" ]]; then
                 fancy_message error $"'%s' index '%s' is improperly formatted" "compatible" "${idx}"
                 ret=1
             fi
@@ -554,7 +554,7 @@ function lint_incompatible() {
         done
         idx=0
         for incompat in "${incompatible[@]}"; do
-            if [[ $incompat != *:* ]] || [[ $incompat == "*:*" ]] || [[ ! $incompat =~ ${incompat_regex} ]]; then
+            if [[ ${incompat} != *":"* ]] || [[ ${incompat} =~ "*:*" ]] || [[ ! ${incompat} =~ ${incompat_regex} ]]; then
                 fancy_message error $"'%s' index '%s' is improperly formatted" "incompatible" "${idx}"
                 ret=1
             fi

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -586,7 +586,7 @@ function set_distro() {
 function get_compatible_releases() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # example for this function is "ubuntu:jammy"
-    local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number is_compat=false comp_list=("${@}")
+    local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number is_compat=false comp_list=("${@},,")
     calc_distro
     for key in "${comp_list[@]}"; do
         # check for `*:jammy`

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -625,10 +625,11 @@ function get_compatible_releases() {
 function get_incompatible_releases() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # example for this function is "ubuntu:jammy"
-    local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number incomp_list=("${@,,}") incomp_keys=() key reason
+    local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number incomp_list=("${@}") incomp_keys=() key reason
     calc_distro
 
     for key in "${incomp_list[@]}"; do
+        key="${key,,}"
         incomp_keys+=("${key%%\[*}")
     done
 
@@ -649,7 +650,8 @@ function get_incompatible_releases() {
         fi
     fi
     for incompat in "${incomp_list[@]}"; do
-        key="${incompat%%\[*}"
+        key="${incompat,,}"
+        key="${key%%\[*}"
         reason="${incompat#*\[}"
         [[ $reason != "${incompat}" ]] && reason="${reason%\]}"
 

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -651,7 +651,7 @@ function get_incompatible_releases() {
     for incompat in "${incomp_list[@]}"; do
         key="${incompat%%\[*}"
         reason="${incompat#*\[}"
-        [[ $reason != "${incompat}" ]] && reason"${reason%\]}"
+        [[ $reason != "${incompat}" ]] && reason="${reason%\]}"
 
         # check for `*:jammy`
         if [[ $key == "*:"* ]]; then

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -653,7 +653,9 @@ function get_incompatible_releases() {
         key="${incompat,,}"
         key="${key%%\[*}"
         reason="${incompat#*\[}"
-        [[ $reason != "${incompat}" ]] && reason="${reason%\]}"
+        if [[ $reason != "${incompat}" ]]; then
+            reason="${reason%\]}"
+        fi
 
         # check for `*:jammy`
         if [[ $key == "*:"* ]]; then

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -695,6 +695,7 @@ function get_incompatible_releases() {
                 { ignore_stack=true; return 1; }
             fi
         fi
+    unset key reason
     done
 }
 

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -586,7 +586,7 @@ function set_distro() {
 function get_compatible_releases() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # example for this function is "ubuntu:jammy"
-    local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number is_compat=false comp_list=("${@},,")
+    local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number is_compat=false comp_list=("${@,,}")
     calc_distro
     for key in "${comp_list[@]}"; do
         # check for `*:jammy`

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -661,20 +661,32 @@ function get_incompatible_releases() {
         if [[ $key == "*:"* ]]; then
             # check for `22.04` or `jammy`
             if [[ ${key#*:} == "${distro_version_number}" || ${key#*:} == "${distro_version_name}" ]]; then
-                fancy_message error $"This Pacscript does not work on %b%b" "${BBlue}${distro_version_name}${NC}/${BBlue}${distro_version_number}${NC}" "${reason:+: $reason}"
+                if [[ -n ${reason} ]]; then
+                    fancy_message error $"This Pacscript does not work on %b: %b" "${BBlue}${distro_version_name}${NC}/${BBlue}${distro_version_number}${NC}" "${reason}"
+                else
+                    fancy_message error $"This Pacscript does not work on %b" "${BBlue}${distro_version_name}${NC}/${BBlue}${distro_version_number}${NC}"
+                fi
                 { ignore_stack=true; return 1; }
             fi
         # check for `ubuntu:*`
         elif [[ $key == *":*" ]]; then
             # check for `ubuntu`
             if [[ ${key%%:*} == "${distro_name}" ]]; then
-                fancy_message error $"This Pacscript does not work on %b%b" "${BBlue}${distro_name}${NC}" "${reason:+: $reason}"
+                if [[ -n ${reason} ]]; then
+                    fancy_message error $"This Pacscript does not work on %b: %b" "${BBlue}${distro_name}${NC}" "${reason}"
+                else
+                    fancy_message error $"This Pacscript does not work on %b" "${BBlue}${distro_name}${NC}"
+                fi
                 { ignore_stack=true; return 1; }
             fi
         else
             # check for `ubuntu:jammy` or `ubuntu:22.04`
             if [[ $key == "${distro_name}:${distro_version_name}" || $key == "${distro_name}:${distro_version_number}" ]]; then
-                fancy_message error $"This Pacscript does not work on %b%b" "${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}" "${reason:+: $reason}"
+                if [[ -n ${reason} ]]; then
+                    fancy_message error $"This Pacscript does not work on %b: %b" "${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}" "${reason}"
+                else
+                    fancy_message error $"This Pacscript does not work on %b" "${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}"
+                fi
                 { ignore_stack=true; return 1; }
             fi
         fi

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -625,18 +625,21 @@ function get_compatible_releases() {
 function get_incompatible_releases() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # example for this function is "ubuntu:jammy"
-    local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number incomp_list=("${@,,}")
+    local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number incomp_list=("${@,,}") incomp_keys=() key reason
     calc_distro
 
+    for key in "${incomp_list[@]}"; do
+        incomp_keys+=("${key%%\[*}")
+    done
 
-    if ! array.contains incomp_list "${distro_name}:${distro_version_name}" && \
-        ! array.contains incomp_list "${distro_name}:${distro_version_number}" && \
-        ! array.contains incomp_list "${distro_name}:*" && \
-        ! array.contains incomp_list "*:${distro_version_name}" && \
-        ! array.contains incomp_list "*:${distro_version_number}"; then
+    if ! array.contains incomp_keys "${distro_name}:${distro_version_name}" && \
+        ! array.contains incomp_keys "${distro_name}:${distro_version_number}" && \
+        ! array.contains incomp_keys "${distro_name}:*" && \
+        ! array.contains incomp_keys "*:${distro_version_name}" && \
+        ! array.contains incomp_keys "*:${distro_version_number}"; then
         if [[ -n ${distro_parent_vname} ]] && \
-            { array.contains incomp_list "*:${distro_parent_vname}" || \
-            array.contains incomp_list "*:${distro_parent_number}";
+            { array.contains incomp_keys "*:${distro_parent_vname}" || \
+            array.contains incomp_keys "*:${distro_parent_number}";
         }; then
             distro_name="${distro_parent}"
             distro_version_name="${distro_parent_vname}"
@@ -645,25 +648,29 @@ function get_incompatible_releases() {
             fi
         fi
     fi
-    for key in "${incomp_list[@]}"; do
+    for incompat in "${incomp_list[@]}"; do
+        key="${incompat%%\[*}"
+        reason="${incompat#*\[}"
+        [[ $reason != "${incompat}" ]] && reason"${reason%\]}"
+
         # check for `*:jammy`
         if [[ $key == "*:"* ]]; then
             # check for `22.04` or `jammy`
             if [[ ${key#*:} == "${distro_version_number}" || ${key#*:} == "${distro_version_name}" ]]; then
-                fancy_message error $"This Pacscript does not work on %b" "${BBlue}${distro_version_name}${NC}/${BBlue}${distro_version_number}${NC}"
+                fancy_message error $"This Pacscript does not work on %b%b" "${BBlue}${distro_version_name}${NC}/${BBlue}${distro_version_number}${NC}" "${reason:+: $reason}"
                 { ignore_stack=true; return 1; }
             fi
         # check for `ubuntu:*`
         elif [[ $key == *":*" ]]; then
             # check for `ubuntu`
             if [[ ${key%%:*} == "${distro_name}" ]]; then
-                fancy_message error $"This Pacscript does not work on %b" "${BBlue}${distro_name}${NC}"
+                fancy_message error $"This Pacscript does not work on %b%b" "${BBlue}${distro_name}${NC}" "${reason:+: $reason}"
                 { ignore_stack=true; return 1; }
             fi
         else
             # check for `ubuntu:jammy` or `ubuntu:22.04`
             if [[ $key == "${distro_name}:${distro_version_name}" || $key == "${distro_name}:${distro_version_number}" ]]; then
-                fancy_message error $"This Pacscript does not work on %b" "${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}"
+                fancy_message error $"This Pacscript does not work on %b%b" "${BBlue}${distro_name}:${distro_version_name}${NC}/${BBlue}${distro_name}:${distro_version_number}${NC}" "${reason:+: $reason}"
                 { ignore_stack=true; return 1; }
             fi
         fi

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -586,7 +586,7 @@ function set_distro() {
 function get_compatible_releases() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     # example for this function is "ubuntu:jammy"
-    local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number is_compat=false comp_list=("${@,,}")
+    local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number is_compat=false comp_list=("${@}")
     calc_distro
     for key in "${comp_list[@]}"; do
         # check for `*:jammy`

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -655,9 +655,11 @@ function get_incompatible_releases() {
     for incompat in "${incomp_list[@]}"; do
         key="${incompat,,}"
         key="${key%%\[*}"
-        reason="${incompat#*\[}"
-        if [[ $reason != "${incompat}" ]]; then
-            reason="${reason%\]}"
+        if [[ ${incompat} =~ "[" ]]; then
+            reason="${incompat#*\[}"
+            if [[ ${reason} != "${incompat}" ]]; then
+                reason="${reason%\]}"
+            fi
         fi
 
         # check for `*:jammy`

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -570,6 +570,7 @@ function set_distro() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local distro_name distro_version_name distro_version_number distro_parent distro_parent_vname distro_parent_number
     calc_distro
+
     if [[ ${1} == "parent" ]]; then
         if [[ ${2} == "number" ]]; then
             echo "${distro_parent_number:-${distro_version_number}}"

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -639,7 +639,10 @@ function get_incompatible_releases() {
         ! array.contains incomp_keys "*:${distro_version_name}" && \
         ! array.contains incomp_keys "*:${distro_version_number}"; then
         if [[ -n ${distro_parent_vname} ]] && \
-            { array.contains incomp_keys "*:${distro_parent_vname}" || \
+            { array.contains incomp_keys "${distro_parent}:${distro_parent_vname}" || \
+            array.contains incomp_keys "${distro_parent}:${distro_parent_number}" || \
+            array.contains incomp_keys "${distro_parent}:*" || \
+            array.contains incomp_keys "*:${distro_parent_vname}" || \
             array.contains incomp_keys "*:${distro_parent_number}";
         }; then
             distro_name="${distro_parent}"


### PR DESCRIPTION
## Purpose

You can now add an optional message to `incompatible` that tells the user why exactly a certain distro clamp won't work:

```bash
incompatible=("debian:sid[package ships rm -rf on Sid]" "ubuntu:*[I just hate Ubuntu]")
```

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
