### PR TITLE
chore(build/fetch-sources): use `is_function` over `type -t`

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -512,12 +512,12 @@ function makedeb() {
     fi
     local pre_inst_upg post_inst_upg
     if is_package_installed "${pacname}"; then
-        if type -t pre_upgrade &> /dev/null; then
+        if is_function pre_upgrade; then
             pre_inst_upg="pre_upgrade"
         else
             pre_inst_upg="pre_install"
         fi
-        if type -t post_upgrade &> /dev/null; then
+        if is_function post_upgrade; then
             post_inst_upg="post_upgrade"
         else
             post_inst_upg="post_install"

--- a/misc/scripts/fetch-sources.sh
+++ b/misc/scripts/fetch-sources.sh
@@ -349,7 +349,7 @@ function deb_down() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     hashcheck_down
     local upgrade=false
-    if is_package_installed "${pacname}" && type -t pre_upgrade &> /dev/null; then
+    if is_package_installed "${pacname}" && is_function pre_upgrade; then
         upgrade=true
         fancy_message sub $"Running %s hook" "pre_upgrade"
         if ! pre_upgrade; then
@@ -357,7 +357,7 @@ function deb_down() {
             fancy_message error $"Could not run %s hook successfully" "preinst"
             exit 1
         fi
-    elif type -t pre_install &> /dev/null; then
+    elif is_function pre_install; then
         fancy_message sub $"Running %s hook" "pre_install"
         if ! pre_install; then
             error_log 5 "pre_install hook"
@@ -371,14 +371,14 @@ function deb_down() {
             sudo apt-mark auto "${gives:-$pacname}" 2> /dev/null
         fi
         fancy_message info $"Performing post install operations"
-        if type -t post_upgrade &> /dev/null && ${upgrade}; then
+        if is_function post_upgrade && ${upgrade}; then
             fancy_message sub $"Running %s hook" "post_upgrade"
             if ! post_upgrade; then
                 error_log 5 "post_upgrade hook"
                 fancy_message error $"Could not run %s hook successfully" "postinst"
                 exit 1
             fi
-        elif type -t post_install &> /dev/null; then
+        elif is_function post_install; then
             fancy_message sub $"Running %s hook" "post_install"
             if ! post_install; then
                 error_log 5 "post_install hook"

--- a/pacstall
+++ b/pacstall
@@ -620,7 +620,7 @@ function is_array() {
 
 function is_function() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    if [[ $(type -t "${1}") == "function" ]]; then
+    if declare -F "${1}" &> /dev/null; then
         return 0
     else
         { ignore_stack=true; return 1; }


### PR DESCRIPTION
## Purpose

We have the function already, and while `type -t` technically does more (checks if alias, keyword, function, builtin or file), we only really want it do be checking function existence.

## Approach

Swap them with `is_function`.

## Progress

<!--Make a checklist of your progress-->

- [x] Example

## Addendum

I changed the internals of `is_function` from `type -t $1 == "function"` to `declare -F $1`, which just looks nicer.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
