### PR TITLE
fix(quality-assurance): transient github errors are handled

### DIFF
--- a/misc/po/pacstall.pot
+++ b/misc/po/pacstall.pot
@@ -11,8 +11,8 @@ msgid "'%s' must be an unsigned integer"
 msgstr ""
 
 #: pacstall:306 misc/scripts/build.sh:163 misc/scripts/build.sh:672
-#: misc/scripts/fetch-sources.sh:175 misc/scripts/fetch-sources.sh:784
-#: misc/scripts/fetch-sources.sh:814 misc/scripts/package-base.sh:173
+#: misc/scripts/fetch-sources.sh:175 misc/scripts/fetch-sources.sh:791
+#: misc/scripts/fetch-sources.sh:821 misc/scripts/package-base.sh:173
 #: misc/scripts/package-base.sh:194
 msgid "Cleaning up"
 msgstr ""
@@ -273,27 +273,27 @@ msgid "Could not find srcinfo.sh"
 msgstr ""
 
 #: misc/scripts/build.sh:95 misc/scripts/build.sh:100
-#: misc/scripts/fetch-sources.sh:736 misc/scripts/fetch-sources.sh:749
+#: misc/scripts/fetch-sources.sh:743 misc/scripts/fetch-sources.sh:756
 #: misc/scripts/package.sh:240
 msgid "%b [required]"
 msgstr ""
 
-#: misc/scripts/build.sh:107 misc/scripts/fetch-sources.sh:743
+#: misc/scripts/build.sh:107 misc/scripts/fetch-sources.sh:750
 msgid "%b [remote]"
 msgstr ""
 
-#: misc/scripts/build.sh:109 misc/scripts/fetch-sources.sh:745
+#: misc/scripts/build.sh:109 misc/scripts/fetch-sources.sh:752
 #: misc/scripts/package.sh:235
 msgid "%b [installed]"
 msgstr ""
 
 #: misc/scripts/build.sh:156 misc/scripts/build.sh:176
-#: misc/scripts/fetch-sources.sh:773 misc/scripts/fetch-sources.sh:807
+#: misc/scripts/fetch-sources.sh:780 misc/scripts/fetch-sources.sh:814
 msgid "%b does not exist in apt repositories"
 msgstr ""
 
 #: misc/scripts/build.sh:160 misc/scripts/build.sh:180
-#: misc/scripts/fetch-sources.sh:811
+#: misc/scripts/fetch-sources.sh:818
 msgid "%b version(s) cannot be satisfied"
 msgstr ""
 
@@ -618,46 +618,46 @@ msgstr ""
 msgid "Copying local archive %b"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:619 misc/scripts/fetch-sources.sh:667
-#: misc/scripts/fetch-sources.sh:678 misc/scripts/fetch-sources.sh:688
-#: misc/scripts/fetch-sources.sh:721
+#: misc/scripts/fetch-sources.sh:620 misc/scripts/fetch-sources.sh:673
+#: misc/scripts/fetch-sources.sh:684 misc/scripts/fetch-sources.sh:694
+#: misc/scripts/fetch-sources.sh:728
 msgid "This Pacscript does not work on %b"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:665 misc/scripts/fetch-sources.sh:676
-#: misc/scripts/fetch-sources.sh:686
+#: misc/scripts/fetch-sources.sh:671 misc/scripts/fetch-sources.sh:682
+#: misc/scripts/fetch-sources.sh:692
 msgid "This Pacscript does not work on %b: %b"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:709
+#: misc/scripts/fetch-sources.sh:716
 msgid "This package is for %b, which is a foreign architecture"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:758
+#: misc/scripts/fetch-sources.sh:765
 msgid "Checking build dependencies"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:778
+#: misc/scripts/fetch-sources.sh:785
 msgid "%b versions cannot be satisfied"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:780
+#: misc/scripts/fetch-sources.sh:787
 msgid "%b version cannot be satisfied"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:792
+#: misc/scripts/fetch-sources.sh:799
 msgid "Checking check dependencies"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:833
+#: misc/scripts/fetch-sources.sh:840
 msgid "Creating build dependency/conflicts dummy package"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:848
+#: misc/scripts/fetch-sources.sh:855
 msgid "Failed to install build or check dependencies"
 msgstr ""
 
-#: misc/scripts/fetch-sources.sh:946
+#: misc/scripts/fetch-sources.sh:953
 msgid "Kernel version constraint for this Pacscript not satisfied: %b"
 msgstr ""
 
