### PR TITLE
chan!(*): remove ppa

### DIFF
--- a/misc/scripts/build.sh
+++ b/misc/scripts/build.sh
@@ -814,9 +814,6 @@ function write_meta() {
         declare -p _maintainer
         unset _maintainer
     fi
-    if [[ -n $ppa ]]; then
-        echo "_ppa=(${ppa[*]})"
-    fi
     if [[ -n $url ]]; then
         echo "_homepage=\"${url}\""
     fi

--- a/misc/scripts/checks.sh
+++ b/misc/scripts/checks.sh
@@ -300,40 +300,6 @@ function lint_deps() {
     { ignore_stack=true; return "${ret}"; }
 }
 
-function lint_ppa() {
-    { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local ret=0 el_ppa idx=0
-    if [[ -n ${ppa[*]} ]]; then
-        for el_ppa in "${ppa[@]}"; do
-            if [[ -z ${el_ppa} ]]; then
-                fancy_message error $"'%s' index '%s' cannot be empty" "ppa" "${idx}"
-                ret=1
-            fi
-            { ignore_stack=true; ((idx++)); }
-        done
-        if ((ret != 0)); then
-            { ignore_stack=true; return 1; }
-        fi
-        idx=0
-        for el_ppa in "${ppa[@]}"; do
-            if [[ $el_ppa =~ ^ppa: ]]; then
-                fancy_message error $"'%s' index '%s' cannot start with %s" "ppa" "${idx}" "'ppa:'"
-                ret=1
-            fi
-            { ignore_stack=true; ((idx++)); }
-        done
-        idx=0
-        for el_ppa in "${ppa[@]}"; do
-            if [[ ! $el_ppa =~ ^[a-zA-Z0-9]+\/[a-zA-Z0-9]+ ]]; then
-                fancy_message error $"%s index '%s' is improperly formatted" "'ppa'" "${idx}"
-                ret=1
-            fi
-            { ignore_stack=true; ((idx++)); }
-        done
-    fi
-    { ignore_stack=true; return "${ret}"; }
-}
-
 function lint_relations() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
     local rel_type rel_array ret=0 rela idx rdarch rdistro rddarch
@@ -696,7 +662,7 @@ function lint_kver() {
 
 function checks() {
     { ignore_stack=false; set -o pipefail; trap stacktrace ERR RETURN; }
-    local ret=0 check linting_checks=(lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_deps lint_ppa lint_relations lint_fields lint_hash lint_priority lint_license lint_bugs)
+    local ret=0 check linting_checks=(lint_gives lint_pkgrel lint_epoch lint_version lint_source lint_pkgdesc lint_maintainer lint_deps lint_relations lint_fields lint_hash lint_priority lint_license lint_bugs)
     for check in "${linting_checks[@]}"; do
         "${check}" || ret=1
     done

--- a/misc/scripts/dep-tree.sh
+++ b/misc/scripts/dep-tree.sh
@@ -58,7 +58,7 @@ function dep_tree.load_traits() {
     local -n out_arr
     pkg="${1:?No pkg given to dep_tree.load_traits}"
     out_arr="${2:?No arr given to dep_tree.load_traits}"
-    unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask _upgrade 2> /dev/null
+    unset _pacstall_depends _pacdeps _name _version _install_date _date _homepage _gives _remoterepo _remotebranch _mask _upgrade 2> /dev/null
     # shellcheck disable=SC1090
     source "${METADIR}/${pkg}"
 
@@ -158,7 +158,7 @@ function dep_tree.trim_pacdeps() {
     local -n merged_array="${1:?Pass array to dep_tree.trim_pacdeps}"
     local i z
     for i in "${merged_array[@]}"; do
-        unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask _upgrade 2> /dev/null
+        unset _pacstall_depends _pacdeps _name _version _install_date _date _homepage _gives _remoterepo _remotebranch _mask _upgrade 2> /dev/null
         # shellcheck disable=SC1090
         source "${METADIR}/${i}"
         if [[ -n ${_pacdeps[*]} ]]; then

--- a/misc/scripts/package.sh
+++ b/misc/scripts/package.sh
@@ -198,13 +198,6 @@ if ! is_package_installed "${pacname}"; then
     fi
 fi
 
-if [[ -n $ppa ]]; then
-    for i in "${ppa[@]}"; do
-        # Add ppa, but ppa bad I guess
-        sudo add-apt-repository ppa:"$i"
-    done
-fi
-
 if [[ -n ${pacdeps[*]} ]]; then
     fancy_message info $"Checking pacstall dependencies"
     for pdep in "${pacdeps[@]}"; do

--- a/misc/scripts/query-info.sh
+++ b/misc/scripts/query-info.sh
@@ -70,9 +70,6 @@ if [[ -n ${_remoterepo} ]]; then
 fi
 license="${license//,/}"
 get_field "$PACKAGE" Maintainer maintainer
-if [[ -n ${_ppa} ]]; then
-    ppa="${_ppa}"
-fi
 if [[ -n ${_pacdeps} ]]; then
     pacstall_dependencies="${_pacdeps[*]}"
 fi
@@ -134,9 +131,6 @@ if [[ -v mask ]]; then
     echo -e "${BGreen}mask${NC}: ${mask}"
 fi
 echo -e "${BGreen}maintainer${NC}: ${maintainer}"
-if [[ -v ppa ]]; then
-    echo -e "${BGreen}ppa${NC}: ${ppa}"
-fi
 if [[ -v pacstall_dependencies ]]; then
     echo -e "${BGreen}pacstall dependencies${NC}: ${pacstall_dependencies}"
 fi

--- a/misc/scripts/remove.sh
+++ b/misc/scripts/remove.sh
@@ -40,12 +40,6 @@ sudo apt-get remove "${_gives:-$_name}" -y || {
     exit 1
 }
 
-if [[ -n ${_ppa[*]} ]]; then
-    for ppa in "${_ppa[@]}"; do
-        fancy_message warn $"You may have dangling PPAs on your system. You can remove them using '%b'" "${UCyan}sudo add-apt-repository --remove ppa:$ppa${NC}"
-    done
-fi
-
 sudo rm -f "${METADIR:?}/${_name}"
 sudo rm -f "/etc/apt/preferences.d/${_name//./-}-pin"
 # vim:set ft=sh ts=4 sw=4 et:

--- a/pacstall
+++ b/pacstall
@@ -218,7 +218,7 @@ function decl_scriptvars() {
         archs="amd64 x86_64 arm64 aarch64 armel arm armhf armv7h i386 i686 ppc64el riscv64 s390x" \
         sums="b2 sha512 sha384 sha256 sha224 sha1 md5"
     pacstallvars=(pkgbase pkgname repology pkgver git_pkgver epoch source_url source depends makedepends checkdepends conflicts
-        breaks replaces gives pkgdesc hash optdepends ppa arch maintainer pacdeps NOBUILDDEP provides incompatible
+        breaks replaces gives pkgdesc hash optdepends arch maintainer pacdeps NOBUILDDEP provides incompatible
         compatible srcdir url backup pkgrel mask pac_functions pac_func_arr repo priority noextract nosubmodules license
         bwrapenv safeenv external_connection enhances recommends suggests custom_fields makeconflicts checkconflicts bugs limit_kver)
     mapfile -t distros < <(awk -F ',' -v current_date="$(date +'%Y-%m-%d')" '
@@ -653,7 +653,7 @@ function getMasks() {
         if [[ -n ${_mask[*]} ]]; then
             masks+=("${_mask[@]}")
         fi
-        unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask _upgrade 2> /dev/null
+        unset _pacstall_depends _pacdeps _name _version _install_date _date _homepage _gives _remoterepo _remotebranch _mask _upgrade 2> /dev/null
     done
 }
 
@@ -672,7 +672,7 @@ function getMasks_offending_pkg() {
                 return 0
             fi
         fi
-        unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _mask _upgrade 2> /dev/null
+        unset _pacstall_depends _pacdeps _name _version _install_date _date _homepage _gives _remoterepo _remotebranch _mask _upgrade 2> /dev/null
     done
     { ignore_stack=true; return 1; }
 }
@@ -1293,7 +1293,7 @@ Helpful links:
 
             if [[ -t 1 ]]; then
                 for pkg in "${packages_installed[@]}"; do
-                    unset _pacstall_depends _pacdeps _name _version _install_date _date _ppa _homepage _gives _remoterepo _remotebranch _maintainer _mask _upgrade 2> /dev/null
+                    unset _pacstall_depends _pacdeps _name _version _install_date _date _homepage _gives _remoterepo _remotebranch _maintainer _mask _upgrade 2> /dev/null
                     source ./"${pkg}"
                     echo -e "${BYellow}~${NC} ${BGreen}${_name}${BPurple}@${BCyan}${_version}${NC}"
                     if [[ -n ${_gives} ]]; then


### PR DESCRIPTION
## Purpose

Nuke it.

## Addendum

The last instance of `ppa` being used was in 2025: https://github.com/pacstall/pacstall-programs/commit/f87bfc34aa35f487db11fdb82771bba9683e8220#diff-a20720d80d7b3b4b8f0a1225f7f1de79a58d60ff0f226bc9d74f01c75b076982L10. Interestingly, we never added `ppa` to `.SRCINFO`.

## Checklist

- [x] I confirm that I have read the [contributing guidelines](https://github.com/pacstall/pacstall/blob/develop/CONTRIBUTING.md), and this pull request is abiding by all the clauses stated in the guideline.