@@ -807,31 +807,39 @@ msgstr ""
 msgid "Could not %s %s properly"
 msgstr ""
 
-#: misc/scripts/quality-assurance.sh:49
+#: misc/scripts/quality-assurance.sh:45
+msgid "Could not retrieve pull request information from %b"
+msgstr ""
+
+#: misc/scripts/quality-assurance.sh:51
+msgid "%b returned an invalid pull request response"
+msgstr ""
+
+#: misc/scripts/quality-assurance.sh:56
 msgid "%b is not a valid provider!"
 msgstr ""
 
-#: misc/scripts/quality-assurance.sh:50
+#: misc/scripts/quality-assurance.sh:57
 msgid "available providers are: '%s'"
 msgstr ""
 
-#: misc/scripts/quality-assurance.sh:59
+#: misc/scripts/quality-assurance.sh:66
 msgid "Returning %b backup"
 msgstr ""
 
-#: misc/scripts/quality-assurance.sh:68
+#: misc/scripts/quality-assurance.sh:75
 msgid "'%s' and '%s' cannot be empty!"
 msgstr ""
 
-#: misc/scripts/quality-assurance.sh:69
+#: misc/scripts/quality-assurance.sh:76
 msgid "use the syntax: %b"
 msgstr ""
 
-#: misc/scripts/quality-assurance.sh:74
+#: misc/scripts/quality-assurance.sh:82
 msgid "Backing up %b"
 msgstr ""
 
-#: misc/scripts/quality-assurance.sh:77
+#: misc/scripts/quality-assurance.sh:85
 msgid "Installing %b"
 msgstr ""
 

--- a/misc/scripts/quality-assurance.sh
+++ b/misc/scripts/quality-assurance.sh
@@ -26,6 +26,7 @@
 
 function parse_pr() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
+    local -a ADDR
     IFS=':' read -ra ADDR <<< "$1"
     local provider user repo pr
     provider="${ADDR[0]}"
@@ -40,10 +41,16 @@ function parse_link() {
     unset login
     local provider="$1" user="$2" repo="$3" pr="$4"
     if [[ $provider == "github" ]]; then
-        gh_provides=$(curl -s "https://api.github.com/repos/$user/$repo/pulls/$pr")
-        head_repo_full_name=$(echo "$gh_provides" | jq -r '.head.repo.full_name')
-        head_sha=$(echo "$gh_provides" | jq -r '.head.sha')
-        login=$(echo "$gh_provides" | jq -r '.head.user.login')
+        if ! gh_provides=$(curl -fSs "https://api.github.com/repos/${user}/${repo}/pulls/${pr}"); then
+            fancy_message error $"Could not retrieve pull request information from %b" "GitHub"
+            exit 1
+        fi
+        if ! read -r head_repo_full_name head_sha login < <(
+            jq -er '[.head.repo.full_name, .head.sha, .head.user.login] | @tsv' <<< "${gh_provides}"
+        ); then
+            fancy_message error $"%b returned an invalid pull request response" "GitHub"
+            exit 1
+        fi
         echo "https://raw.githubusercontent.com/$head_repo_full_name/$head_sha" "$login"
     else
         fancy_message error $"%b is not a valid provider!" "${CYAN}$provider${NC}"

--- a/misc/scripts/quality-assurance.sh
+++ b/misc/scripts/quality-assurance.sh
@@ -39,11 +39,9 @@ function parse_pr() {
 function parse_link() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     unset login
-    local provider="$1" user="$2" repo="$3" pr="$4" gh_catch
+    local provider="$1" user="$2" repo="$3" pr="$4" gh_provides head_repo_full_name head_sha
     if [[ $provider == "github" ]]; then
-        gh_provides=$(curl -fSs "https://api.github.com/repos/${user}/${repo}/pulls/${pr}")
-        gh_catch=$?
-        if ((gh_catch != 0)); then
+        if ! gh_provides=$(curl -fSs "https://api.github.com/repos/${user}/${repo}/pulls/${pr}"); then
             fancy_message error $"Could not retrieve pull request information from %b" "GitHub"
             { ignore_stack=true; return 1; }
         fi

--- a/misc/scripts/quality-assurance.sh
+++ b/misc/scripts/quality-assurance.sh
@@ -43,19 +43,19 @@ function parse_link() {
     if [[ $provider == "github" ]]; then
         if ! gh_provides=$(curl -fSs "https://api.github.com/repos/${user}/${repo}/pulls/${pr}"); then
             fancy_message error $"Could not retrieve pull request information from %b" "GitHub"
-            exit 1
+            { ignore_stack=true; return 1; }
         fi
         if ! read -r head_repo_full_name head_sha login < <(
             jq -er '[.head.repo.full_name, .head.sha, .head.user.login] | @tsv' <<< "${gh_provides}"
         ); then
             fancy_message error $"%b returned an invalid pull request response" "GitHub"
-            exit 1
+            { ignore_stack=true; return 1; }
         fi
         echo "https://raw.githubusercontent.com/$head_repo_full_name/$head_sha" "$login"
     else
         fancy_message error $"%b is not a valid provider!" "${CYAN}$provider${NC}"
         fancy_message sub $"available providers are: '%s'" "github"
-        exit 1
+        { ignore_stack=true; return 1; }
     fi
 }
 

--- a/misc/scripts/quality-assurance.sh
+++ b/misc/scripts/quality-assurance.sh
@@ -30,8 +30,8 @@ function parse_pr() {
     IFS=':' read -ra ADDR <<< "$1"
     local provider user repo pr
     provider="${ADDR[0]}"
-    user=$(echo "${ADDR[1]}" | cut -d'/' -f1)
-    repo=$(echo "${ADDR[1]}" | cut -d'/' -f2)
+    user="${ADDR[1]%%/*}"
+    repo="${ADDR[1]#*/}"
     pr="$2"
     echo "$provider" "$user" "$repo" "$pr"
 }

--- a/misc/scripts/quality-assurance.sh
+++ b/misc/scripts/quality-assurance.sh
@@ -39,9 +39,11 @@ function parse_pr() {
 function parse_link() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     unset login
-    local provider="$1" user="$2" repo="$3" pr="$4"
+    local provider="$1" user="$2" repo="$3" pr="$4" gh_catch
     if [[ $provider == "github" ]]; then
-        if ! gh_provides=$(curl -fSs "https://api.github.com/repos/${user}/${repo}/pulls/${pr}"); then
+        gh_provides=$(curl -fSs "https://api.github.com/repos/${user}/${repo}/pulls/${pr}")
+        gh_catch=$?
+        if ((gh_catch != 0)); then
             fancy_message error $"Could not retrieve pull request information from %b" "GitHub"
             { ignore_stack=true; return 1; }
         fi

--- a/misc/scripts/quality-assurance.sh
+++ b/misc/scripts/quality-assurance.sh
@@ -77,7 +77,8 @@ if [[ -z $number || -z $inst ]]; then
     exit 1
 fi
 read -r provider user repo pr <<< "$(parse_pr "$metalink" "$number")"
-read -r provider_url login <<< "$(parse_link "$provider" "$user" "$repo" "$pr")"
+parse_link_output=$(parse_link "$provider" "$user" "$repo" "$pr")
+read -r provider_url login <<< "$parse_link_output"
 fancy_message info $"Backing up %b" "${CYAN}$SCRIPTDIR/repo/pacstallrepo${NC}"
 sudo mv "$SCRIPTDIR/repo/pacstallrepo" "$SCRIPTDIR/repo/pacstallrepo.pacstall-qa.bak"
 echo "$provider_url" | sudo tee "$SCRIPTDIR/repo/pacstallrepo" > /dev/null


### PR DESCRIPTION
## Purpose

Sometimes we see in the CI stuff like:

```bash
$ pacstall -Qa honkers-launcher-bin#9280@github:pacstall/pacstall-programs
[*] WARNING: Reading input from pipe
[+] INFO: Backing up /usr/share/pacstall/repo/pacstallrepo
[+] INFO: Installing honkers-launcher-bin(null:9280)
[*] WARNING: Reading input from pipe
[*] WARNING: Prompts are disabled
[*] WARNING: Reading input from pipe
[!] ERROR: The URL cannot be found
[⠿] Suggested solution(s):
    | Confirm that 'https://raw.githubusercontent.com/null/null/packagelist' exists
[!] ERROR: Cannot connect to Pacstall repo: https://raw.githubusercontent.com/null/null
[*] WARNING: You can remove or fix the URL by editing /usr/share/pacstall/repo/pacstallrepo
[+] INFO: Returning /usr/share/pacstall/repo/pacstallrepo backup
```

This PR aims to catch when `null` pops up.

## Approach

* Make `curl` fail on bad codes
* Make `jq` handle parsing errors

## Addendum

I'm unsure how to test this on a CI without just merging it.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.